### PR TITLE
Fix broken display SDL test

### DIFF
--- a/tests/platform/display_test_SDL.c
+++ b/tests/platform/display_test_SDL.c
@@ -51,7 +51,6 @@ void drawRect(int x, int y, int width, int height, uint16_t color)
 int main()
 {
     display_init();
-    display_setBacklightLevel(254);
 
     /* Horizontal red line */
     drawRect(0, 10, SCREEN_WIDTH, 20, 0xF800);


### PR DESCRIPTION
`display_setBacklightLevel` is undefined and not part of the display.h
interface.


```
 meson compile -C build_osx  openrtx_linux
ninja: Entering directory `/Users/nolith/src/hamradio/OpenRTX/build_osx'
[1/2] Compiling C object openrtx_linux.p/tests_platform_display_test_SDL.c.o
../tests/platform/display_test_SDL.c: In function 'main':
../tests/platform/display_test_SDL.c:54:5: warning: implicit declaration of function 'display_setBacklightLevel' [-Wimplicit-function-declaration]
   54 |     display_setBacklightLevel(254);
      |     ^~~~~~~~~~~~~~~~~~~~~~~~~
[2/2] Linking target openrtx_linux
FAILED: openrtx_linux
g++-9  -o openrtx_linux openrtx_linux.p/openrtx_src_state.c.o openrtx_linux.p/openrtx_src_ui_ui.c.o openrtx_linux.p/openrtx_src_ui_ui_main.c.o openrtx_linux.p/openrtx_src_ui_ui_mode.c.o openrtx_linux.p/openrtx_src_ui_ui_menu.c.o openrtx_linux.p/openrtx_src_threads.c.o openrtx_linux.p/openrtx_src_battery.c.o openrtx_linux.p/openrtx_src_graphics.c.o openrtx_linux.p/openrtx_src_input.c.o openrtx_linux.p/openrtx_src_calibUtils.c.o openrtx_linux.p/openrtx_src_queue.c.o openrtx_linux.p/openrtx_src_rtx_rtx.cpp.o openrtx_linux.p/openrtx_src_rtx_OpMode_FM.cpp.o openrtx_linux.p/openrtx_src_rtx_OpMode_M17.cpp.o openrtx_linux.p/openrtx_src_gps.c.o openrtx_linux.p/openrtx_src_dsp.cpp.o openrtx_linux.p/openrtx_src_memory_profiling.cpp.o openrtx_linux.p/openrtx_src_protocols_M17_M17Callsign.cpp.o openrtx_linux.p/openrtx_src_protocols_M17_M17Modulator.cpp.o openrtx_linux.p/openrtx_src_protocols_M17_M17Transmitter.cpp.o openrtx_linux.p/openrtx_src_protocols_M17_M17LinkSetupFrame.cpp.o openrtx_linux.p/tests_platform_display_test_SDL.c.o openrtx_linux.p/lib_minmea_minmea.c.o openrtx_linux.p/platform_targets_linux_emulator_emulator.c.o openrtx_linux.p/platform_drivers_display_display_libSDL.c.o openrtx_linux.p/platform_drivers_keyboard_keyboard_linux.c.o openrtx_linux.p/platform_drivers_NVM_nvmem_linux.c.o openrtx_linux.p/platform_drivers_GPS_GPS_linux.c.o openrtx_linux.p/platform_mcu_x86_64_drivers_gpio.c.o openrtx_linux.p/platform_mcu_x86_64_drivers_delays.c.o openrtx_linux.p/platform_mcu_x86_64_drivers_rtc.c.o openrtx_linux.p/platform_drivers_baseband_radio_linux.cpp.o openrtx_linux.p/platform_drivers_audio_audio_linux.c.o openrtx_linux.p/platform_drivers_audio_inputStream_linux.c.o openrtx_linux.p/platform_targets_linux_platform.c.o -Wl,-dead_strip_dylibs -Wl,-headerpad_max_install_names -Wl,-undefined,error -Wl,-rpath,/usr/local/lib -Wl,-rpath,/usr/local/Cellar/codec2/1.0.1/lib -lm -lreadline /usr/local/lib/libSDL2.dylib /usr/local/Cellar/codec2/1.0.1/lib/libcodec2.dylib
Undefined symbols for architecture x86_64:
  "_display_setBacklightLevel", referenced from:
      _main in tests_platform_display_test_SDL.c.o
ld: symbol(s) not found for architecture x86_64
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

A simple removal of that function call will make it work.


