### PR TITLE
Fix M17 Call Info flickering during reception

### DIFF
--- a/openrtx/src/rtx/OpMode_M17.cpp
+++ b/openrtx/src/rtx/OpMode_M17.cpp
@@ -237,11 +237,6 @@ void OpMode_M17::rxState(rtxStatus_t *const status)
                     strncpy(status->M17_orig, exCall1.c_str(), 10);
                     strncpy(status->M17_refl, exCall2.c_str(), 10);
                 }
-                else
-                {
-                    status->M17_orig[0] = '\0';
-                    status->M17_refl[0] = '\0';
-                }
 
                 // Extract audio data
                 if((type == M17FrameType::STREAM) && (pthSts == PATH_OPEN))
@@ -268,6 +263,8 @@ void OpMode_M17::rxState(rtxStatus_t *const status)
     {
         status->lsfOk = false;
         dataValid     = false;
+        status->M17_orig[0] = '\0';
+        status->M17_refl[0] = '\0';
     }
 }
 


### PR DESCRIPTION
When receiving M17 from a repeater/hotspot, the extended callsign data is flickering.
This is happened because not every LSF might contain the extended callsign info and the info was reset when not received.

This change keeps the extended callsign info for as long as a we stay locked.