### PR TITLE
Check if in M17 mode before entering edit mode

### DIFF
--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -1524,10 +1524,14 @@ void ui_updateFSM(bool *sync_rtx)
                     }
                     else if(msg.keys & KEY_HASH)
                     {
-                        // Enable dst ID input
-                        ui_state.edit_mode = true;
-                        // Reset text input variables
-                        _ui_textInputReset(ui_state.new_callsign);
+                        // Only enter edit mode when using M17
+                        if(state.channel.mode == OPMODE_M17)
+                        {
+                            // Enable dst ID input
+                            ui_state.edit_mode = true;
+                            // Reset text input variables
+                            _ui_textInputReset(ui_state.new_callsign);
+                        }
                     }
                     else if(msg.keys & KEY_F1)
                     {

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -1346,12 +1346,16 @@ void ui_updateFSM(bool *sync_rtx)
                     }
                     else if(msg.keys & KEY_HASH)
                     {
-                        // Enable dst ID input
-                        ui_state.edit_mode = true;
-                        // Reset text input variables
-                        _ui_textInputReset(ui_state.new_callsign);
-                        vp_announceM17Info(NULL,  ui_state.edit_mode, 
-                                           queueFlags);
+                        // Only enter edit mode when using M17
+                        if(state.channel.mode == OPMODE_M17)
+                        {
+                            // Enable dst ID input
+                            ui_state.edit_mode = true;
+                            // Reset text input variables
+                            _ui_textInputReset(ui_state.new_callsign);
+                            vp_announceM17Info(NULL,  ui_state.edit_mode,
+                                               queueFlags);
+                        }
                     }
                     else if(msg.keys & KEY_UP || msg.keys & KNOB_RIGHT)
                     {


### PR DESCRIPTION
# Observed behavior

- When in FM mode and clicking the HASH key the keypad would no longer respond
- The only way to leave edit mode would then be to use the macro key to switch to m17 to exit edit mode and then switch back to FM

# Expected Behavior

- When in FM mode and clicking the HASH key nothing happens and the keypad still responds

# Fix

To prevent this behavior we check if we are in M17 mode before entering edit mode