### PR TITLE
Standby led

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -69,6 +69,7 @@ openrtx_inc = ['openrtx/include',
                'platform/drivers/ADC',
                'platform/drivers/NVM',
                'platform/drivers/GPS',
+               'platform/drivers/LED',
                'platform/drivers/USB',
                'platform/drivers/tones',
                'platform/drivers/baseband',
@@ -161,7 +162,8 @@ mdx_src = ['openrtx/src/core/xmodem.c',
            'platform/drivers/backlight/backlight_MDx.c',
            'platform/drivers/tones/toneGenerator_MDx.cpp',
            'platform/drivers/USB/usb_MDx.cpp',
-           'platform/drivers/USB/usb_descriptors.c']
+           'platform/drivers/USB/usb_descriptors.c',
+           'platform/drivers/LED/led.c']
 
 ##
 ## GDx family: Radioddity GD-77 and Baofeng DM-1801

--- a/openrtx/include/core/settings.h
+++ b/openrtx/include/core/settings.h
@@ -46,7 +46,7 @@ typedef enum
 display_timer_t;
 
 
-#define MAX_MIGRATION_VERSION 1 // this should be bumped if any new setting is added to settings_t
+#define MAX_MIGRATION_VERSION 2 // this should be bumped if any new setting is added to settings_t
 // and a migration should be made in state.c in the state_migrate() function
 
 typedef struct
@@ -62,6 +62,7 @@ typedef struct
             not_in_use    : 4;
 
     uint8_t migration_version;    // Used to keep track of new settings to ensure good defaults
+    bool    standby_led;          // Enable/disable the standby LED
 }
 __attribute__((packed)) settings_t;
 
@@ -82,6 +83,7 @@ static const settings_t default_settings =
     TIMER_30S,        // 30 seconds
     0.                // not in use
     0,                // Migration version
+    false,            // Standby LED
 };
 
 #endif /* SETTINGS_H */

--- a/openrtx/include/core/settings.h
+++ b/openrtx/include/core/settings.h
@@ -45,6 +45,10 @@ typedef enum
 }
 display_timer_t;
 
+
+#define MAX_MIGRATION_VERSION 1 // this should be bumped if any new setting is added to settings_t
+// and a migration should be made in state.c in the state_migrate() function
+
 typedef struct
 {
     uint8_t brightness;           // Display brightness
@@ -56,6 +60,8 @@ typedef struct
     char    callsign[10];         // Plaintext callsign, for future use
     uint8_t display_timer : 4,    // Standby timer
             not_in_use    : 4;
+
+    uint8_t migration_version;    // Used to keep track of new settings to ensure good defaults
 }
 __attribute__((packed)) settings_t;
 
@@ -74,7 +80,8 @@ static const settings_t default_settings =
     false,            // GPS enabled
     "",               // Empty callsign
     TIMER_30S,        // 30 seconds
-    0                 // not in use
+    0.                // not in use
+    0,                // Migration version
 };
 
 #endif /* SETTINGS_H */

--- a/openrtx/include/core/ui.h
+++ b/openrtx/include/core/ui.h
@@ -60,6 +60,7 @@ enum uiScreen
     SETTINGS_DISPLAY,
     SETTINGS_GPS,
     SETTINGS_M17,
+    SETTINGS_LED,
     SETTINGS_RESET2DEFAULTS,
     LOW_BAT
 };
@@ -96,6 +97,7 @@ enum settingsItems
     ,S_GPS
 #endif
     ,S_M17
+    ,S_LED
     ,S_RESET2DEFAULTS
 };
 
@@ -122,6 +124,11 @@ enum settingsGPSItems
     G_TIMEZONE
 };
 #endif
+
+enum settingsLEDItems
+{
+    L_ENABLED = 0,
+};
 
 /**
  * Struct containing a set of positions and sizes that get
@@ -197,6 +204,7 @@ extern const char *menu_items[];
 extern const char *settings_items[];
 extern const char *display_items[];
 extern const char *settings_gps_items[];
+extern const char *settings_led_items[];
 extern const char *backup_restore_items[];
 extern const char *info_items[];
 extern const char *authors[];
@@ -204,6 +212,7 @@ extern const uint8_t menu_num;
 extern const uint8_t settings_num;
 extern const uint8_t display_num;
 extern const uint8_t settings_gps_num;
+extern const uint8_t settings_led_num;
 extern const uint8_t backup_restore_num;
 extern const uint8_t info_num;
 extern const uint8_t author_num;

--- a/openrtx/src/core/state.c
+++ b/openrtx/src/core/state.c
@@ -30,6 +30,21 @@
 state_t state;
 pthread_mutex_t state_mutex;
 
+void state_migrate() {
+    // Invalid initial state
+    if (state.settings.migration_version == 0 ||
+        state.settings.migration_version > MAX_MIGRATION_VERSION)
+    {
+        // Migration from 0->1 does nothing
+        state.settings.migration_version = 1;
+    }
+    if (state.settings.migration_version == 1)
+    {
+        //example migration from 1>2
+        //state.settings.migration_version = 2;
+    }
+}
+
 void state_init()
 {
     pthread_mutex_init(&state_mutex, NULL);
@@ -43,6 +58,8 @@ void state_init()
         state.settings = default_settings;
         strncpy(state.settings.callsign, "OPNRTX", 10);
     }
+
+    state_migrate();
 
     /*
      * Try loading VFO configuration from nonvolatile memory and default to sane

--- a/openrtx/src/core/state.c
+++ b/openrtx/src/core/state.c
@@ -40,8 +40,9 @@ void state_migrate() {
     }
     if (state.settings.migration_version == 1)
     {
-        //example migration from 1>2
-        //state.settings.migration_version = 2;
+        // Migration from 1->2, add standby_led
+        state.settings.standby_led = default_settings.standby_led;
+        state.settings.migration_version = 2;
     }
 }
 

--- a/openrtx/src/core/threads.c
+++ b/openrtx/src/core/threads.c
@@ -28,6 +28,9 @@
 #include <interfaces/platform.h>
 #include <interfaces/delays.h>
 #include <interfaces/radio.h>
+#ifdef LED_PRESENT
+#include <led.h>
+#endif
 #include <event.h>
 #include <rtx.h>
 #include <string.h>
@@ -172,6 +175,10 @@ void *dev_task(void *arg)
             state_update();
             ui_pushEvent(EVENT_STATUS, 0);
         }
+
+        #ifdef LED_PRESENT
+        led_tick();
+        #endif
 
         // Run this loop once every 5ms
         time += 5;

--- a/openrtx/src/ui/ui.c
+++ b/openrtx/src/ui/ui.c
@@ -77,6 +77,9 @@
 #include <battery.h>
 #include <input.h>
 #include <hwconfig.h>
+#ifdef LED_PRESENT
+#include <led.h>
+#endif
 
 /* UI main screen functions, their implementation is in "ui_main.c" */
 extern void _ui_drawMainBackground();
@@ -409,6 +412,9 @@ void ui_init()
     redraw_needed = true;
     layout = _ui_calculateLayout();
     layout_ready = true;
+    #ifdef LED_PRESENT
+    led_link_standby_state(&standby);
+    #endif
     // Initialize struct ui_state to all zeroes
     // This syntax is called compound literal
     // https://stackoverflow.com/questions/6891720/initialize-reset-struct-to-zero-null

--- a/openrtx/src/ui/ui_menu.c
+++ b/openrtx/src/ui/ui_menu.c
@@ -202,6 +202,25 @@ int _ui_getSettingsGPSValueName(char *buf, uint8_t max_len, uint8_t index)
 }
 #endif
 
+int _ui_getSettingsLEDEntryName(char *buf, uint8_t max_len, uint8_t index)
+{
+    if(index >= settings_led_num) return -1;
+    snprintf(buf, max_len, "%s", settings_led_items[index]);
+    return 0;
+}
+
+int _ui_getSettingsLEDValueName(char *buf, uint8_t max_len, uint8_t index)
+{
+    if(index >= settings_led_num) return -1;
+    switch(index)
+    {
+        case L_ENABLED:
+            snprintf(buf, max_len, "%s", (last_state.settings.standby_led) ? "ON" : "OFF");
+            break;
+    }
+    return 0;
+}
+
 int _ui_getBackupRestoreEntryName(char *buf, uint8_t max_len, uint8_t index)
 {
     if(index >= backup_restore_num) return -1;
@@ -545,6 +564,18 @@ void _ui_drawSettingsGPS(ui_state_t* ui_state)
                           _ui_getSettingsGPSValueName);
 }
 #endif
+
+void _ui_drawSettingsLED(ui_state_t* ui_state)
+{
+    gfx_clearScreen();
+    // Print "LED Settings" on top bar
+    gfx_print(layout.top_pos, layout.top_font, TEXT_ALIGN_CENTER,
+              color_white, "LED Settings");
+    // Print display settings entries
+    _ui_drawMenuListValue(ui_state, ui_state->menu_selected,
+                          _ui_getSettingsLEDEntryName,
+                          _ui_getSettingsLEDValueName);
+}
 
 #ifdef RTC_PRESENT
 void _ui_drawSettingsTimeDate()

--- a/platform/drivers/LED/led.c
+++ b/platform/drivers/LED/led.c
@@ -1,0 +1,53 @@
+#include <hwconfig.h>
+#include "interfaces/delays.h"
+#ifdef LED_PRESENT
+#include "interfaces/gpio.h"
+#endif
+#include <stdint.h>
+#include <stdbool.h>
+
+uint16_t standby_toggle_tick = 0;
+uint16_t standby_swap_tick = 0;
+bool * standby_active = false;
+bool led_on = false;
+bool red_on = false;
+
+// Runs every 5ms
+void led_tick() {
+    if (*standby_active) {
+        standby_toggle_tick++;
+        if (standby_toggle_tick % 40 == 0) {
+            // 200ms passed, switch active LED
+            red_on = !red_on;
+        }
+        standby_swap_tick++;
+        if (standby_swap_tick % 1000 == 0 && !led_on)
+        {
+            // 5 seconds has passed, toggle LED on
+            led_on = true;
+        } else if (standby_swap_tick % 200 == 0)
+        {
+            // 1 second has passed, toggle LED off
+            led_on = false;
+        }
+
+        #ifdef LED_PRESENT
+        if(led_on) {
+            if (red_on) {
+                gpio_setPin(RED_LED);
+                gpio_clearPin(GREEN_LED);
+            } else {
+                gpio_setPin(GREEN_LED);
+                gpio_clearPin(RED_LED);
+            }
+        } else {
+            gpio_clearPin(GREEN_LED);
+            gpio_clearPin(RED_LED);
+        }
+        #endif
+    }
+}
+
+void led_link_standby_state(bool * standby) {
+    standby_active = standby;
+}

--- a/platform/drivers/LED/led.c
+++ b/platform/drivers/LED/led.c
@@ -4,6 +4,7 @@
 #include "interfaces/gpio.h"
 #endif
 #include <stdint.h>
+#include <state.h>
 #include <stdbool.h>
 
 uint16_t standby_toggle_tick = 0;
@@ -14,7 +15,7 @@ bool red_on = false;
 
 // Runs every 5ms
 void led_tick() {
-    if (*standby_active) {
+    if (*standby_active && state.settings.standby_led) {
         standby_toggle_tick++;
         if (standby_toggle_tick % 40 == 0) {
             // 200ms passed, switch active LED

--- a/platform/drivers/LED/led.h
+++ b/platform/drivers/LED/led.h
@@ -1,0 +1,7 @@
+#ifndef LED_H
+#define LED_H
+
+void led_tick();
+void led_link_standby_state(bool * standby);
+
+#endif

--- a/platform/drivers/baseband/radio_MD3x0.cpp
+++ b/platform/drivers/baseband/radio_MD3x0.cpp
@@ -207,14 +207,12 @@ void radio_setOpmode(const enum opmode mode)
         case OPMODE_DMR:
             gpio_clearPin(FM_SW);       // Disable analog RX stage after superhet
             gpio_setPin(DMR_SW);        // Enable analog paths for DMR
-            _setBandwidth(BW_12_5);     // Set bandwidth to 12.5kHz
             //C5000_dmrMode();
             break;
 
         case OPMODE_M17:
             gpio_clearPin(DMR_SW);      // Disconnect analog paths for DMR
             gpio_setPin(FM_SW);         // Enable analog RX stage after superhet
-            _setBandwidth(BW_25);       // Set bandwidth to 25kHz for proper deviation
             C5000.fmMode();             // HR_C5000 in FM mode
             C5000.setInputGain(-3);     // Input gain in dB, found experimentally
             break;
@@ -354,12 +352,10 @@ void radio_updateConfiguration()
 
     C5000.setModAmplitude(I, Q);
 
-    // Set bandwidth, only for analog FM mode
-    if(config->opMode == OPMODE_FM)
-    {
-        enum bandwidth bw = static_cast< enum bandwidth >(config->bandwidth);
-        _setBandwidth(bw);
-    }
+    // Set bandwidth, force 12.5kHz for DMR mode
+    enum bandwidth bandwidth = static_cast< enum bandwidth >(config->bandwidth);
+    if(config->opMode == OPMODE_DMR) bandwidth = BW_12_5;
+    _setBandwidth(bandwidth);
 
     // Set CTCSS tone
     float tone = static_cast< float >(config->txTone) / 10.0f;

--- a/platform/targets/MD-3x0/hwconfig.h
+++ b/platform/targets/MD-3x0/hwconfig.h
@@ -32,6 +32,9 @@ extern "C" {
 /* Device supports an optional GPS chip */
 #define GPS_PRESENT
 
+/* Device has onboard LEDs */
+#define LED_PRESENT
+
 /* Device has a channel selection knob */
 #define HAS_ABSOLUTE_KNOB
 


### PR DESCRIPTION
Builds on settings migration in #105 to add a standby LED driver, allowing the LED to blink at an interval while the screen is on standby