### PR TITLE
macro menu mode change: catch invalid states

### DIFF
--- a/openrtx/src/ui/ui.c
+++ b/openrtx/src/ui/ui.c
@@ -790,6 +790,8 @@ void _ui_fsm_menuMacro(kbd_msg_t msg, bool *sync_rtx)
                 state.channel.mode = OPMODE_M17;
             else if(state.channel.mode == OPMODE_M17)
                 state.channel.mode = OPMODE_FM;
+            else //catch any invalid states so they don't get locked out
+                state.channel.mode = OPMODE_FM;
             *sync_rtx = true;
             break;
         case 6:


### PR DESCRIPTION

Bonnie's radio is running the latest (as of thursday night) master branch. Somewhere between the fest and being at home, it somehow picked up DMR mode and couldn't get out of it from the macro menu in VFO mode. It's expected to be either of FM or M17.
A 'default settings' cleared the VFO settings and fixed it.

Looking at the code, if the opmode isn't listed but the radio somehow has that state, there's no way to get back into the FSM of working opmodes. In case 5 for the macro menu an 'else' to catch currently-invalid mode settings (like DMR) will provide an on-ramp to the finite states listed in case there's an issue. That's what this PR does. I used FM as I figure that'll almost always be a safe choice.

What I don't understand is how it got to DMR mode in the first place, because when I tested the radio before giving it to Bonnie, it was firmly in M17 mode and so should not have broken out of the two available states. Keep an eye out for that I guess. 

Beware
----------
untested but does compile and should be fine