### PR TITLE
Add integer/lookup-table M17 Modulator

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -38,6 +38,8 @@ openrtx_src = ['openrtx/src/state.c',
                'openrtx/src/memory_profiling.cpp',
                'openrtx/src/protocols/M17/M17Callsign.cpp',
                'openrtx/src/protocols/M17/M17Modulator.cpp',
+               'openrtx/src/protocols/M17/M17IntegerModulator.cpp',
+               'openrtx/src/protocols/M17/M17LookupModulator.cpp',
                'openrtx/src/protocols/M17/M17Transmitter.cpp',
                'openrtx/src/protocols/M17/M17LinkSetupFrame.cpp']
 
@@ -529,3 +531,6 @@ unit_test_src = openrtx_src + minmea_src + linux_platform_src
 
 dummy_test = executable('dummy', 'tests/unit/dummy.c')
 test('Dummy Unit Test', dummy_test)
+
+m17mod_test = executable('m17mod', 'tests/unit/test_m17mod.cpp')
+test('M17Mod Unit Test', m17mod_test)

--- a/openrtx/include/protocols/M17/M17IntegerModulator.h
+++ b/openrtx/include/protocols/M17/M17IntegerModulator.h
@@ -1,8 +1,5 @@
 /***************************************************************************
- *   Copyright (C) 2021 by Federico Amedeo Izzo IU2NUO,                    *
- *                         Niccolò Izzo IU2KIN                             *
- *                         Frederik Saraci IU2NRO                          *
- *                         Silvano Seva IU2KWO                             *
+ *   Copyright (C) 2021 by Alain Carlucci                                  *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -18,8 +15,8 @@
  *   along with this program; if not, see <http://www.gnu.org/licenses/>   *
  ***************************************************************************/
 
-#ifndef M17_MODULATOR_H
-#define M17_MODULATOR_H
+#ifndef M17_INTEGER_MODULATOR_H
+#define M17_INTEGER_MODULATOR_H
 
 #ifndef __cplusplus
 #error This header is C++ only!
@@ -31,20 +28,22 @@
 
 /**
  * Modulator device for M17 protocol.
+ *
+ * This modulator uses integer arithmetic to perform 4FSK.
  */
-class M17Modulator
+class M17IntegerModulator
 {
 public:
 
     /**
      * Constructor.
      */
-    M17Modulator();
+    M17IntegerModulator();
 
     /**
      * Destructor.
      */
-    ~M17Modulator();
+    ~M17IntegerModulator();
 
     /**
      * Allocate buffers for baseband audio generation and initialise modulator.
@@ -91,12 +90,9 @@ private:
         std::array< int8_t, 4 > symbols;
 
         symbols[3] = LUT[value & 0x03];
-        value >>= 2;
-        symbols[2] = LUT[value & 0x03];
-        value >>= 2;
-        symbols[1] = LUT[value & 0x03];
-        value >>= 2;
-        symbols[0] = LUT[value & 0x03];
+        symbols[2] = LUT[(value >> 2) & 0x03];
+        symbols[1] = LUT[(value >> 4) & 0x03];
+        symbols[0] = LUT[(value >> 6) & 0x03];
 
         return symbols;
     }

--- a/openrtx/include/protocols/M17/M17LookupModulator.h
+++ b/openrtx/include/protocols/M17/M17LookupModulator.h
@@ -1,8 +1,5 @@
 /***************************************************************************
- *   Copyright (C) 2021 by Federico Amedeo Izzo IU2NUO,                    *
- *                         Niccolò Izzo IU2KIN                             *
- *                         Frederik Saraci IU2NRO                          *
- *                         Silvano Seva IU2KWO                             *
+ *   Copyright (C) 2021 by Alain Carlucci                                  *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -18,8 +15,8 @@
  *   along with this program; if not, see <http://www.gnu.org/licenses/>   *
  ***************************************************************************/
 
-#ifndef M17_MODULATOR_H
-#define M17_MODULATOR_H
+#ifndef M17_LOOKUP_MODULATOR_H
+#define M17_LOOKUP_MODULATOR_H
 
 #ifndef __cplusplus
 #error This header is C++ only!
@@ -31,20 +28,22 @@
 
 /**
  * Modulator device for M17 protocol.
+ *
+ * This modulator uses lookup tables to perform 4FSK.
  */
-class M17Modulator
+class M17LookupModulator
 {
 public:
 
     /**
      * Constructor.
      */
-    M17Modulator();
+    M17LookupModulator();
 
     /**
      * Destructor.
      */
-    ~M17Modulator();
+    ~M17LookupModulator();
 
     /**
      * Allocate buffers for baseband audio generation and initialise modulator.
@@ -85,18 +84,14 @@ private:
      * @param value: value to be encoded in 4FSK symbols.
      * @return std::array containing the four symbols obtained by 4FSK encoding.
      */
-    inline std::array< int8_t, 4 > byteToSymbols(uint8_t value)
+    inline std::array< uint8_t, 4 > byteToSymbols(uint8_t value)
     {
-        static constexpr int8_t LUT[] = { +1, +3, -1, -3};
-        std::array< int8_t, 4 > symbols;
+        std::array< uint8_t, 4 > symbols;
 
-        symbols[3] = LUT[value & 0x03];
-        value >>= 2;
-        symbols[2] = LUT[value & 0x03];
-        value >>= 2;
-        symbols[1] = LUT[value & 0x03];
-        value >>= 2;
-        symbols[0] = LUT[value & 0x03];
+        symbols[3] = 1 + (value & 0x03);
+        symbols[2] = 1 + ((value >> 2) & 0x03);
+        symbols[1] = 1 + ((value >> 4) & 0x03);
+        symbols[0] = 1 + ((value >> 6) & 0x03);
 
         return symbols;
     }

--- a/openrtx/src/protocols/M17/M17IntegerModulator.cpp
+++ b/openrtx/src/protocols/M17/M17IntegerModulator.cpp
@@ -1,0 +1,137 @@
+/***************************************************************************
+ *   Copyright (C) 2021 by Alain Carlucci                                  *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, see <http://www.gnu.org/licenses/>   *
+ ***************************************************************************/
+
+#include <new>
+#include <dsp.h>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <experimental/array>
+#include <M17/M17IntegerModulator.h>
+
+#if defined(PLATFORM_MD3x0) || defined(PLATFORM_MDUV3x0)
+#include <toneGenerator_MDx.h>
+#elif defined(PLATFORM_LINUX)
+#include <stdio.h>
+#endif
+
+const auto jrrc_taps = std::experimental::make_array<int32_t>(
+    -2125, -1407, -258, 1122, 2458, 3453, 3851, 3499, 2392, 695, -1269, -3074,
+    -4266, -4460, -3441, -1236, 1847, 5233, 8145, 9735, 9233, 6128, 316, -7786,
+    -17209, -26472, -33727, -36975, -34336, -24337, -6175, 20088, 53429, 91888,
+    132724, 172680, 208333, 236478, 254506, 260713, 254506, 236478, 208333,
+    172680, 132724, 91888, 53429, 20088, -6175, -24337, -34336, -36975, -33727,
+    -26472, -17209, -7786, 316, 6128, 9233, 9735, 8145, 5233, 1847, -1236,
+    -3441, -4460, -4266, -3074, -1269, 695, 2392, 3499, 3851, 3453, 2458, 1122,
+    -258, -1407, -2125);
+
+static IntegerFir<std::tuple_size<decltype(jrrc_taps)>::value> jrrc(jrrc_taps);
+
+M17IntegerModulator::M17IntegerModulator() {}
+
+M17IntegerModulator::~M17IntegerModulator() { terminate(); }
+
+void M17IntegerModulator::init()
+{
+    /*
+     * Allocate a chunk of memory to contain two complete buffers for baseband
+     * audio. Split this chunk in two separate blocks for float buffering using
+     * placement new.
+     */
+
+    baseband_buffer = new int16_t[2 * M17_FRAME_SAMPLES];
+    activeBuffer    = new (baseband_buffer) dataBuffer_t;
+    int16_t* ptr    = baseband_buffer + activeBuffer->size();
+    idleBuffer      = new (ptr) dataBuffer_t;
+
+    memset(baseband_buffer, 0, 2 * M17_FRAME_SAMPLES);
+}
+
+void M17IntegerModulator::terminate()
+{
+    // Delete the buffers and deallocate memory.
+    activeBuffer->~dataBuffer_t();
+    idleBuffer->~dataBuffer_t();
+    delete[] baseband_buffer;
+}
+
+void M17IntegerModulator::send(const std::array<uint8_t, 2>& sync,
+                         const std::array<uint8_t, 46>& data)
+{
+    auto sync1 = byteToSymbols(sync[0]);
+    auto sync2 = byteToSymbols(sync[1]);
+
+    auto it = std::copy(sync1.begin(), sync1.end(), symbols.begin());
+    it      = std::copy(sync2.begin(), sync2.end(), it);
+
+    for (size_t i = 0; i < data.size(); i++)
+    {
+        auto sym = byteToSymbols(data[i]);
+        it       = std::copy(sym.begin(), sym.end(), it);
+    }
+
+    generateBaseband();
+    emitBaseband();
+}
+
+void M17IntegerModulator::generateBaseband()
+{
+    auto& buf = *idleBuffer;
+    buf.fill(0);
+    for (size_t i = 0; i < symbols.size(); i++)
+        buf[i * 10] = symbols[i];
+
+    for (size_t i = 0; i < buf.size(); i++)
+        buf[i] = jrrc(buf[i]);
+}
+
+#if defined(PLATFORM_MD3x0) || defined(PLATFORM_MDUV3x0)
+void M17IntegerModulator::emitBaseband()
+{
+    dsp_pwmCompensate(idleBuffer->data(), idleBuffer->size());
+    dsp_invertPhase(idleBuffer->data(), idleBuffer->size());
+
+    for (size_t i = 0; i < M17_FRAME_SAMPLES; i++)
+    {
+        int32_t pos_sample      = idleBuffer->at(i) + 32768;
+        uint16_t shifted_sample = pos_sample >> 8;
+        idleBuffer->at(i)       = shifted_sample;
+    }
+
+    toneGen_waitForStreamEnd();
+    std::swap(idleBuffer, activeBuffer);
+
+    toneGen_playAudioStream(reinterpret_cast<uint16_t*>(activeBuffer->data()),
+                            activeBuffer->size(), M17_RTX_SAMPLE_RATE);
+}
+#elif defined(PLATFORM_LINUX)
+void M17IntegerModulator::emitBaseband()
+{
+    std::swap(idleBuffer, activeBuffer);
+
+    FILE *outfile = fopen("/tmp/m17_output.raw", "ab");
+
+    for(auto s : *activeBuffer)
+    {
+        fwrite(&s, sizeof(s), 1, outfile);
+    }
+
+    fclose(outfile);
+}
+#else
+void M17IntegerModulator::emitBaseband() {}
+#endif

--- a/openrtx/src/protocols/M17/M17LookupModulator.cpp
+++ b/openrtx/src/protocols/M17/M17LookupModulator.cpp
@@ -1,0 +1,179 @@
+/***************************************************************************
+ *   Copyright (C) 2021 by Alain Carlucci                                  *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, see <http://www.gnu.org/licenses/>   *
+ ***************************************************************************/
+
+#include <new>
+#include <dsp.h>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <experimental/array>
+#include <M17/M17LookupModulator.h>
+
+#if defined(PLATFORM_MD3x0) || defined(PLATFORM_MDUV3x0)
+#include <toneGenerator_MDx.h>
+#elif defined(PLATFORM_LINUX)
+#include <stdio.h>
+#endif
+
+static const std::array<std::array<int32_t, 79>, 5> irrc_taps = {{
+    {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+    // +1
+    {-531,  -351,  -64,   280,   614,   863,   962,   874,   598,   173,
+     -317,  -768,  -1066, -1115, -860,  -309,  461,   1308,  2036,  2433,
+     2308,  1532,  79,    -1946, -4302, -6618, -8431, -9243, -8584, -6084,
+     -1543, 5022,  13357, 22972, 33181, 43170, 52083, 59119, 63626, 65178,
+     63626, 59119, 52083, 43170, 33181, 22972, 13357, 5022,  -1543, -6084,
+     -8584, -9243, -8431, -6618, -4302, -1946, 79,    1532,  2308,  2433,
+     2036,  1308,  461,   -309,  -860,  -1115, -1066, -768,  -317,  173,
+     598,   874,   962,   863,   614,   280,   -64,   -351,  -531},
+
+    // +3
+    {-1593,  -1053,  -192,   840,    1842,   2589,   2886,   2622,   1794,
+     519,    -951,   -2304,  -3198,  -3345,  -2580,  -927,   1383,   3924,
+     6108,   7299,   6924,   4596,   237,    -5838,  -12906, -19854, -25293,
+     -27729, -25752, -18252, -4629,  15066,  40071,  68916,  99543,  129510,
+     156249, 177357, 190878, 195534, 190878, 177357, 156249, 129510, 99543,
+     68916,  40071,  15066,  -4629,  -18252, -25752, -27729, -25293, -19854,
+     -12906, -5838,  237,    4596,   6924,   7299,   6108,   3924,   1383,
+     -927,   -2580,  -3345,  -3198,  -2304,  -951,   519,    1794,   2622,
+     2886,   2589,   1842,   840,    -192,   -1053,  -1593},
+
+    // -1
+    {531,    351,    64,     -280,   -614,   -863,   -962,   -874,   -598,
+     -173,   317,    768,    1066,   1115,   860,    309,    -461,   -1308,
+     -2036,  -2433,  -2308,  -1532,  -79,    1946,   4302,   6618,   8431,
+     9243,   8584,   6084,   1543,   -5022,  -13357, -22972, -33181, -43170,
+     -52083, -59119, -63626, -65178, -63626, -59119, -52083, -43170, -33181,
+     -22972, -13357, -5022,  1543,   6084,   8584,   9243,   8431,   6618,
+     4302,   1946,   -79,    -1532,  -2308,  -2433,  -2036,  -1308,  -461,
+     309,    860,    1115,   1066,   768,    317,    -173,   -598,   -874,
+     -962,   -863,   -614,   -280,   64,     351,    531},
+
+    // -3
+    {1593,    1053,    192,     -840,    -1842,   -2589,   -2886,   -2622,
+     -1794,   -519,    951,     2304,    3198,    3345,    2580,    927,
+     -1383,   -3924,   -6108,   -7299,   -6924,   -4596,   -237,    5838,
+     12906,   19854,   25293,   27729,   25752,   18252,   4629,    -15066,
+     -40071,  -68916,  -99543,  -129510, -156249, -177357, -190878, -195534,
+     -190878, -177357, -156249, -129510, -99543,  -68916,  -40071,  -15066,
+     4629,    18252,   25752,   27729,   25293,   19854,   12906,   5838,
+     -237,    -4596,   -6924,   -7299,   -6108,   -3924,   -1383,   927,
+     2580,    3345,    3198,    2304,    951,     -519,    -1794,   -2622,
+     -2886,   -2589,   -1842,   -840,    192,     1053,    1593},
+}};
+
+static LookupFir<79> irrc(irrc_taps);
+
+M17LookupModulator::M17LookupModulator() {}
+
+M17LookupModulator::~M17LookupModulator() { terminate(); }
+
+void M17LookupModulator::init()
+{
+    /*
+     * Allocate a chunk of memory to contain two complete buffers for baseband
+     * audio. Split this chunk in two separate blocks for float buffering using
+     * placement new.
+     */
+
+    baseband_buffer = new int16_t[2 * M17_FRAME_SAMPLES];
+    activeBuffer    = new (baseband_buffer) dataBuffer_t;
+    int16_t* ptr    = baseband_buffer + activeBuffer->size();
+    idleBuffer      = new (ptr) dataBuffer_t;
+
+    memset(baseband_buffer, 0, 2 * M17_FRAME_SAMPLES);
+}
+
+void M17LookupModulator::terminate()
+{
+    // Delete the buffers and deallocate memory.
+    activeBuffer->~dataBuffer_t();
+    idleBuffer->~dataBuffer_t();
+    delete[] baseband_buffer;
+}
+
+void M17LookupModulator::send(const std::array<uint8_t, 2>& sync,
+                         const std::array<uint8_t, 46>& data)
+{
+    auto sync1 = byteToSymbols(sync[0]);
+    auto sync2 = byteToSymbols(sync[1]);
+
+    auto it = std::copy(sync1.begin(), sync1.end(), symbols.begin());
+    it      = std::copy(sync2.begin(), sync2.end(), it);
+
+    for (size_t i = 0; i < data.size(); i++)
+    {
+        auto sym = byteToSymbols(data[i]);
+        it       = std::copy(sym.begin(), sym.end(), it);
+    }
+
+    generateBaseband();
+    emitBaseband();
+}
+
+void M17LookupModulator::generateBaseband()
+{
+    auto& buf = *idleBuffer;
+    buf.fill(0);
+    for (size_t i = 0; i < symbols.size(); i++)
+        buf[i * 10] = symbols[i];
+
+    for (size_t i = 0; i < buf.size(); i++)
+    {
+        buf[i] = irrc(buf[i]);
+    }
+}
+
+#if defined(PLATFORM_MD3x0) || defined(PLATFORM_MDUV3x0)
+void M17LookupModulator::emitBaseband()
+{
+    dsp_pwmCompensate(idleBuffer->data(), idleBuffer->size());
+    dsp_invertPhase(idleBuffer->data(), idleBuffer->size());
+
+    for (size_t i = 0; i < M17_FRAME_SAMPLES; i++)
+    {
+        int32_t pos_sample      = idleBuffer->at(i) + 32768;
+        uint16_t shifted_sample = pos_sample >> 8;
+        idleBuffer->at(i)       = shifted_sample;
+    }
+
+    toneGen_waitForStreamEnd();
+    std::swap(idleBuffer, activeBuffer);
+
+    toneGen_playAudioStream(reinterpret_cast<uint16_t*>(activeBuffer->data()),
+                            activeBuffer->size(), M17_RTX_SAMPLE_RATE);
+}
+#elif defined(PLATFORM_LINUX)
+void M17LookupModulator::emitBaseband()
+{
+    std::swap(idleBuffer, activeBuffer);
+
+    FILE *outfile = fopen("/tmp/m17_output.raw", "ab");
+
+    for(auto s : *activeBuffer)
+    {
+        fwrite(&s, sizeof(s), 1, outfile);
+    }
+
+    fclose(outfile);
+}
+#else
+void M17LookupModulator::emitBaseband() {}
+#endif

--- a/openrtx/src/protocols/M17/M17Modulator.cpp
+++ b/openrtx/src/protocols/M17/M17Modulator.cpp
@@ -1,8 +1,5 @@
 /***************************************************************************
- *   Copyright (C) 2021 by Federico Amedeo Izzo IU2NUO,                    *
- *                         Niccolò Izzo IU2KIN                             *
- *                         Frederik Saraci IU2NRO                          *
- *                         Silvano Seva IU2KWO                             *
+ *   Copyright (C) 2021 by Alain Carlucci                                  *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/tests/unit/test_m17mod.cpp
+++ b/tests/unit/test_m17mod.cpp
@@ -1,0 +1,200 @@
+#include <cassert>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+#include "protocols/M17/M17IntegerModulator.h"
+#include "protocols/M17/M17LookupModulator.h"
+#include "protocols/M17/M17Modulator.h"
+
+namespace chrono = std::chrono;
+
+using lclock = std::chrono::high_resolution_clock;
+
+static constexpr int N = 1000;
+
+int x4mance_test_standard()
+{
+    M17Modulator m;
+
+    std::array<uint8_t, 2> a;
+    std::array<uint8_t, 46> b;
+
+    m.init();
+    for (int i = 0; i < 100; i++)
+        m.send(a, b);
+
+    auto t1 = lclock::now();
+    int ctr = 0;
+    for (int i = 0; i < N; i++)
+    {
+        m.send(a, b);
+        ctr += m.getOutputBuffer()->at(i % 1920);
+    }
+    auto t2 = lclock::now();
+    auto d  = t2 - t1;
+    long x  = chrono::duration_cast<chrono::milliseconds>(d).count();
+
+    printf("M17Modulator standard: %lf msec\n", x / float(N));
+    return ctr;
+}
+
+int x4mance_test_lookup()
+{
+    M17LookupModulator m;
+
+    std::array<uint8_t, 2> a;
+    std::array<uint8_t, 46> b;
+
+    m.init();
+    for (int i = 0; i < 100; i++)
+        m.send(a, b);
+    auto t1 = lclock::now();
+    int ctr = 0;
+
+    for (int i = 0; i < N; i++)
+    {
+        m.send(a, b);
+        ctr += m.getOutputBuffer()->at(i % 1920);
+    }
+    auto t2 = lclock::now();
+    auto d  = t2 - t1;
+    long x  = chrono::duration_cast<chrono::milliseconds>(d).count();
+
+    printf("M17Modulator lookup: %lf msec\n", x / float(N));
+    return ctr;
+}
+
+int x4mance_test_integer()
+{
+    M17IntegerModulator m;
+
+    std::array<uint8_t, 2> a;
+    std::array<uint8_t, 46> b;
+
+    m.init();
+    for (int i = 0; i < 100; i++)
+        m.send(a, b);
+    auto t1 = lclock::now();
+    int ctr = 0;
+    for (int i = 0; i < N; i++)
+    {
+        m.send(a, b);
+        ctr += m.getOutputBuffer()->at(i % 1920);
+    }
+    auto t2 = lclock::now();
+    auto d  = t2 - t1;
+    long x  = chrono::duration_cast<chrono::milliseconds>(d).count();
+
+    printf("M17Modulator integer: %lf msec\n", x / float(N));
+    return ctr;
+}
+
+std::vector<int16_t> ifir_test(int input_id)
+{
+    srand(input_id);
+
+    M17LookupModulator m;
+    m.init();
+
+    std::array<uint8_t, 2> a;
+    std::array<uint8_t, 46> b;
+    for (int i = 0; i < 2; i++)
+        a[i] = rand();
+
+    for (int i = 0; i < 46; i++)
+        b[i] = rand();
+
+    m.send(a, b);
+    auto* out = m.getOutputBuffer();  // 1920 bytes
+    assert(out->size() == 1920);
+
+    std::vector<int16_t> oo(1920);
+    memcpy(oo.data(), out, 1920 * 2);
+    return oo;
+}
+
+std::vector<int16_t> fir_test(int input_id)
+{
+    srand(input_id);
+
+    M17Modulator m;
+    m.init();
+
+    std::array<uint8_t, 2> a;
+    std::array<uint8_t, 46> b;
+
+    for (int i = 0; i < 2; i++)
+        a[i] = rand();
+
+    for (int i = 0; i < 46; i++)
+        b[i] = rand();
+
+    m.send(a, b);
+    auto* out = m.getOutputBuffer();  // 1920 bytes
+    assert(out->size() == 1920);
+
+    std::vector<int16_t> oo(1920);
+    memcpy(oo.data(), out, 1920 * 2);
+    return oo;
+}
+
+std::vector<int16_t> jfir_test(int input_id)
+{
+    srand(input_id);
+
+    M17IntegerModulator m;
+    m.init();
+
+    std::array<uint8_t, 2> a;
+    std::array<uint8_t, 46> b;
+
+    for (int i = 0; i < 2; i++)
+        a[i] = rand();
+
+    for (int i = 0; i < 46; i++)
+        b[i] = rand();
+
+    m.send(a, b);
+    auto* out = m.getOutputBuffer();  // 1920 bytes
+    assert(out->size() == 1920);
+
+    std::vector<int16_t> oo(1920);
+    memcpy(oo.data(), out, 1920 * 2);
+    return oo;
+}
+
+bool compare(const std::vector<int16_t>& a, const std::vector<int16_t>& b,
+             int maxdiff)
+{
+    assert(a.size() == b.size());
+
+    bool eq = true;
+    for (size_t i = 0; i < a.size(); i++)
+        if (abs(a[i] - b[i]) > maxdiff)
+        {
+            printf("Difference at %lu: %d vs %d\n", i, a[i], b[i]);
+            eq = false;
+        }
+    return eq;
+}
+
+int main()
+{
+    volatile int a = x4mance_test_standard();
+    a += x4mance_test_integer();
+    a += x4mance_test_lookup();
+
+    for (int i = 0; i < 1000; i++)
+    {
+        auto a = fir_test(i);
+        auto b = ifir_test(i);
+        auto c = jfir_test(i);
+        compare(a, b, 3);
+        compare(a, c, 2);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This PR adds two classes that can replace `M17Modulator`:
`M17IntegerModulator` which uses only integer arithmetic
`M17LookupModulator` which does not use arithmetic but only lookup tables

There is a small unit test available (`tests/unit/test_m17mod.cpp`) which does: 
* Benchmarks and print results
* Checks that given the same input, they all provide the same output

At the moment I can't build the test using meson, so I use this command:
```
g++ -Ofast -march=native tests/unit/test_m17mod.cpp -Iopenrtx/include openrtx/src/protocols/M17/M17*Modulator.cpp -Iopenrtx/include/protocols -o my_test
```
and these are the results on my laptop:
```
$ ./my_test
M17Modulator standard: 0.216000 msec
M17Modulator integer: 0.094000 msec
M17Modulator lookup: 0.197000 msec
```