### PR TITLE
Macro latching

### DIFF
--- a/openrtx/include/core/state.h
+++ b/openrtx/include/core/state.h
@@ -43,6 +43,7 @@ typedef struct
 
     uint8_t    ui_screen;
     uint8_t    tuner_mode;
+    bool       macro_latched;
 
     uint16_t   channel_index;
     channel_t  channel;

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -1262,17 +1262,17 @@ void ui_updateFSM(bool *sync_rtx)
 
         // If MONI is pressed, activate MACRO functions
         bool moniPressed = (msg.keys & KEY_MONI) ? true : false;
-        if(moniPressed || FunctionKeyIsLatched())
+        if(moniPressed || state.macro_latched)
         {
             macro_menu = true;
             // long press moni on its own latches function.
-            if (moniPressed && msg.long_press && !input_getPressedNumber(msg))
+            if (moniPressed && msg.long_press && !state.macro_latched)
             {
-                SetFunctionLatchTimer(); // 3000 ms.
+                state.macro_latched = true;
             }
-            else
+            else if (moniPressed && state.macro_latched)
             {
-                ReleaseFunctionLatchIfNeeded();
+                state.macro_latched = false;
             }
             _ui_fsm_menuMacro(msg, sync_rtx);
             return;

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -1269,10 +1269,12 @@ void ui_updateFSM(bool *sync_rtx)
             if (moniPressed && msg.long_press && !state.macro_latched)
             {
                 state.macro_latched = true;
+                vp_beep(BEEP_FUNCTION_LATCH_ON, LONG_BEEP);
             }
             else if (moniPressed && state.macro_latched)
             {
                 state.macro_latched = false;
+                vp_beep(BEEP_FUNCTION_LATCH_OFF, LONG_BEEP);
             }
             _ui_fsm_menuMacro(msg, sync_rtx);
             return;

--- a/openrtx/src/ui/default/ui_menu.c
+++ b/openrtx/src/ui/default/ui_menu.c
@@ -875,6 +875,11 @@ bool _ui_drawMacroMenu()
         // Header
         gfx_print(layout.top_pos, layout.top_font, TEXT_ALIGN_CENTER,
                   color_white, currentLanguage->macroMenu);
+        if (state.macro_latched)
+        {
+            gfx_print(layout.top_pos, layout.top_font, TEXT_ALIGN_LEFT,
+                  color_white, "L");
+        }
         // First row
         if (last_state.channel.mode == OPMODE_FM)
         {


### PR DESCRIPTION
This merge request will change the behavior of the macro latching

Now when the macro button is held it will latch the macro menu.
The letter L will be displayed in the upper left corner to show the latched status.
When the macro menu is latched, the macro button will unlatch the menu.

It would be good if some one who is vision impaired can check, if the menu is still usable with this change.

Fix #142 