### PR TITLE
Allow newly-added settings to take their default values

### DIFF
--- a/openrtx/include/core/settings.h
+++ b/openrtx/include/core/settings.h
@@ -59,7 +59,8 @@ typedef struct
     uint8_t vpLevel         : 3,  // Voice prompt level
             vpPhoneticSpell : 1,  // Phonetic spell enabled
             _reserved       : 4;
-
+    unsigned int structSize;
+    uint16_t   crc;
 }
 __attribute__((packed)) settings_t;
 
@@ -81,7 +82,9 @@ static const settings_t default_settings =
     0,                // not used
     0,                // Voice prompts off
     0,                // Phonetic spell off
-    0                 // not used
+    0,                // not used
+    0,                // struct size
+    0,                // crc
 };
 
 #endif /* SETTINGS_H */

--- a/openrtx/src/core/state.c
+++ b/openrtx/src/core/state.c
@@ -38,12 +38,12 @@ void state_init()
     pthread_mutex_init(&state_mutex, NULL);
 
     /*
-     * Try loading settings from nonvolatile memory and default to sane values
-     * in case of failure.
+     * Default to sane values, then try overwriting default
+     * settings from nonvolatile memory.
      */
+    state.settings = default_settings;
     if(nvm_readSettings(&state.settings) < 0)
     {
-        state.settings = default_settings;
         strncpy(state.settings.callsign, "OPNRTX", 10);
     }
 

--- a/platform/drivers/NVM/nvmem_settings_MDx.c
+++ b/platform/drivers/NVM/nvmem_settings_MDx.c
@@ -19,6 +19,7 @@
  ***************************************************************************/
 
 #include <interfaces/nvmem.h>
+#include <interfaces/platform.h>
 #include <string.h>
 #include <cps.h>
 #include <crc.h>
@@ -30,7 +31,6 @@
  */
 typedef struct
 {
-    uint16_t   crc;
     settings_t settings;
     channel_t  vfoData;
 }
@@ -55,7 +55,7 @@ memory_t *memory = ((memory_t *) baseAddress);
  * is the one containing the last saved settings. Blocks containing legacy data
  * are marked with numbers starting from 4096.
  *
- * @return number currently active data block or -1 if memory data is invalid.
+ * @return number currently active data block or -1 if memory data is invalid, -2 if the CRC check fails.
  */
 static int findActiveBlock()
 {
@@ -88,10 +88,24 @@ static int findActiveBlock()
     block -= 1;
 
     // Check data validity
-    uint16_t crc = crc_ccitt(&(memory->data[block].settings),
-                             sizeof(settings_t) + sizeof(channel_t));
-    if(crc != memory->data[block].crc)
+    unsigned int settingsSize = memory->data[block].settings.structSize;
+
+    // Prevent reading obviously bad values as the settings size
+    if (settingsSize > sizeof(settings_t)) {
+        platform_ledOn(RED);
+        settingsSize = sizeof(settings_t);
+    }
+
+    settings_t tmpSettings;
+    memcpy(&tmpSettings, &(memory->data[block].settings), settingsSize);
+    tmpSettings.crc = 0;
+
+    uint16_t crc = crc_ccitt(&tmpSettings, settingsSize);
+
+    if(crc != memory->data[block].settings.crc) {
+        platform_ledOn(GREEN);
         return -2;
+    }
 
     return block;
 }
@@ -116,7 +130,7 @@ int nvm_readSettings(settings_t *settings)
     // Invalid data found
     if(block < 0) return -1;
 
-    memcpy(settings, &(memory->data[block].settings), sizeof(settings_t));
+    memcpy(settings, &(memory->data[block].settings), memory->data[block].settings.structSize);
 
     return 0;
 }
@@ -141,18 +155,21 @@ int nvm_writeSettingsAndVfo(const settings_t *settings, const channel_t *vfo)
     }
     else
     {
-        prevCrc = memory->data[block].crc;
+        prevCrc = memory->data[block].settings.crc;
         block += 1;
     }
 
     dataBlock_t tmpBlock;
-    memcpy((&tmpBlock.settings), settings, sizeof(settings_t));
     memcpy((&tmpBlock.vfoData), vfo, sizeof(channel_t));
-    tmpBlock.crc = crc_ccitt(&(tmpBlock.settings),
-                             sizeof(settings_t) + sizeof(channel_t));
+
+    memcpy((&tmpBlock.settings), settings, sizeof(settings_t));
+    // Clear out any existing CRC
+    tmpBlock.settings.crc = 0;
+    tmpBlock.settings.structSize = sizeof(settings_t);
+    tmpBlock.settings.crc = crc_ccitt(&(tmpBlock.settings), sizeof(settings_t));
 
     // New data is equal to the old one, avoid saving
-    if((block != 0) && (tmpBlock.crc == prevCrc))
+    if((block != 0) && (tmpBlock.settings.crc == prevCrc))
         return 0;
 
     // Save data


### PR DESCRIPTION
This allows devs to ensure new values added to the NVM will come into new releases with a sane value. Without this patch set, a new setting in the NVM would default to the value of data that previously occupied this space, regardless of whether that data was a part of the settings structure.

The process for adding a setting doesn't change, just ensure that the settings changes are append-only. The NVM driver has been updated to save the current structure size into the settings, to ensure we only load the data we want from the NVM.