### PR TITLE
Fix default channel index

### DIFF
--- a/openrtx/src/core/state.c
+++ b/openrtx/src/core/state.c
@@ -66,7 +66,7 @@ void state_init()
     state.charge = battery_getCharge(state.v_bat);
     state.rssi   = -127.0f;
 
-    state.channel_index = 1;    // Set default channel index (it is 1-based)
+    state.channel_index = 0;    // Set default channel index (it is 0-based)
     state.bank_enabled  = false;
     state.rtxStatus     = RTX_OFF;
     state.emergency     = false;


### PR DESCRIPTION
it should be 0 instead of 1

According to this check:
https://github.com/OpenRTX/OpenRTX/blob/master/openrtx/src/ui/ui.c#L584
the channel index should default to 0 instead of 1.

I have tested this on my radio.
With 0.3.5 the default channel would always be channel 2.
With this change the default channel is now channel 1.