### PR TITLE
Docs improvement for the dumpSecurityRegs test, and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+from archlinux as builder
+
+RUN pacman -Syyu --noconfirm \
+	base-devel \
+	meson \
+	sdl2 \
+	cmake \
+	arm-none-eabi-binutils arm-none-eabi-gcc arm-none-eabi-newlib \
+	git vim screen 
+
+RUN git clone https://github.com/v0l/radio_tool.git /radio_tool && \
+	cd /radio_tool && mkdir build && cd build && \
+	cmake .. && make -j4
+RUN cp /radio_tool/build/radio_tool /usr/bin/
+
+#allow for automated builds
+ADD ./ /app
+
+#allow for override for using as a dev environment
+VOLUME /app
+
+WORKDIR /app
+
+
+#can even flash from within the container if you run it like this:
+#sudo docker run --rm -it -v "${PWD}"/:/app --privileged -v /dev/bus/usb:/dev/bus/usb openrtx 

--- a/tests/platform/dumpSecurityRegs_MDx.c
+++ b/tests/platform/dumpSecurityRegs_MDx.c
@@ -28,6 +28,31 @@
  *   along with this program; if not, see <http://www.gnu.org/licenses/>   *
  ***************************************************************************/
 
+/*
+ *
+ * Use instructions:
+ * setup like normal, e.g. meson setup --cross-file cross_arm.txt build_arm
+ * configure this test: meson configure -Dtest=dumpSecurityRegs_MDx build_arm/
+ * make sure START_TSK_STKSIZE in openrtx/src/bootstrap.c is increased (2048/sizeof(CPU_STK) is a good number) or test will not run
+ * flash like normal, e.g. meson compile -C build_arm openrtx_md380_flash
+ *
+ * Then reboot the radio into this app once it's flashed.
+ * It will print out the registers after you press a button.
+ *
+ * Example: minicom -D /dev/ttyACM0
+ * (ctrl-a o to bring up the menu, serial port setup to choose 115200 8N1)
+ * (ctrl-a l to bring up minicom logging, enter to set the log filename)
+ * press enter key or whatever you like, view output
+ * (ctrl-a q  to close minicom)
+ * the logged output is in that .cap file you named with ctrl-L
+ *
+ * Name it with the model number (MD380, MD380V, MD380G, MD380VG) (or MD390 variants)
+ * and then the serial number, like MD380_SN12345678.cap
+ * put it in this repo under data/tests/dumpSecurityRegs_MDx
+ *
+ *
+ */
+
 #include <stdio.h>
 #include <stdint.h>
 #include <sys/types.h>

--- a/tests/platform/dumpSecurityRegs_MDx.c
+++ b/tests/platform/dumpSecurityRegs_MDx.c
@@ -48,7 +48,9 @@
  *
  * Name it with the model number (MD380, MD380V, MD380G, MD380VG) (or MD390 variants)
  * and then the serial number, like MD380_SN12345678.cap
- * put it in this repo under data/tests/dumpSecurityRegs_MDx
+ *
+ * add these files to https://github.com/OpenRTX/OpenRTX-external-docs/
+ * under /External%20flash%20dumps/MDx%20security%20registers
  *
  *
  */


### PR DESCRIPTION
A couple things too small to deserve their own pull requests, but separate commits at least.
Dockerfile allows docker users to build (and even flash the radio, if on Linux) without having to install anything. It may also serve for doing some automated builds later.
Also added some comments to the dumpSecurityRegs test to help others run it consistently.