### PR TITLE
fixes #60 (make sure volume setting is restored after tx)

### DIFF
--- a/openrtx/src/rtx/OpMode_FM.cpp
+++ b/openrtx/src/rtx/OpMode_FM.cpp
@@ -53,15 +53,8 @@ void _setVolume()
     else
     {
         audio_enableAmp();
-
-        // Update HR_C6000 gain only if volume changed
-        static uint8_t old_volume = 0;
-        if(volume != old_volume)
-        {
-            // Setting HR_C6000 volume to 0 = max volume
-            HR_C6000::instance().setDacGain(volume);
-            old_volume = volume;
-        }
+        // Setting HR_C6000 volume to 0 = max volume
+        HR_C6000::instance().setDacGain(volume);
     }
 }
 #endif


### PR DESCRIPTION
Instead of saving the old value and checking against it, just always set the volume.
Tested successfully on my MD-UV380G.