### PR TITLE
Enable 1750Hz tone for GDx

### DIFF
--- a/platform/drivers/baseband/radio_GDx.cpp
+++ b/platform/drivers/baseband/radio_GDx.cpp
@@ -220,6 +220,16 @@ void radio_enableTx()
         at1846s.enableTxCtcss(config->txTone);
     }
 
+    if (config->toneEn)
+    {
+        tone_t freq = 17500;
+        at1846s.enableTone(freq);
+    }
+    else
+    {
+        at1846s.disableTone();
+    }
+
     radioStatus = TX;
 }
 


### PR DESCRIPTION
This should allow the GDx to send a 1750Hz tone.
I did not test this, as I do not own the device.