### PR TITLE
Allow callsigns to have spaces so that linking works for m17gateway.

### DIFF
--- a/openrtx/src/ui/ui.c
+++ b/openrtx/src/ui/ui.c
@@ -203,7 +203,7 @@ const char *symbols_ITU_T_E161[] =
 
 const char *symbols_ITU_T_E161_callsign[] =
 {
-    "0",
+    "0 ",
     "1",
     "ABC2",
     "DEF3",


### PR DESCRIPTION
The Dst ID needs a space between the reflector (eg "M17-USA") and the module (e.g. "C") to trigger m17gateway to make the link. This patch makes the "0⎵" button to make a " " (space) when pressed twice when entering the Dst ID.