### PR TITLE
Fix CTCSS tone not correctly set when decreasing

### DIFF
--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -872,7 +872,14 @@ static void _ui_fsm_menuMacro(kbd_msg_t msg, bool *sync_rtx)
         case 1:
             if(state.channel.mode == OPMODE_FM)
             {
-                state.channel.fm.txTone--;
+                if (0 == state.channel.fm.txTone)
+                {
+                    state.channel.fm.txTone = MAX_TONE_INDEX-1;
+                }
+                else
+                {
+                    state.channel.fm.txTone--;
+                }
                 state.channel.fm.txTone %= MAX_TONE_INDEX;
                 state.channel.fm.rxTone = state.channel.fm.txTone;
                 *sync_rtx = true;


### PR DESCRIPTION
Explicitly set CTCSS index when decreasing index below 0.

This is necessary, as the txTone is unsigned 7 Bit.
When decreasing index 0 the result is 127.
127 mod MAX_TONE_INDEX is not the last index.