### PR TITLE
MD3x0: RF fixes for frequency "wiggle" and offset

### DIFF
--- a/openrtx/src/core/graphics.cpp
+++ b/openrtx/src/core/graphics.cpp
@@ -181,9 +181,9 @@ inline void gfx_setPixel(point_t pos, color_t color)
         rgb565_t new_pixel = _true2highColor(color);
         rgb565_t old_pixel = buf[pos.x + pos.y*SCREEN_WIDTH];
         rgb565_t pixel;
-        pixel.r = ((255-alpha)*old_pixel.b+alpha*new_pixel.b)/255;
+        pixel.r = ((255-alpha)*old_pixel.r+alpha*new_pixel.r)/255;
         pixel.g = ((255-alpha)*old_pixel.g+alpha*new_pixel.g)/255;
-        pixel.b = ((255-alpha)*old_pixel.r+alpha*new_pixel.r)/255;
+        pixel.b = ((255-alpha)*old_pixel.b+alpha*new_pixel.b)/255;
         buf[pos.x + pos.y*SCREEN_WIDTH] = pixel;
     }
     else

--- a/openrtx/src/rtx/OpMode_M17.cpp
+++ b/openrtx/src/rtx/OpMode_M17.cpp
@@ -71,7 +71,10 @@ void OpMode_M17::update(rtxStatus_t *const status, const bool newCfg)
     // Force inversion of RX phase for MD-3x0 VHF and MD-UV3x0 radios
     #if defined(PLATFORM_MD3x0) || defined(PLATFORM_MDUV3x0)
     const hwInfo_t* hwinfo = platform_getHwInfo();
-    status->invertRxPhase |= hwinfo->vhf_band;
+    if(hwinfo->vhf_band == 1)
+        status->invertRxPhase = true;
+    else
+        status->invertRxPhase = false;
     #endif
 
     // Main FSM logic

--- a/openrtx/src/ui/ui_menu.c
+++ b/openrtx/src/ui/ui_menu.c
@@ -26,6 +26,7 @@
 #include <interfaces/nvmem.h>
 #include <interfaces/cps_io.h>
 #include <interfaces/platform.h>
+#include <interfaces/delays.h>
 #include <memory_profiling.h>
 
 /* UI main screen helper functions, their implementation is in "ui_main.c" */
@@ -639,11 +640,13 @@ void _ui_drawSettingsReset2Defaults(ui_state_t* ui_state)
     (void) ui_state;
 
     static int drawcnt = 0;
+    static long long lastDraw = 0;
+
     gfx_clearScreen();
     gfx_print(layout.top_pos, layout.top_font, TEXT_ALIGN_CENTER,
               color_white, "Reset to Defaults");
 
-    //text will flash yellow and white based on update rate of screen
+    // Make text flash yellow once every 1s
     color_t textcolor = drawcnt % 2 == 0 ? color_white : yellow_fab413;
     gfx_printLine(1, 4, layout.top_h, SCREEN_HEIGHT - layout.bottom_h,
                   layout.horizontal_pad, layout.top_font,
@@ -651,7 +654,12 @@ void _ui_drawSettingsReset2Defaults(ui_state_t* ui_state)
     gfx_printLine(2, 4, layout.top_h, SCREEN_HEIGHT - layout.bottom_h,
                   layout.horizontal_pad, layout.top_font,
                   TEXT_ALIGN_CENTER, textcolor, "Press Enter twice");
-    drawcnt++;
+
+    if((getTick() - lastDraw) > 1000)
+    {
+        drawcnt++;
+        lastDraw = getTick();
+    }
 }
 
 bool _ui_drawMacroMenu()

--- a/platform/drivers/NVM/nvmem_MD3x0.c
+++ b/platform/drivers/NVM/nvmem_MD3x0.c
@@ -43,7 +43,17 @@ void nvm_readCalibData(void *buf)
 
     md3x0Calib_t *calib = ((md3x0Calib_t *) buf);
 
-    (void) W25Qx_readSecurityRegister(0x1000, &(calib->vox1), 11);
+    (void) W25Qx_readSecurityRegister(0x1000, &(calib->vox1), 1);
+    (void) W25Qx_readSecurityRegister(0x1001, &(calib->vox10), 1);
+    (void) W25Qx_readSecurityRegister(0x1002, &(calib->rxLowVoltage), 1);
+    (void) W25Qx_readSecurityRegister(0x1003, &(calib->rxFullVoltage), 1);
+    (void) W25Qx_readSecurityRegister(0x1004, &(calib->rssi1), 1);
+    (void) W25Qx_readSecurityRegister(0x1005, &(calib->rssi4), 1);
+    (void) W25Qx_readSecurityRegister(0x1006, &(calib->analogMic), 1);
+    (void) W25Qx_readSecurityRegister(0x1007, &(calib->digitalMic), 1);
+    (void) W25Qx_readSecurityRegister(0x1008, &(calib->freqAdjustHigh), 1);
+    (void) W25Qx_readSecurityRegister(0x1009, &(calib->freqAdjustMid), 1);
+    (void) W25Qx_readSecurityRegister(0x100A, &(calib->freqAdjustLow), 1);
     (void) W25Qx_readSecurityRegister(0x1010, calib->txHighPower, 9);
     (void) W25Qx_readSecurityRegister(0x1020, calib->txLowPower, 9);
     (void) W25Qx_readSecurityRegister(0x1030, calib->rxSensitivity, 9);

--- a/platform/drivers/baseband/HR_C5000_MDx.cpp
+++ b/platform/drivers/baseband/HR_C5000_MDx.cpp
@@ -163,6 +163,7 @@ void HR_Cx000< M >::fmMode()
     writeReg(M::CONFIG, 0x81, 0x00);    // Mask other interrupts
     writeReg(M::CONFIG, 0x60, 0x00);    // Disable both analog and DMR transmission
     writeReg(M::CONFIG, 0x00, 0x28);    // Reset register
+    writeReg(M::CONFIG, 0x0E, 0x40 | 0x04); // Set the mic input during early init, if we don't the "frequency wiggle" is present
 }
 
 template< class M >


### PR DESCRIPTION
Two separate fixes here. One is to explicitly read the calibration data to fix the two-point modulation. The other sets the mic input register of the C5000 in the function to set FM mode to ensure it gets set early. When this first gets set right before TX the "frequency wiggle" is present.

Supersedes #92

I would greatly appreciate if someone could test these out (especially if you've got a spectrum analyzer), as I've only verified with an RTL-SDR