### PR TITLE
Update battery config for Module17

### DIFF
--- a/openrtx/src/core/battery.c
+++ b/openrtx/src/core/battery.c
@@ -35,9 +35,6 @@ static const uint16_t bat_v_max = 0x0819;   // 8.10V
 #elif defined BAT_LIPO_3S
 static const uint16_t bat_v_min = 0x0AD4;   // 10.83V
 static const uint16_t bat_v_max = 0x0C73;   // 12.45V
-#elif defined BAT_MOD17
-static const uint16_t bat_v_min = 0x0600;   // 6.00V
-static const uint16_t bat_v_max = 0x0DCD;   // 13.8V
 #elif defined BAT_NONE
 static const uint16_t bat_v_min = 0;
 static const uint16_t bat_v_max = 0;

--- a/platform/targets/Module17/hwconfig.h
+++ b/platform/targets/Module17/hwconfig.h
@@ -39,7 +39,7 @@
 #define PIX_FMT_BW
 
 /* Device has no battery */
-#define BAT_MOD17
+#define BAT_NONE
 
 /* Signalling LEDs */
 #define PTT_LED     GPIOC,8


### PR DESCRIPTION
As Module17 has no battery, it's pretty much useless to display a battery icon with a bar showing battery charge. Instead - the function checking battery charge is made to return `100` percent all the time. There's no chance of getting 'Low battery' screen then.