### PR TITLE
Fix README hardware mod link

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Currently the radios supporting this digital mode are the following:
 - MD-UV380 and MD-UV390 support support both modulation and demodulation.
 - GD77 and DM-1801 currently **do not support** the new digital voice mode.
 
-To make the digital mode work, some modding is required: refer to the [dedicated page](https://openrtx.org/#/hw_mods) on our website for the details.
+To make the digital mode work, some modding is required: refer to the [dedicated page](https://openrtx.org/#/M17/m17?id=hardware-modifications) on our website for the details.
 
 ## Disclaimer
 


### PR DESCRIPTION
# What

The README had a dead link. I replaced it with the current version of the referenced page (I think).

# Why

Because having dead links is distracting.

# How

Updated the link

# Anything else

I'd like someone more familiar with the project to confirm that I put the right value for the page. I think the one I used is logical, but I may be wrong.