### PR TITLE
add md380v and md390v targets to respect single-bander freq limitations

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -351,6 +351,9 @@ foreach k, v : md9600_def
   endif
 endforeach
 
+band_uhf = ['-DBAND_UHF']
+band_vhf = ['-DBAND_VHF']
+
 linux_opts = {'sources': linux_src,
               'c_args': linux_c_args,
               'include_directories': linux_inc,
@@ -358,13 +361,25 @@ linux_opts = {'sources': linux_src,
               'link_args' : linux_l_args}
 
 md380_opts = {'sources': md380_src,
-              'c_args': md380_args,
+              'c_args': md380_args + band_uhf,
+              'link_args' : ['-Wl,-T../platform/mcu/STM32F4xx/linker_script.ld',
+                             '-Wl,--print-memory-usage'],
+              'include_directories': md380_inc}
+
+md380v_opts = {'sources': md380_src,
+              'c_args': md380_args + band_vhf,
               'link_args' : ['-Wl,-T../platform/mcu/STM32F4xx/linker_script.ld',
                              '-Wl,--print-memory-usage'],
               'include_directories': md380_inc}
 
 md390_opts = {'sources': md390_src,
-              'c_args': md390_args,
+              'c_args': md390_args + band_uhf,
+              'link_args' : ['-Wl,-T../platform/mcu/STM32F4xx/linker_script.ld',
+                             '-Wl,--print-memory-usage'],
+              'include_directories': md390_inc}
+
+md390v_opts = {'sources': md390_src,
+              'c_args': md390_args + band_vhf,
               'link_args' : ['-Wl,-T../platform/mcu/STM32F4xx/linker_script.ld',
                              '-Wl,--print-memory-usage'],
               'include_directories': md390_inc}
@@ -414,7 +429,19 @@ targets = [
    'wrap': 'MD380',
    'load_addr': '0x0800C000'},
 
+  {'name': 'md380v',
+   'opts': md380v_opts,
+   'flashable': true,
+   'wrap': 'MD380',
+   'load_addr': '0x0800C000'},
+
   {'name': 'md390',
+   'opts': md390_opts,
+   'flashable': true,
+   'wrap': 'MD390',
+   'load_addr': '0x0800C000'},
+
+  {'name': 'md390v',
    'opts': md390_opts,
    'flashable': true,
    'wrap': 'MD390',

--- a/platform/targets/MD-380/hwconfig.h
+++ b/platform/targets/MD-380/hwconfig.h
@@ -36,8 +36,14 @@
 #define HAS_RTC
 
 /* Supported radio bands */
-#define BAND_VHF
-#define BAND_UHF
+//since each MD-380 is only capable of one band, and we don't (yet?) have a
+//way to query the radio hardware (or pre-existing code) before flash
+//user must specify a VHF or UHF target addendum which will provide
+//either BAND_VHF or BAND_UHF at compile time
+//
+//UHF is assumed, since for the FCC IDs on the radios themselves the MD-380 is UHF
+//and MD-380V is VHF
+//that means the build targets ar md380 and md380v respectively
 
 /* Band limits in Hz */
 #define FREQ_LIMIT_VHF_LO 136000000

--- a/platform/targets/MD-390/hwconfig.h
+++ b/platform/targets/MD-390/hwconfig.h
@@ -36,8 +36,14 @@
 #define HAS_RTC
 
 /* Supported radio bands */
-#define BAND_VHF
-#define BAND_UHF
+//since each MD-3?0 is only capable of one band, and we don't (yet?) have a
+//way to query the radio hardware (or pre-existing code) before flash
+//user must specify a VHF or UHF target addendum which will provide
+//either BAND_VHF or BAND_UHF at compile time
+//
+//MD-390 UHF is build target md390 - since the MD-380 VHF model numbers have
+// a V at the end and a regular "MD-380" is UHF, we're carrying the same
+// thing forward to the MD-390, so MD-390 VHF is build target md390v
 
 /* Band limits in Hz */
 #define FREQ_LIMIT_VHF_LO 136000000


### PR DESCRIPTION
MD-3?0 and MD3?0V radios were being treated as dual band. This allows building and flashing them as single-banders, which means the frequency checks elsewhere in the codebase operate correctly and prevent tuning inaccessible frequencies.

This adds md380v and md390v targets to meson and builds them with BAND_VHF, while treating md380 and md390 targets as UHF only with only BAND_UHF defined. To that end, the BAND_(U|V)HF definitions were removed from the hwconfig.h.

I named them as different targets and specifically with that format to be consistent with the FCC and IC IDs printed on the stickers under the battery, e.g. a 'V' indicates VHF, no V is UHF.