### PR TITLE
Enable edit mode for dst callsign on mod17

### DIFF
--- a/openrtx/src/ui/module17/ui.c
+++ b/openrtx/src/ui/module17/ui.c
@@ -811,12 +811,34 @@ void ui_updateFSM(bool *sync_rtx)
         {
             // VFO screen
             case MAIN_VFO:
-                if(msg.keys & KEY_ENTER)
+                if(ui_state.edit_mode)
                 {
-                    // Save current main state
-                    ui_state.last_main_state = state.ui_screen;
-                    // Open Menu
-                    state.ui_screen = MENU_TOP;
+                    if(msg.keys & KEY_ENTER)
+                    {
+                        _ui_textInputConfirm(ui_state.new_callsign);
+                        // Save selected callsign and disable input mode
+                        strncpy(state.m17_dest, ui_state.new_callsign, 10);
+                        *sync_rtx = true;
+                        ui_state.edit_mode = false;
+                    }
+                    else if(msg.keys & KEY_ESC)
+                        ui_state.edit_mode = false;
+                    else
+                        _ui_textInputArrows(ui_state.new_callsign, 9, msg);
+                }
+                else
+                {
+                    if(msg.keys & KEY_ENTER)
+                    {
+                        // Save current main state
+                        ui_state.last_main_state = state.ui_screen;
+                        // Open Menu
+                        state.ui_screen = MENU_TOP;
+                    }
+                    else if (msg.keys & KEY_RIGHT)
+                    {
+                        ui_state.edit_mode = true;
+                    }
                 }
                 break;
 


### PR DESCRIPTION
This allows editing the destination callsign on the module17 When on the main screen, the right arrow will enter edit mode.