### PR TITLE
WIP: Input lockout

### DIFF
--- a/openrtx/include/ui/ui_default.h
+++ b/openrtx/include/ui/ui_default.h
@@ -196,6 +196,7 @@ typedef struct ui_state_t
     uint8_t menu_selected;
     // If true we can change a menu entry value with UP/DOWN
     bool edit_mode;
+    bool input_lockedout;
     // Variables used for VFO input
     uint8_t input_number;
     uint8_t input_position;

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -81,7 +81,7 @@
 
 /* UI main screen functions, their implementation is in "ui_main.c" */
 extern void _ui_drawMainBackground();
-extern void _ui_drawMainTop();
+extern void _ui_drawMainTop(ui_state_t* ui_state);
 extern void _ui_drawVFOMiddle();
 extern void _ui_drawMEMMiddle();
 extern void _ui_drawVFOBottom();
@@ -113,7 +113,7 @@ extern void _ui_drawSettingsDisplay(ui_state_t* ui_state);
 extern void _ui_drawSettingsM17(ui_state_t* ui_state);
 extern void _ui_drawSettingsVoicePrompts(ui_state_t* ui_state);
 extern void _ui_drawSettingsReset2Defaults(ui_state_t* ui_state);
-extern bool _ui_drawMacroMenu();
+extern bool _ui_drawMacroMenu(ui_state_t* ui_state);
 extern void _ui_reset_menu_anouncement_tracking();
 
 const char *menu_items[] =
@@ -2267,7 +2267,7 @@ bool ui_updateGUI()
     if(macro_menu)
     {
         _ui_drawDarkOverlay();
-        _ui_drawMacroMenu(&last_state);
+        _ui_drawMacroMenu(&ui_state);
     }
 
     redraw_needed = false;

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -966,6 +966,12 @@ static void _ui_fsm_menuMacro(kbd_msg_t msg, bool *sync_rtx)
                                    state.settings.brightness);
             break;
 #endif
+        case 9:
+            if( ui_state.input_lockedout == false )
+                ui_state.input_lockedout = true;
+            else 
+                ui_state.input_lockedout = false;
+            break;
     }
 
 #ifdef HAS_ABSOLUTE_KNOB // If the radio has an absolute position knob
@@ -1294,6 +1300,9 @@ void ui_updateFSM(bool *sync_rtx)
             // VFO screen
             case MAIN_VFO:
                 // M17 Destination callsign input
+                if( ui_state.input_lockedout == true ){
+                    break;
+                }
                 if(ui_state.edit_mode)
                 {
                     if(state.channel.mode == OPMODE_M17)
@@ -1463,6 +1472,9 @@ void ui_updateFSM(bool *sync_rtx)
                 break;
             // MEM screen
             case MAIN_MEM:
+                if( ui_state.input_lockedout == true ){
+                    break;
+                }
                 // M17 Destination callsign input
                 if(ui_state.edit_mode)
                 {

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -1300,9 +1300,8 @@ void ui_updateFSM(bool *sync_rtx)
             // VFO screen
             case MAIN_VFO:
                 // M17 Destination callsign input
-                if( ui_state.input_lockedout == true ){
+                if( ui_state.input_lockedout == true )
                     break;
-                }
                 if(ui_state.edit_mode)
                 {
                     if(state.channel.mode == OPMODE_M17)
@@ -1472,9 +1471,8 @@ void ui_updateFSM(bool *sync_rtx)
                 break;
             // MEM screen
             case MAIN_MEM:
-                if( ui_state.input_lockedout == true ){
+                if( ui_state.input_lockedout == true )
                     break;
-                }
                 // M17 Destination callsign input
                 if(ui_state.edit_mode)
                 {

--- a/openrtx/src/ui/default/ui_main.c
+++ b/openrtx/src/ui/default/ui_main.c
@@ -215,8 +215,10 @@ void convertToCompressedFrequency( unsigned long tx, unsigned long rx, char * st
   if( offset != 0 ){
     if( offset > 0 )
       offset_s[0] = '+';
-    else
+    else{
+      offset *= -1;
       offset_s[0] = '-';
+    }
     if( offset != stdoffset ){
       snprintFrequency(offset, offset_s+1, 18);
     }
@@ -230,17 +232,12 @@ void _ui_drawFrequency()
   band_t txband = freq2band(tx);
   band_t rxband = freq2band(rx);
 
-    // Print big numbers frequency
-    gfx_print(layout.line3_large_pos, layout.line3_large_font, TEXT_ALIGN_CENTER,
-              color_white, "%03lu.%05lu",
-              (unsigned long)frequency/1000000,
-              (unsigned long)frequency%1000000/10);
   if( !platform_getPttStatus() && txband != BAND_UNK && rxband != BAND_UNK && txband == rxband ){
     char freq[20] = {0};
     convertToCompressedFrequency( tx, rx, freq, 19 );
     if( strnlen(freq,19) <= 10 ){ 
       //make sure it will fit sanely on screen -- hardcoded to 10 chars TODO
-      gfx_print(layout.line3_pos, layout.line3_font, TEXT_ALIGN_CENTER,
+      gfx_print(layout.line3_large_pos, layout.line3_large_font, TEXT_ALIGN_CENTER,
           color_white, freq);
       return;
     }

--- a/openrtx/src/ui/default/ui_main.c
+++ b/openrtx/src/ui/default/ui_main.c
@@ -34,7 +34,7 @@ void _ui_drawMainBackground()
     gfx_drawHLine(SCREEN_HEIGHT - layout.bottom_h - 1, layout.hline_h, color_grey);
 }
 
-void _ui_drawMainTop()
+void _ui_drawMainTop(ui_state_t * ui_state)
 {
 #ifdef RTC_PRESENT
     // Print clock on top bar
@@ -56,22 +56,9 @@ void _ui_drawMainTop()
                        layout.status_v_pad};
     gfx_drawBattery(bat_pos, bat_width, bat_height, last_state.charge);
 #endif
-    // Print radio mode on top bar
-    switch(last_state.channel.mode)
-    {
-        case OPMODE_FM:
-        gfx_print(layout.top_pos, layout.top_font, TEXT_ALIGN_LEFT,
-                  color_white, currentLanguage->fm);
-        break;
-        case OPMODE_DMR:
-        gfx_print(layout.top_pos, layout.top_font, TEXT_ALIGN_LEFT,
-                  color_white, currentLanguage->dmr);
-        break;
-        case OPMODE_M17:
-        gfx_print(layout.top_pos, layout.top_font, TEXT_ALIGN_LEFT,
-                  color_white, currentLanguage->m17);
-        break;
-    }
+    if( ui_state->input_lockedout == true )
+      gfx_drawSymbol(layout.top_pos, layout.top_symbol_size, TEXT_ALIGN_LEFT,
+                         color_white, SYMBOL_LOCK);
 }
 
 void _ui_drawBankChannel()
@@ -95,33 +82,41 @@ void _ui_drawModeInfo(ui_state_t* ui_state)
         case OPMODE_FM:
         // Get Bandwidth string
         if(last_state.channel.bandwidth == BW_12_5)
-            snprintf(bw_str, 8, "12.5");
+            snprintf(bw_str, 8, "NFM");
         else if(last_state.channel.bandwidth == BW_20)
-            snprintf(bw_str, 8, "20");
+            snprintf(bw_str, 8, "FM20");
         else if(last_state.channel.bandwidth == BW_25)
-            snprintf(bw_str, 8, "25");
+            snprintf(bw_str, 8, "FM");
         // Get encdec string
         bool tone_tx_enable = last_state.channel.fm.txToneEn;
         bool tone_rx_enable = last_state.channel.fm.rxToneEn;
         if (tone_tx_enable && tone_rx_enable)
-            snprintf(encdec_str, 9, "E+D");
+            snprintf(encdec_str, 9, "ED");
         else if (tone_tx_enable && !tone_rx_enable)
-            snprintf(encdec_str, 9, "E");
+            snprintf(encdec_str, 9, " E");
         else if (!tone_tx_enable && tone_rx_enable)
-            snprintf(encdec_str, 9, "D");
+            snprintf(encdec_str, 9, " D");
         else
-            snprintf(encdec_str, 9, " ");
+            snprintf(encdec_str, 9, "  ");
 
-        // Print Bandwidth, Tone and encdec info
-        gfx_print(layout.line2_pos, layout.line2_font, TEXT_ALIGN_CENTER,
-              color_white, "B:%s T:%4.1f S:%s",
-              bw_str, ctcss_tone[last_state.channel.fm.txTone]/10.0f,
-              encdec_str);
+        if (tone_tx_enable || tone_rx_enable)
+          // Print Bandwidth, Tone and encdec info
+          gfx_print(layout.line2_pos, layout.line2_font, TEXT_ALIGN_CENTER,
+                color_white, "%s %4.1f %s",
+                bw_str, 
+                ctcss_tone[last_state.channel.fm.txTone]/10.0f,
+                encdec_str
+                );
+        else
+          gfx_print(layout.line2_pos, layout.line2_font, TEXT_ALIGN_CENTER,
+                color_white, "%s",
+                bw_str
+                );
         break;
         case OPMODE_DMR:
         // Print talkgroup
         gfx_print(layout.line2_pos, layout.line2_font, TEXT_ALIGN_CENTER,
-              color_white, "TG:%s",
+              color_white, "DMR TG%s",
               "");
         break;
         case OPMODE_M17:
@@ -134,22 +129,131 @@ void _ui_drawModeInfo(ui_state_t* ui_state)
                 dst = (!strnlen(cfg.destination_address, 10)) ?
                     currentLanguage->broadcast : cfg.destination_address;
             gfx_print(layout.line2_pos, layout.line2_font, TEXT_ALIGN_CENTER,
-                  color_white, "#%s", dst);
+                  color_white, "M17 #%s", dst);
             break;
         }
     }
 }
 
+typedef enum band {
+  BAND_UNK  = 0,
+  BAND_2M   = 1,
+  BAND_70CM = 2,
+  BAND_1M25 = 3,
+  BAND_33CM = 4,
+  BAND_23CM = 5,
+  BAND_6M   = 6,
+  BAND_10M   = 7,
+} band_t;
+unsigned long std_offset_by_band[] = { //order is of the enums for band_t
+        0, //UNKnown band
+   600000, //2M
+  5000000, //70cm
+  1600000, //1.25M
+ 25000000, //33cm 25MHz offset
+ 12000000, //23cm 12MHz
+  1000000, //6m  1MHz
+   100000, //10m  .1MHz
+};
+band_t freq2band( unsigned long freq ){
+  if( freq >= 136000000 && freq <= 174000000 )
+    return BAND_2M;
+  if( freq >= 400000000 && freq <= 520000000 )
+    return BAND_70CM;
+  if( freq >= 219000000 && freq <= 225000000 )
+    return BAND_1M25;
+  if( freq >= 902000000 && freq <= 928000000 )
+    return BAND_33CM;
+  if( freq >= 1240000000 && freq <= 1300000000 )
+    return BAND_23CM;
+  if( freq >= 50000000 && freq <= 54000000 )
+    return BAND_6M;
+  if( freq >= 28000000 && freq <= 29700000 )
+    return BAND_10M;
+  else
+    return BAND_UNK;
+}
+
+int cleanLeadingZeros( char * s, int len ){
+  int i = 0;
+  int n = 0;
+  for( ; n < len && s[n] == '0' && s[n+1] != 0; n++ ){
+    ;
+  }
+  for( i = 0; i < len-n; i++ ){
+    s[i] = s[i+n];
+  }
+  return n;
+}
+int cleanTrailingZerosAndPeriods( char * s, int len ){
+  int i = len-1;
+  for( ; i >= 0 && (s[i] == '0' || s[i] == '.' || s[i] == 0); i-- ){
+    //if( s[i] == '0' )
+    s[i] = 0;
+  }
+  return i+1; //exits from for loop with first character we want to keep
+              //but we want to return index of first overwritable spot
+}
+void snprintFrequency( long f, char * store, size_t maxspace ){
+  if( f < 0 ){
+    f *= -1;
+  }
+  long mhz = (long)f/1000000;
+  long frac = (long)f%1000000/10;
+  snprintf(store, maxspace, "%ld.%ld", mhz, frac);
+  cleanTrailingZerosAndPeriods(store,maxspace);
+  cleanLeadingZeros(store,maxspace);
+}
+void convertToCompressedFrequency( unsigned long tx, unsigned long rx, char * store, size_t maxspace){
+  /*band_t txband = freq2band(tx);*/
+  band_t rxband = freq2band(rx);
+  long stdoffset = std_offset_by_band[rxband];
+  long offset = tx - rx; //note signed!
+  char offset_s[20] = {0};
+  snprintFrequency(rx, store, maxspace);
+  int nextSpot = strnlen(store, maxspace);
+  if( offset != 0 ){
+    if( offset > 0 )
+      offset_s[0] = '+';
+    else
+      offset_s[0] = '-';
+    if( offset != stdoffset ){
+      snprintFrequency(offset, offset_s+1, 18);
+    }
+    snprintf( store+nextSpot, maxspace-nextSpot, "%s", offset_s);
+  }
+}
 void _ui_drawFrequency()
 {
-  unsigned long frequency = platform_getPttStatus() ?
-       frequency = last_state.channel.tx_frequency : last_state.channel.rx_frequency;
+  unsigned long tx = last_state.channel.tx_frequency;
+  unsigned long rx = last_state.channel.rx_frequency;
+  band_t txband = freq2band(tx);
+  band_t rxband = freq2band(rx);
 
     // Print big numbers frequency
     gfx_print(layout.line3_large_pos, layout.line3_large_font, TEXT_ALIGN_CENTER,
               color_white, "%03lu.%05lu",
               (unsigned long)frequency/1000000,
               (unsigned long)frequency%1000000/10);
+  if( !platform_getPttStatus() && txband != BAND_UNK && rxband != BAND_UNK && txband == rxband ){
+    char freq[20] = {0};
+    convertToCompressedFrequency( tx, rx, freq, 19 );
+    if( strnlen(freq,19) <= 10 ){ 
+      //make sure it will fit sanely on screen -- hardcoded to 10 chars TODO
+      gfx_print(layout.line3_pos, layout.line3_font, TEXT_ALIGN_CENTER,
+          color_white, freq);
+      return;
+    }
+    //else fall through and print normally
+
+  }
+  unsigned long frequency = platform_getPttStatus() ?
+    frequency = last_state.channel.tx_frequency : last_state.channel.rx_frequency;
+  // Print big numbers frequency
+  gfx_print(layout.line3_large_pos, layout.line3_large_font, TEXT_ALIGN_CENTER,
+      color_white, "%03lu.%05lu",
+      (unsigned long)frequency/1000000,
+      (unsigned long)frequency%1000000/10);
 }
 
 void _ui_drawVFOMiddleInput(ui_state_t* ui_state)
@@ -247,7 +351,7 @@ void _ui_drawMainBottom()
 void _ui_drawMainVFO(ui_state_t* ui_state)
 {
     gfx_clearScreen();
-    _ui_drawMainTop();
+    _ui_drawMainTop(ui_state);
     _ui_drawModeInfo(ui_state);
     _ui_drawFrequency();
     _ui_drawMainBottom();
@@ -256,7 +360,7 @@ void _ui_drawMainVFO(ui_state_t* ui_state)
 void _ui_drawMainVFOInput(ui_state_t* ui_state)
 {
     gfx_clearScreen();
-    _ui_drawMainTop();
+    _ui_drawMainTop(ui_state);
     _ui_drawVFOMiddleInput(ui_state);
     _ui_drawMainBottom();
 }
@@ -264,7 +368,7 @@ void _ui_drawMainVFOInput(ui_state_t* ui_state)
 void _ui_drawMainMEM(ui_state_t* ui_state)
 {
     gfx_clearScreen();
-    _ui_drawMainTop();
+    _ui_drawMainTop(ui_state);
     _ui_drawBankChannel();
     _ui_drawModeInfo(ui_state);
     _ui_drawFrequency();

--- a/openrtx/src/ui/default/ui_menu.c
+++ b/openrtx/src/ui/default/ui_menu.c
@@ -896,7 +896,7 @@ void _ui_drawMacroTop()
     }
 }
 
-bool _ui_drawMacroMenu()
+bool _ui_drawMacroMenu(ui_state_t* ui_state)
 {
         // Header
         _ui_drawMacroTop();
@@ -1017,8 +1017,12 @@ bool _ui_drawMacroMenu()
 #endif
         gfx_print(layout.line3_large_pos, layout.top_font, TEXT_ALIGN_RIGHT,
                   yellow_fab413, "9        ");
-        gfx_print(layout.line3_large_pos, layout.top_font, TEXT_ALIGN_RIGHT,
-                  color_white, "Lck");
+        if( ui_state->input_lockedout == true )
+           gfx_print(layout.line3_large_pos, layout.top_font, TEXT_ALIGN_RIGHT,
+                 color_white, "Unlk");
+        else
+           gfx_print(layout.line3_large_pos, layout.top_font, TEXT_ALIGN_RIGHT,
+                 color_white, "Lck");
 
         // Draw S-meter bar
         _ui_drawMainBottom();


### PR DESCRIPTION
Users sometimes need a way to prevent accidental channel changes. On many radios there is usually some mechanism to lock the keypad, often by holding a button or combination of buttons to lock and unlock. On some radios - like TYT OEM - this is done in such a way that the channel knob still changes the channel, utterly defeating the purpose.

This locks out all input except PTT and the macro menu, allowing for unlock the same way as lock. Volume is independent and therefore not effected, though I wouldn't mind having an option to lock that too at some point.

Draft because it still needs UI indications. I know there was a lot of discussion around that so I didn't want to jump ahead (and for my immediate usage, I don't need it :grin:  )

I was also considering the usage of the '*' key instead, as on TYT radios that has the lock icon, but I imagine that will change too often across platforms to be worth chasing.