### PR TITLE
Fix double-free 

### DIFF
--- a/openrtx/src/core/audio_codec.c
+++ b/openrtx/src/core/audio_codec.c
@@ -79,7 +79,10 @@ void codec_terminate()
     pthread_cond_destroy(&not_empty);
     pthread_cond_destroy(&not_full);
 
-    if(audioBuf != NULL) free(audioBuf);
+    if(audioBuf != NULL) {
+        free(audioBuf);
+        audioBuf = NULL;
+    }
 }
 
 bool codec_startEncode(const enum AudioSource source)


### PR DESCRIPTION
This PR fixes a crash that happens when `codec_terminate()` is called multiple times. On my setup, i get a double free everytime i close the linux emulator. The double free is caused because the variable is freed and not set to null, the check that prevents the double free is bypassed and crashes.

This is the stack trace:
```
=================================================================
==551795==ERROR: AddressSanitizer: attempting double-free on 0x616000060080 in thread T8:
    #0 0x7fd64c0d1672 in __interceptor_free /usr/src/debug/gcc/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x560d0de13608 in codec_terminate ../openrtx/src/core/audio_codec.c:82
    #2 0x560d0de35643 in OpMode_M17::disable() ../openrtx/src/rtx/OpMode_M17.cpp:59
    #3 0x560d0de34adb in OpMode_M17::~OpMode_M17() ../openrtx/src/rtx/OpMode_M17.cpp:40
    #4 0x7fd64b15eef4  (/usr/lib/libc.so.6+0x40ef4)
    #5 0x7fd64b15f06f in exit (/usr/lib/libc.so.6+0x4106f)
    #6 0x560d0de80e51 in platform_terminate ../platform/targets/linux/platform.c:53
    #7 0x560d0de1347e in openrtx_run ../openrtx/src/core/openrtx.c:91
    #8 0x7fd64b1aa54c  (/usr/lib/libc.so.6+0x8c54c)
    #9 0x7fd64b22f873 in clone (/usr/lib/libc.so.6+0x111873)
```