### PR TITLE
Module17-oriented PR

### DIFF
--- a/99-openrtx.rules
+++ b/99-openrtx.rules
@@ -5,3 +5,5 @@
 SUBSYSTEM=="usb", ATTRS{idVendor}=="15a2", ATTRS{idProduct}=="0073", MODE="0666"
 # MDx family (example: Tytera MD380)
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE="0666"
+# Module17 (GigaDevice GD32 support)
+SUBSYSTEM=="usb", ATTRS{idVendor}=="28e9", ATTRS{idProduct}=="0189", MODE="0666"

--- a/platform/targets/Module17/platform.c
+++ b/platform/targets/Module17/platform.c
@@ -53,7 +53,7 @@ void platform_init()
     i2c_init();
     mcp4551_init(SOFTPOT_RX);
     mcp4551_init(SOFTPOT_TX);
-    mcp4551_setWiper(SOFTPOT_TX, 0x100);
+    mcp4551_setWiper(SOFTPOT_TX, 0x090);
     //mcp4551_setWiper(SOFTPOT_RX, MCP4551_WIPER_A);
 
     audio_init();

--- a/platform/targets/Module17/platform.c
+++ b/platform/targets/Module17/platform.c
@@ -53,7 +53,7 @@ void platform_init()
     i2c_init();
     mcp4551_init(SOFTPOT_RX);
     mcp4551_init(SOFTPOT_TX);
-    mcp4551_setWiper(SOFTPOT_TX, 0x090);
+    mcp4551_setWiper(SOFTPOT_TX, 0x100);
     //mcp4551_setWiper(SOFTPOT_RX, MCP4551_WIPER_A);
 
     audio_init();


### PR DESCRIPTION
1. Changing the TX pot value in Module17 isn't needed, as the default value can be left as is. The intention was to reduce the baseband output amplitude, so the Yaesu FTM-6000 is happy with the signal. Of course this isn't the only radio that is M17 capable, so the modification is pointless. This is just a workaround anyway, as there's a menu entry needed for setting both TX and RX baseband levels.
2. The udev rule allows the use of `dfu-util` to program GD32-based Module17 without having root privileges.