### PR TITLE
M17: Implement EOT marker

### DIFF
--- a/openrtx/include/protocols/M17/M17Constants.hpp
+++ b/openrtx/include/protocols/M17/M17Constants.hpp
@@ -41,6 +41,7 @@ static constexpr syncw_t LSF_SYNC_WORD    = {0x55, 0xF7};  // LSF sync word
 static constexpr syncw_t BERT_SYNC_WORD   = {0xDF, 0x55};  // BERT data sync word
 static constexpr syncw_t STREAM_SYNC_WORD = {0xFF, 0x5D};  // Stream data sync word
 static constexpr syncw_t PACKET_SYNC_WORD = {0x75, 0xFF};  // Packet data sync word
+static constexpr syncw_t EOT_SYNC_WORD    = {0x55, 0x5D};  // End of transmission sync word
 
 }      // namespace M17
 

--- a/openrtx/include/protocols/M17/M17Modulator.hpp
+++ b/openrtx/include/protocols/M17/M17Modulator.hpp
@@ -58,7 +58,7 @@ public:
     void init();
 
     /**
-     * Shutdown modulator and deallocate data buffers.
+     * Forcefully shutdown modulator and deallocate data buffers.
      */
     void terminate();
 
@@ -88,6 +88,9 @@ private:
      */
     void emitBaseband();
 
+    /** Gracefully end the transmission **/
+    void stop();
+
     static constexpr size_t M17_TX_SAMPLE_RATE     = 48000;
     static constexpr size_t M17_SAMPLES_PER_SYMBOL = M17_TX_SAMPLE_RATE / M17_SYMBOL_RATE;
     static constexpr size_t M17_FRAME_SAMPLES      = M17_FRAME_SYMBOLS * M17_SAMPLES_PER_SYMBOL;
@@ -105,7 +108,6 @@ private:
     stream_sample_t              *idleBuffer;      ///< Half baseband buffer, free for processing.
     streamId                     outStream;        ///< Baseband output stream ID.
     bool                         txRunning;        ///< Transmission running.
-    bool                         stopTx;           ///< Stop transmission request.
 
     #if defined(PLATFORM_MD3x0) || defined(PLATFORM_MDUV3x0)
     filter_state_t   pwmFilterState;


### PR DESCRIPTION
Super early work in progress for the End Of Transmission marker. 

With this patch, I'm getting odd behavior on my MMDVM_HS Dual Hat after an M17 transmission from my MD380. I'm not yet sure whether this is due to a bug in the MMDVM_HS firmware or a bad EOT marker. 

The MMDVM ends up in an odd loop where it acts as if it's receiving a network stream from my callsign to ALL and keeps repeating this, even though the radio has stopped transmitting. Any help in narrowing this down is much appreciated.