### PR TITLE
Add 1750 Hz tone

### DIFF
--- a/openrtx/include/core/state.h
+++ b/openrtx/include/core/state.h
@@ -51,6 +51,7 @@ typedef struct
     bool       bank_enabled;
     uint16_t   bank;
     uint8_t    rtxStatus;
+    bool       tone_enabled;
 
     bool       emergency;
     settings_t settings;

--- a/openrtx/include/rtx/rtx.h
+++ b/openrtx/include/rtx/rtx.h
@@ -52,6 +52,8 @@ typedef struct
     uint16_t txToneEn : 1,  /**< TX CTC/DCS tone enable        */
              txTone   : 15; /**< TX CTC/DCS tone               */
 
+    bool     toneEn;
+
     uint8_t  can      : 4,  /**< M17 Channel Access Number     */
              _unused  : 4;
 

--- a/openrtx/src/core/threads.c
+++ b/openrtx/src/core/threads.c
@@ -96,6 +96,7 @@ void *ui_threadFunc(void *arg)
             rtx_cfg.rxTone      = ctcss_tone[state.channel.fm.rxTone];
             rtx_cfg.txToneEn    = state.channel.fm.txToneEn;
             rtx_cfg.txTone      = ctcss_tone[state.channel.fm.txTone];
+            rtx_cfg.toneEn      = state.tone_enabled;
 
             // Copy new M17 CAN, source and destination addresses
             rtx_cfg.can = state.settings.m17_can;

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -1372,8 +1372,11 @@ void ui_updateFSM(bool *sync_rtx)
                         }
                         else
                         {
-                            state.tone_enabled = true;
-                            *sync_rtx = true;
+                            if(!state.tone_enabled)
+                            {
+                                state.tone_enabled = true;
+                                *sync_rtx = true;
+                            }
                         }
                     }
                     else if(msg.keys & KEY_UP || msg.keys & KNOB_RIGHT)
@@ -1553,8 +1556,11 @@ void ui_updateFSM(bool *sync_rtx)
                         }
                         else
                         {
-                            state.tone_enabled = true;
-                            *sync_rtx = true;
+                            if(!state.tone_enabled)
+                            {
+                                state.tone_enabled = true;
+                                *sync_rtx = true;
+                            }
                         }
                     }
                     else if(msg.keys & KEY_F1)

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -1286,6 +1286,12 @@ void ui_updateFSM(bool *sync_rtx)
             macro_menu = false;
         }
 
+        if(state.tone_enabled && !(msg.keys & KEY_HASH))
+        {
+            state.tone_enabled = false;
+            *sync_rtx = true;
+        }
+
         int priorUIScreen = state.ui_screen;
         switch(state.ui_screen)
         {
@@ -1363,6 +1369,11 @@ void ui_updateFSM(bool *sync_rtx)
                             _ui_textInputReset(ui_state.new_callsign);
                             vp_announceM17Info(NULL,  ui_state.edit_mode,
                                                queueFlags);
+                        }
+                        else
+                        {
+                            state.tone_enabled = true;
+                            *sync_rtx = true;
                         }
                     }
                     else if(msg.keys & KEY_UP || msg.keys & KNOB_RIGHT)
@@ -1539,6 +1550,11 @@ void ui_updateFSM(bool *sync_rtx)
                             ui_state.edit_mode = true;
                             // Reset text input variables
                             _ui_textInputReset(ui_state.new_callsign);
+                        }
+                        else
+                        {
+                            state.tone_enabled = true;
+                            *sync_rtx = true;
                         }
                     }
                     else if(msg.keys & KEY_F1)

--- a/platform/drivers/baseband/AT1846S.h
+++ b/platform/drivers/baseband/AT1846S.h
@@ -142,6 +142,10 @@ public:
         maskSetRegister(0x30, 0x0060, value);
     }
 
+    /**
+     * Setup and enable tone output
+     * @param freq frequency in 1/10 Hz
+     */
     void enableTone(const tone_t freq)
     {
         i2c_writeReg16(0x35, freq); // Set tone 1 freq
@@ -149,6 +153,9 @@ public:
         maskSetRegister(0x79, 0xF000, 0xC000); // Enable tone output
     }
 
+    /**
+     * Change output back to microphone
+     */
     void disableTone()
     {
         maskSetRegister(0x3A, 0x7000, 0x4000); // Use microphone

--- a/platform/drivers/baseband/AT1846S.h
+++ b/platform/drivers/baseband/AT1846S.h
@@ -142,6 +142,18 @@ public:
         maskSetRegister(0x30, 0x0060, value);
     }
 
+    void enableTone(const tone_t freq)
+    {
+        i2c_writeReg16(0x35, freq); // Set tone 1 freq
+        maskSetRegister(0x3A, 0x7000, 0x1000); // Use tone 1
+        maskSetRegister(0x79, 0xF000, 0xC000); // Enable tone output
+    }
+
+    void disableTone()
+    {
+        maskSetRegister(0x3A, 0x7000, 0x4000); // Use microphone
+    }
+
     /**
      * Enable the CTCSS tone for transmission.
      *

--- a/platform/drivers/baseband/radio_UV3x0.cpp
+++ b/platform/drivers/baseband/radio_UV3x0.cpp
@@ -254,6 +254,16 @@ void radio_enableTx()
         at1846s.enableTxCtcss(config->txTone);
     }
 
+    if (config->toneEn)
+    {
+        tone_t freq = 17500;
+        at1846s.enableTone(freq);
+    }
+    else
+    {
+        at1846s.disableTone();
+    }
+
     radioStatus = TX;
 }
 


### PR DESCRIPTION
When pressing the Hash key and the PTT key in FM mode a 1750 Hz tone is transmitted

This is currently only implemented for the MD-UV380, once the code is reviewed and OK, I can add the relevant logic to other radios.

This will resolve #101