### PR TITLE
meson: Fix warning in cross arm file

### DIFF
--- a/cross_arm.txt
+++ b/cross_arm.txt
@@ -12,7 +12,7 @@ gdb     = 'arm-miosix-eabi-gdb'
 terminal= 'x-terminal-emulator'
 openocd = '/usr/local/bin/openocd'
 
-[properties]
+[built-in options]
 c_args      = [
                '-D_DEFAULT_SOURCE=1',
                '-ffunction-sections',


### PR DESCRIPTION
Meson throws the following warnings:
```
DEPRECATION: c_args in the [properties] section of the machine file is deprecated, use the [built-in options] section.
DEPRECATION: cpp_args in the [properties] section of the machine file is deprecated, use the [built-in options] section.
DEPRECATION: c_link_args in the [properties] section of the machine file is deprecated, use the [built-in options] section.
DEPRECATION: cpp_link_args in the [properties] section of the machine file is deprecated, use the [built-in options] section.
```

This comes from changes in 0.56.0 version. See https://mesonbuild.com/Release-notes-for-0-56-0.html#project-and-builtin-options-can-be-set-in-native-or-cross-files

WARNING: This may require a meson version bump to 0.56.0!