### PR TITLE
Extend the M17 data structures

### DIFF
--- a/openrtx/include/protocols/M17/M17Datatypes.hpp
+++ b/openrtx/include/protocols/M17/M17Datatypes.hpp
@@ -126,7 +126,7 @@ typedef union
         m17_lsf_encryption_type encType : 2;  //< Encryption type
         uint8_t encryption_subtype      : 2;  //< Encryption subtype
         uint16_t CAN : 4;  //< Channel Access Number
-        uint16_t     : 4;  //< Reserved, padding to 16 bit
+        uint16_t     : 5;  //< Reserved, padding to 16 bit
     } fields;
 
     uint16_t value;

--- a/openrtx/include/protocols/M17/M17Datatypes.hpp
+++ b/openrtx/include/protocols/M17/M17Datatypes.hpp
@@ -122,11 +122,11 @@ typedef union
     struct __attribute__((packed))
     {
         m17_lsf_packet_stream_indicator stream : 1;  //< Packet/stream indicator: 0 = packet, 1 = stream
-        m17_lsf_data_type dataType      : 2;  //< Data type indicator
-        m17_lsf_encryption_type encType : 2;  //< Encryption type
-        uint8_t encryption_subtype      : 2;  //< Encryption subtype
-        uint16_t CAN : 4;  //< Channel Access Number
-        uint16_t     : 5;  //< Reserved, padding to 16 bit
+        m17_lsf_data_type dataType             : 2;  //< Data type indicator
+        m17_lsf_encryption_type encType        : 2;  //< Encryption type
+        uint8_t encryption_subtype             : 2;  //< Encryption subtype
+        uint16_t CAN                           : 4;  //< Channel Access Number
+        uint16_t                               : 5;  //< Reserved, padding to 16 bit
     } fields;
 
     uint16_t value;

--- a/openrtx/include/protocols/M17/M17LinkSetupFrame.hpp
+++ b/openrtx/include/protocols/M17/M17LinkSetupFrame.hpp
@@ -107,7 +107,7 @@ public:
      * @return a reference to frame's metadata field, allowing for both read and
      * write access.
      */
-    meta_t& metadata();
+    meta_t metadata();
 
     /**
      * Compute a new CRC over the frame content and update the corresponding

--- a/openrtx/src/protocols/M17/M17Callsign.cpp
+++ b/openrtx/src/protocols/M17/M17Callsign.cpp
@@ -80,7 +80,7 @@ std::string M17::decode_callsign(const call_t& encodedCall)
         }
     }
 
-    if(isBroadcast) return "BROADCAST";
+    if(isBroadcast) return "ALL";
 
     /*
      * Address is not broadcast, decode it.

--- a/openrtx/src/protocols/M17/M17Callsign.cpp
+++ b/openrtx/src/protocols/M17/M17Callsign.cpp
@@ -86,7 +86,7 @@ std::string M17::decode_callsign(const call_t& encodedCall)
      * Address is not broadcast, decode it.
      * TODO: current implementation works only on little endian architectures.
      */
-    static const char charMap[] = "xABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-/.";
+    static const char charMap[] = " ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-/.";
 
     uint64_t encoded = 0;
     auto p = reinterpret_cast<uint8_t*>(&encoded);

--- a/openrtx/src/protocols/M17/M17LinkSetupFrame.cpp
+++ b/openrtx/src/protocols/M17/M17LinkSetupFrame.cpp
@@ -76,7 +76,7 @@ void M17LinkSetupFrame::setType(streamType_t type)
     data.type  = type;
 }
 
-meta_t& M17LinkSetupFrame::metadata()
+meta_t M17LinkSetupFrame::metadata()
 {
     return data.meta;
 }

--- a/openrtx/src/rtx/OpMode_M17.cpp
+++ b/openrtx/src/rtx/OpMode_M17.cpp
@@ -224,9 +224,9 @@ void OpMode_M17::txState(rtxStatus_t *const status)
         if(!dst.empty()) lsf.setDestination(dst);
 
         streamType_t type;
-        type.fields.stream   = M17_LSF_STREAM_MODE;             // Stream
-        type.fields.dataType = M17_LSF_DATATYPE_VOICE;             // Voice data
-        type.fields.CAN      = status->can;   // Channel access number
+        type.fields.stream   = M17_LSF_STREAM_MODE;     // Stream
+        type.fields.dataType = M17_LSF_DATATYPE_VOICE;  // Voice data
+        type.fields.CAN      = status->can;             // Channel access number
 
         lsf.setType(type);
         lsf.updateCrc();

--- a/openrtx/src/rtx/OpMode_M17.cpp
+++ b/openrtx/src/rtx/OpMode_M17.cpp
@@ -224,8 +224,8 @@ void OpMode_M17::txState(rtxStatus_t *const status)
         if(!dst.empty()) lsf.setDestination(dst);
 
         streamType_t type;
-        type.fields.stream   = 1;             // Stream
-        type.fields.dataType = 2;             // Voice data
+        type.fields.stream   = M17_LSF_STREAM_MODE;             // Stream
+        type.fields.dataType = M17_LSF_DATATYPE_VOICE;             // Voice data
         type.fields.CAN      = status->can;   // Channel access number
 
         lsf.setType(type);


### PR DESCRIPTION
This will extend the data structures for M17 to include the data types for the encryption sub types and the data structures that can be represented inside the meta field for the null encryption.

This does not change any functionality.

Additional this changes the `decodeCallsign` function to use space instead of `x` and return `ALL` instead of `BROADCAST`