### PR TITLE
[do not merge] MD380 Two-point modulation

### DIFF
--- a/openrtx/include/calibration/calibInfo_MDx.h
+++ b/openrtx/include/calibration/calibInfo_MDx.h
@@ -34,17 +34,17 @@
  */
 typedef struct
 {
-    uint8_t vox1;
-    uint8_t vox10;
-    uint8_t rxLowVoltage;
-    uint8_t rxFullVoltage;
-    uint8_t rssi1;
-    uint8_t rssi4;
-    uint8_t analogMic;
-    uint8_t digitalMic;
-    uint8_t freqAdjustHigh;
-    uint8_t freqAdjustMid;
-    uint8_t freqAdjustLow;
+    uint8_t vox1;  // 0x2001c380
+    uint8_t vox10; // 0x2001c381
+    uint8_t rxLowVoltage; // 82
+    uint8_t rxFullVoltage; // 83
+    uint8_t rssi1; // 84
+    uint8_t rssi4; // 85
+    uint8_t analogMic; // 86
+    uint8_t digitalMic; // 87
+    uint8_t freqAdjustHigh; // 88
+    uint8_t freqAdjustMid; // 89 <<-!
+    uint8_t freqAdjustLow; // 8A
     freq_t  rxFreq[9];
     freq_t  txFreq[9];
     uint8_t txHighPower[9];

--- a/platform/drivers/baseband/radio_MD3x0.cpp
+++ b/platform/drivers/baseband/radio_MD3x0.cpp
@@ -149,8 +149,8 @@ void radio_init(const rtxStatus_t *rtxState)
     /*
      * Modulation bias settings, as per TYT firmware.
      */
-    DAC->DHR12R2 = (calData->freqAdjustMid)*4 + 0x600;
-    C5000.setModOffset(calData->freqAdjustMid);
+    DAC->DHR12R2 = (calData->freqAdjustHigh)*4 + 0x600;
+    C5000.setModOffset(calData->freqAdjustHigh);
 }
 
 void radio_terminate()
@@ -187,7 +187,7 @@ void radio_tuneVcxo(const int16_t vhfOffset, const int16_t uhfOffset)
      * register, as we still have to deeply understand how TYT computes
      * the values written there.
      */
-    int16_t calValue  = static_cast< int16_t >(calData->freqAdjustMid);
+    int16_t calValue  = static_cast< int16_t >(calData->freqAdjustHigh);
     int16_t oscTune   = (calValue*4 + 0x600) + uhfOffset;
     oscTune           = std::max(std::min(oscTune, int16_t(4095)), int16_t(0));
     DAC->DHR12R2      = static_cast< uint16_t >(oscTune);


### PR DESCRIPTION
**Please do not merge this, as this is a draft PR for keeping track of information related to modulation issues in OpenRTX on the MD380. It adds bad code and extra verbose comments**

the change from `calData->freqAdjustMid` to `calData->freqAdjustHigh` is a red herring based on a mental off-by-one error. However, it did seem to actively change the output waveform and make it much closer to on center. 

Useful and related links:
- C6000 English translated datasheet - https://github.com/open-ham/OpenGD77/blob/main/docs/data_sheets/C6000/HR_C6000_updated_chinese_translated_english.pdf
- WIP Mapping of C5000 registers - https://gist.github.com/USA-RedDragon/cab6de88bc13dbb525f59cb47a62ff31
- D13.020 symbols - https://github.com/USA-RedDragon/md380tools/blob/master/applet/src/symbols_d13.020
- Known C5000 registers: https://www.qsl.net/dl4yhf/RT3/HR_C5000_english.html#registers
- Known C6000 registers: https://github.com/open-ham/OpenGD77/blob/main/docs/data_sheets/C6000/HR-C6000%20Registers_G4EML.docx

Here's the RE work that I've got so far: 

<img width="1920" alt="1_spi_flash_security_registers" src="https://user-images.githubusercontent.com/13051767/178784034-1fb51595-6992-4521-bd93-db01d8303a9a.png">

I started by checking the references of `md380_spiflash_security_registers_read` to find where the calibration data is loaded into memory on the stock MD380 firmware. 

<img width="1920" alt="2_spi_flash_read" src="https://user-images.githubusercontent.com/13051767/178784361-91cfedf5-929a-48d5-bff9-e1afcb0995de.png">

256 bytes are read from the flash starting at the 0x1000 address, ending up at 0x2001c380-0x2001c480 similar to https://github.com/OpenRTX/OpenRTX/blob/master/platform/drivers/NVM/nvmem_MD3x0.c#L46

<img width="1920" alt="3_c5000_register_set" src="https://user-images.githubusercontent.com/13051767/178785064-9d46cd99-4613-48ab-9d82-ce5df1d00b82.png">

Here, in the function that most seems like the C5000 initialization function (at address 0803f8f2), the C5000 0x47 register is set to 128 minus the value in 0x2001c389 that seems tied to the two-point modulation as the "Two Point Modulation Offset Low 8 Bits". Note that the source is 9 bytes after the MD380 calibration data. 

If we take this struct as a source of truth (I need to make sure on this), https://github.com/USA-RedDragon/OpenRTX/blob/two-point-modulation/openrtx/include/calibration/calibInfo_MDx.h#L35-L75, `freqAdjustMid` is the correct value to use. 

So at this point, we've got a bit more knowledge but don't seem to be closer to stock yet.