### PR TITLE
Align Macro menu fm and M17

### DIFF
--- a/openrtx/src/ui/default/ui_menu.c
+++ b/openrtx/src/ui/default/ui_menu.c
@@ -897,7 +897,7 @@ bool _ui_drawMacroMenu()
             gfx_print(layout.line1_pos, layout.top_font, TEXT_ALIGN_LEFT,
                       color_white, "          ");
             gfx_print(layout.line1_pos, layout.top_font, TEXT_ALIGN_CENTER,
-                      yellow_fab413, "2       ");
+                      yellow_fab413, "2");
         }
         gfx_print(layout.line1_pos, layout.top_font, TEXT_ALIGN_RIGHT,
                   yellow_fab413, "3        ");


### PR DESCRIPTION
This merge request will align the macro menu UI for FM and M17

Macro Menu before:
![Macro Menu M17 Before](https://github.com/OpenRTX/OpenRTX/assets/49691247/610bddd3-3f39-4acd-bf22-47dc75a1612c)
Macro Menu now:
![Macro Menu M17 Now](https://github.com/OpenRTX/OpenRTX/assets/49691247/6851cc86-8567-49eb-85ff-32e601faa702)
FM macro menu:
![Macro Menu FM](https://github.com/OpenRTX/OpenRTX/assets/49691247/75d05f73-25c2-4e00-9bdb-18a962ef1e62)
