### PR TITLE
Change M17_orig to link and change callsign handling

### DIFF
--- a/openrtx/include/rtx/rtx.h
+++ b/openrtx/include/rtx/rtx.h
@@ -62,9 +62,10 @@ typedef struct
     char     destination_address[10];  /**< M17 call routing address   */
     bool     invertRxPhase;            /**< M17 RX phase inversion     */
     bool     lsfOk;                    /**  M17 LSF is valid           */
+    bool     M17_extCall;              /**  M17 stream with ext call   */
     char     M17_dst[10];              /**  M17 LSF destination        */
     char     M17_src[10];              /**  M17 LSF source             */
-    char     M17_orig[10];             /**  M17 LSF traffic originator */
+    char     M17_link[10];             /**  M17 LSF traffic originator */
     char     M17_refl[10];             /**  M17 LSF reflector module   */
 }
 rtxStatus_t;

--- a/openrtx/src/rtx/rtx.cpp
+++ b/openrtx/src/rtx/rtx.cpp
@@ -62,7 +62,7 @@ void rtx_init(pthread_mutex_t *m)
     rtxStatus.lsfOk         = false;
     rtxStatus.M17_src[0]    = '\0';
     rtxStatus.M17_dst[0]    = '\0';
-    rtxStatus.M17_orig[0]   = '\0';
+    rtxStatus.M17_link[0]   = '\0';
     rtxStatus.M17_refl[0]   = '\0';
     currMode = &noMode;
 

--- a/openrtx/src/ui/default/ui_main.c
+++ b/openrtx/src/ui/default/ui_main.c
@@ -143,14 +143,14 @@ void _ui_drawModeInfo(ui_state_t* ui_state)
                 gfx_print(layout.line1_pos, layout.line2_font, TEXT_ALIGN_CENTER,
                           color_white, "%s", rtxStatus.M17_src);
 
-                // Stream originator (if present)
-                if(rtxStatus.M17_orig[0] != '\0')
+                // RF link (if present)
+                if(rtxStatus.M17_link[0] != '\0')
                 {
                     gfx_drawSymbol(layout.line4_pos, layout.line3_symbol_size, TEXT_ALIGN_LEFT,
                                    color_white, SYMBOL_ACCESS_POINT);
 
                     gfx_print(layout.line4_pos, layout.line2_font, TEXT_ALIGN_CENTER,
-                              color_white, "%s", rtxStatus.M17_orig);
+                              color_white, "%s", rtxStatus.M17_link);
                 }
 
                 // Reflector (if present)

--- a/openrtx/src/ui/module17/ui_main.c
+++ b/openrtx/src/ui/module17/ui_main.c
@@ -112,12 +112,12 @@ void _ui_drawModeInfo(ui_state_t* ui_state)
                 gfx_print(layout.line1_pos, layout.line2_font, TEXT_ALIGN_CENTER,
                           color_white, "%s", rtxStatus.M17_src);
 
-                if(rtxStatus.M17_orig[0] != '\0')
+                if(rtxStatus.M17_link[0] != '\0')
                 {
                     gfx_drawSymbol(layout.line4_pos, layout.line3_symbol_font, TEXT_ALIGN_LEFT,
                                 color_white, SYMBOL_ACCESS_POINT);
                     gfx_print(layout.line4_pos, layout.line2_font, TEXT_ALIGN_CENTER,
-                            color_white, "%s", rtxStatus.M17_orig);
+                            color_white, "%s", rtxStatus.M17_link);
                 }
 
                 if(rtxStatus.M17_refl[0] != '\0')


### PR DESCRIPTION
This will swap the first extended callsign with the source callsign if there is extended callsign data.
This allows to always store the true source in the M17_src variable

See #188