### PR TITLE
Add UI and check for CAN on RX

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -94,7 +94,8 @@ openrtx_ui_default = ['openrtx/src/ui/default/ui.c',
 
 openrtx_ui_module17 = ['openrtx/src/ui/module17/ui.c',
                        'openrtx/src/ui/module17/ui_main.c',
-                       'openrtx/src/ui/module17/ui_menu.c']
+                       'openrtx/src/ui/module17/ui_menu.c',
+                       'openrtx/src/ui/default/ui_strings.c']
 
 ##
 ## Selection of main entrypoint

--- a/openrtx/include/core/settings.h
+++ b/openrtx/include/core/settings.h
@@ -56,6 +56,7 @@ typedef struct
     char    callsign[10];         // Plaintext callsign
     uint8_t display_timer   : 4,  // Standby timer
             m17_can         : 4;  // M17 CAN
+    bool    m17_can_rx;           // Check M17 CAN on RX
     uint8_t vpLevel         : 3,  // Voice prompt level
             vpPhoneticSpell : 1,  // Phonetic spell enabled
             _reserved       : 4;

--- a/openrtx/include/rtx/rtx.h
+++ b/openrtx/include/rtx/rtx.h
@@ -54,6 +54,7 @@ typedef struct
 
     uint8_t  can      : 4,  /**< M17 Channel Access Number     */
              _unused  : 4;
+    bool     canRxEn;       /**< M17 Check CAN on RX           */
 
     char     source_address[10];      /**< M17 call source address  */
     char     destination_address[10]; /**< M17 call routing address */

--- a/openrtx/include/ui/ui_default.h
+++ b/openrtx/include/ui/ui_default.h
@@ -136,7 +136,8 @@ enum settingsVoicePromptItems
 enum settingsM17Items
 {
     M17_CALLSIGN = 0,
-    M17_CAN
+    M17_CAN,
+    M17_CAN_RX
 };
 
 /**

--- a/openrtx/include/ui/ui_mod17.h
+++ b/openrtx/include/ui/ui_mod17.h
@@ -128,8 +128,9 @@ enum settingsGPSItems
 
 enum m17Items
 {
-    M_CALLSIGN = 0
-    ,M_CAN
+    M_CALLSIGN = 0,
+    M_CAN,
+    M_CAN_RX
 };
 
 enum module17Items

--- a/openrtx/src/core/threads.c
+++ b/openrtx/src/core/threads.c
@@ -97,8 +97,9 @@ void *ui_threadFunc(void *arg)
             rtx_cfg.txToneEn    = state.channel.fm.txToneEn;
             rtx_cfg.txTone      = ctcss_tone[state.channel.fm.txTone];
 
-            // Copy new M17 CAN, source and destination addresses
+            // Copy new M17 CAN, M17 CAN RX check,source and destination addresses
             rtx_cfg.can = state.settings.m17_can;
+            rtx_cfg.canRxEn = state.settings.m17_can_rx;
             strncpy(rtx_cfg.source_address,      state.settings.callsign, 10);
             strncpy(rtx_cfg.destination_address, state.m17_dest, 10);
 

--- a/openrtx/src/rtx/OpMode_M17.cpp
+++ b/openrtx/src/rtx/OpMode_M17.cpp
@@ -200,9 +200,11 @@ void OpMode_M17::rxState(rtxStatus_t *const status)
         {
             auto& frame  = demodulator.getFrame();
             auto  type   = decoder.decodeFrame(frame);
-            bool  lsfOk  = decoder.getLsf().valid();
+            M17LinkSetupFrame lsf = decoder.getLsf();
+            bool  lsfOk  = lsf.valid();
 
-            if((type == M17FrameType::STREAM) && (lsfOk == true) && (pthSts == PATH_OPEN))
+            if((type == M17FrameType::STREAM) && (lsfOk == true) && (pthSts == PATH_OPEN)
+                && (!status->canRxEn || (lsf.getType().fields.CAN == status->can)))
             {
                 M17StreamFrame sf = decoder.getStreamFrame();
                 codec_pushFrame(sf.payload().data(),     false);

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -166,7 +166,8 @@ const char *settings_gps_items[] =
 const char * settings_m17_items[] =
 {
     "Callsign",
-    "CAN"
+    "CAN",
+    "CAN RX Check"
 };
 
 const char * settings_voice_items[] =
@@ -1952,51 +1953,65 @@ void ui_updateFSM(bool *sync_rtx)
             case SETTINGS_M17:
                 if(ui_state.edit_mode)
                 {
-                    if(ui_state.menu_selected == M17_CALLSIGN)
+                    switch (ui_state.menu_selected)
                     {
-                        // Handle text input for M17 callsign
-                        if(msg.keys & KEY_ENTER)
-                        {
-                            _ui_textInputConfirm(ui_state.new_callsign);
-                            // Save selected callsign and disable input mode
-                            strncpy(state.settings.callsign, ui_state.new_callsign, 10);
-                            ui_state.edit_mode = false;
-                            vp_announceBuffer(&currentLanguage->callsign,
-                                             false, true, state.settings.callsign);
-                        }
-                        else if(msg.keys & KEY_ESC)
-                        {
-                            // Discard selected callsign and disable input mode
-                            ui_state.edit_mode = false;
-                            vp_announceBuffer(&currentLanguage->callsign,
-                                            false, true, state.settings.callsign);
-                        }
-                        else if(msg.keys & KEY_UP || msg.keys & KEY_DOWN ||
-                                msg.keys & KEY_LEFT || msg.keys & KEY_RIGHT)
-                        {
-                            _ui_textInputDel(ui_state.new_callsign);
-                        }
-                        else if(input_isNumberPressed(msg))
-                        {
-                            _ui_textInputKeypad(ui_state.new_callsign, 9, msg, true);
-                        }
-                        else if (msg.long_press && (msg.keys & KEY_F1) && (state.settings.vpLevel > vpBeep))
-                        {
-                            vp_announceBuffer(&currentLanguage->callsign,
-                                            true, true, ui_state.new_callsign);
-                            f1Handled=true;
-                        }
-                    }
-                    else
-                    {
-                        if(msg.keys & KEY_DOWN || msg.keys & KNOB_LEFT)
-                            _ui_changeM17Can(-1);
-                        else if(msg.keys & KEY_UP || msg.keys & KNOB_RIGHT)
-                            _ui_changeM17Can(+1);
-                        else if(msg.keys & KEY_ENTER)
-                            ui_state.edit_mode = !ui_state.edit_mode;
-                        else if(msg.keys & KEY_ESC)
-                            ui_state.edit_mode = false;
+                        case M17_CALLSIGN:
+                            // Handle text input for M17 callsign
+                            if(msg.keys & KEY_ENTER)
+                            {
+                                _ui_textInputConfirm(ui_state.new_callsign);
+                                // Save selected callsign and disable input mode
+                                strncpy(state.settings.callsign, ui_state.new_callsign, 10);
+                                ui_state.edit_mode = false;
+                                vp_announceBuffer(&currentLanguage->callsign,
+                                                  false, true, state.settings.callsign);
+                            }
+                            else if(msg.keys & KEY_ESC)
+                            {
+                                // Discard selected callsign and disable input mode
+                                ui_state.edit_mode = false;
+                                vp_announceBuffer(&currentLanguage->callsign,
+                                                  false, true, state.settings.callsign);
+                            }
+                            else if(msg.keys & KEY_UP || msg.keys & KEY_DOWN ||
+                                     msg.keys & KEY_LEFT || msg.keys & KEY_RIGHT)
+                            {
+                                _ui_textInputDel(ui_state.new_callsign);
+                            }
+                            else if(input_isNumberPressed(msg))
+                            {
+                                _ui_textInputKeypad(ui_state.new_callsign, 9, msg, true);
+                            }
+                            else if (msg.long_press && (msg.keys & KEY_F1) && (state.settings.vpLevel > vpBeep))
+                            {
+                                vp_announceBuffer(&currentLanguage->callsign,
+                                                  true, true, ui_state.new_callsign);
+                                f1Handled=true;
+                            }
+                            break;
+                        case M17_CAN:
+                            if(msg.keys & KEY_DOWN || msg.keys & KNOB_LEFT)
+                                _ui_changeM17Can(-1);
+                            else if(msg.keys & KEY_UP || msg.keys & KNOB_RIGHT)
+                                _ui_changeM17Can(+1);
+                            else if(msg.keys & KEY_ENTER)
+                                ui_state.edit_mode = !ui_state.edit_mode;
+                            else if(msg.keys & KEY_ESC)
+                                ui_state.edit_mode = false;
+                            break;
+                        case M17_CAN_RX:
+                            if(msg.keys & KEY_LEFT || msg.keys & KEY_RIGHT ||
+                                (ui_state.edit_mode &&
+                                 (msg.keys & KEY_DOWN || msg.keys & KNOB_LEFT ||
+                                  msg.keys & KEY_UP || msg.keys & KNOB_RIGHT)))
+                            {
+                                state.settings.m17_can_rx =
+                                    !state.settings.m17_can_rx;
+                            }
+                            else if(msg.keys & KEY_ENTER)
+                                ui_state.edit_mode = !ui_state.edit_mode;
+                            else if(msg.keys & KEY_ESC)
+                                ui_state.edit_mode = false;
                     }
                 }
                 else

--- a/openrtx/src/ui/default/ui_menu.c
+++ b/openrtx/src/ui/default/ui_menu.c
@@ -353,6 +353,11 @@ int _ui_getM17ValueName(char *buf, uint8_t max_len, uint8_t index)
         case M17_CAN:
             snprintf(buf, max_len, "%d", last_state.settings.m17_can);
             break;
+        case M17_CAN_RX:
+            snprintf(buf, max_len, "%s", (last_state.settings.m17_can_rx) ?
+                                                           currentLanguage->on :
+                                                           currentLanguage->off);
+            break;
     }
 
     return 0;

--- a/openrtx/src/ui/module17/ui.c
+++ b/openrtx/src/ui/module17/ui.c
@@ -97,7 +97,8 @@ const char *display_items[] =
 const char *m17_items[] =
 {
     "Callsign",
-    "CAN"
+    "CAN",
+    "CAN RX Check"
 };
 
 const char *module17_items[] =
@@ -957,6 +958,9 @@ void ui_updateFSM(bool *sync_rtx)
                             case M_CAN:
                                 _ui_changeCAN(-1);
                                 break;
+                            case M_CAN_RX:
+                                state.settings.m17_can_rx = !state.settings.m17_can_rx;
+                                break;
                             default:
                                 state.ui_screen = SETTINGS_M17;
                         }
@@ -967,6 +971,9 @@ void ui_updateFSM(bool *sync_rtx)
                         {
                             case M_CAN:
                                 _ui_changeCAN(+1);
+                                break;
+                            case M_CAN_RX:
+                                state.settings.m17_can_rx = !state.settings.m17_can_rx;
                                 break;
                             default:
                                 state.ui_screen = SETTINGS_M17;

--- a/openrtx/src/ui/module17/ui_menu.c
+++ b/openrtx/src/ui/module17/ui_menu.c
@@ -27,6 +27,7 @@
 #include <interfaces/cps_io.h>
 #include <interfaces/platform.h>
 #include <interfaces/delays.h>
+#include <ui/ui_strings.h>
 #include <memory_profiling.h>
 
 /* UI main screen helper functions, their implementation is in "ui_main.c" */
@@ -209,6 +210,11 @@ int _ui_getM17ValueName(char *buf, uint8_t max_len, uint8_t index)
             return 0;
         case M_CAN:
             snprintf(buf, max_len, "%d", last_state.settings.m17_can);
+            break;
+        case M_CAN_RX:
+            snprintf(buf, max_len, "%s", (last_state.settings.m17_can_rx) ?
+                                                          currentLanguage->on :
+                                                          currentLanguage->off);
             break;
     }
 


### PR DESCRIPTION
This adds the UI and logic to check the CAN on M17 RX.
It can be enabled and disabled in the settings menu.
When enabled, sound will only be played when the CAN matches the one set.
The LED will still light up.
The changes are for the default UI and the Module17 UI.
The Module17 UI needs to be tested.

This will fix #168