### PR TITLE
Add menu wrapping for channel, bank and contact menu

### DIFF
--- a/openrtx/include/core/cps.h
+++ b/openrtx/include/core/cps.h
@@ -275,4 +275,10 @@ __attribute__((packed)) cps_header_t; // 88B
  */
 channel_t cps_getDefaultChannel();
 
+/**
+ * This function initializes the number of channels, banks
+ * and contacts
+ */
+void cps_init();
+
 #endif // CPS_H

--- a/openrtx/include/core/state.h
+++ b/openrtx/include/core/state.h
@@ -70,6 +70,10 @@ typedef struct
     bool       backup_eflash;
     bool       restore_eflash;
     m17_t      m17_data;
+
+    uint8_t    bank_number;
+    uint8_t    channel_number;
+    uint8_t    contact_number;
 }
 state_t;
 

--- a/openrtx/include/core/ui.h
+++ b/openrtx/include/core/ui.h
@@ -228,6 +228,13 @@ extern const color_t yellow_fab413;
  */
 void ui_init();
 
+
+/**
+ * This function initializes the number of channels, banks
+ * and contacts
+ */
+void menu_init();
+
 /**
  * This function writes the OpenRTX splash screen image into the framebuffer.
  *

--- a/openrtx/include/core/ui.h
+++ b/openrtx/include/core/ui.h
@@ -228,13 +228,6 @@ extern const color_t yellow_fab413;
  */
 void ui_init();
 
-
-/**
- * This function initializes the number of channels, banks
- * and contacts
- */
-void menu_init();
-
 /**
  * This function writes the OpenRTX splash screen image into the framebuffer.
  *

--- a/openrtx/src/core/cps.c
+++ b/openrtx/src/core/cps.c
@@ -20,6 +20,8 @@
 
 #include <interfaces/platform.h>
 #include <cps.h>
+#include "interfaces/cps_io.h"
+#include "state.h"
 
 channel_t cps_getDefaultChannel()
 {
@@ -46,4 +48,36 @@ channel_t cps_getDefaultChannel()
     channel.fm.txToneEn = 0;
     channel.fm.txTone   = 0;
     return channel;
+}
+
+void cps_init()
+{
+    // Calculate Number of Channels
+    uint8_t channel_number = 0;
+    channel_t channel;
+    while (cps_readChannel(&channel, channel_number) != -1)
+    {
+        channel_number += 1;
+    }
+    state.channel_number = channel_number;
+    // Calculate Number of Banks
+    uint8_t bank_number = 0;
+    bankHdr_t bank;
+
+    while (cps_readBankHeader(&bank, bank_number) != -1)
+    {
+        bank_number += 1;
+    }
+    // manu_selected is 0-based
+    // bank 0 means "All Channel" mode
+    // banks (1, n) are mapped to banks (0, n-1)
+    state.bank_number = bank_number + 1;
+    // Calculate Number of Contacts
+    uint8_t contact_number = 0;
+    contact_t contact;
+    while (cps_readContact(&contact, contact_number) != -1)
+    {
+        contact_number += 1;
+    }
+    state.contact_number = contact_number;
 }

--- a/openrtx/src/core/openrtx.c
+++ b/openrtx/src/core/openrtx.c
@@ -64,8 +64,7 @@ void openrtx_init()
             #endif
         }
     }
-
-    menu_init();
+    cps_init();
     // Display splash screen, turn on backlight after a suitable time to
     // hide random pixels during render process
     ui_drawSplashScreen(true);

--- a/openrtx/src/core/openrtx.c
+++ b/openrtx/src/core/openrtx.c
@@ -65,6 +65,7 @@ void openrtx_init()
         }
     }
 
+    menu_init();
     // Display splash screen, turn on backlight after a suitable time to
     // hide random pixels during render process
     ui_drawSplashScreen(true);

--- a/openrtx/src/ui/ui.c
+++ b/openrtx/src/ui/ui.c
@@ -1112,38 +1112,6 @@ void ui_init()
     ui_state = (const struct ui_state_t){ 0 };
 }
 
-void menu_init()
-{
-    // Calculate Number of Channels
-    uint8_t channel_number = 0;
-    channel_t channel;
-    while (cps_readChannel(&channel, channel_number) != -1)
-    {
-        channel_number += 1;
-    }
-    state.channel_number = channel_number;
-    // Calculate Number of Banks
-    uint8_t bank_number = 0;
-    bankHdr_t bank;
-
-    while (cps_readBankHeader(&bank, bank_number) != -1)
-    {
-        bank_number += 1;
-    }
-    // manu_selected is 0-based
-    // bank 0 means "All Channel" mode
-    // banks (1, n) are mapped to banks (0, n-1)
-    state.bank_number = bank_number + 1;
-    // Calculate Number of Contacts
-    uint8_t contact_number = 0;
-    contact_t contact;
-    while (cps_readContact(&contact, contact_number) != -1)
-    {
-        contact_number += 1;
-    }
-    state.contact_number = contact_number;
-}
-
 void ui_drawSplashScreen(bool centered)
 {
     gfx_clearScreen();


### PR DESCRIPTION
This will fix #64 

We check the number of channels, banks and contacts once on startup and then use those numbers to allow wrapping the menus.