### PR TITLE
 Saving destination callsign in memory

### DIFF
--- a/openrtx/include/core/settings.h
+++ b/openrtx/include/core/settings.h
@@ -54,6 +54,7 @@ typedef struct
     int8_t  utc_timezone;         // Timezone, in units of half hours
     bool    gps_enabled;          // GPS active
     char    callsign[10];         // Plaintext callsign
+    char    m17_dest[10];         // Plaintext callsign
     uint8_t display_timer   : 4,  // Standby timer
             m17_can         : 4;  // M17 CAN
     uint8_t vpLevel         : 3,  // Voice prompt level
@@ -76,6 +77,7 @@ static const settings_t default_settings =
     0,                // Vox level
     0,                // UTC Timezone
     false,            // GPS enabled
+    "",               // Empty callsign
     "",               // Empty callsign
     TIMER_30S,        // 30 seconds
     0,                // M17 CAN

--- a/openrtx/include/core/state.h
+++ b/openrtx/include/core/state.h
@@ -59,7 +59,6 @@ typedef struct
     bool       gpsDetected;
     bool       backup_eflash;
     bool       restore_eflash;
-    char       m17_dest[10];
     bool       txDisable;
     uint8_t    step_index;
 }

--- a/openrtx/src/core/threads.c
+++ b/openrtx/src/core/threads.c
@@ -107,7 +107,7 @@ void *ui_threadFunc(void *arg)
             rtx_cfg.can = state.settings.m17_can;
             rtx_cfg.canRxEn = state.settings.m17_can_rx;
             strncpy(rtx_cfg.source_address,      state.settings.callsign, 10);
-            strncpy(rtx_cfg.destination_address, state.m17_dest, 10);
+            strncpy(rtx_cfg.destination_address, state.settings.m17_dest, 10);
 
             pthread_mutex_unlock(&rtx_mutex);
 

--- a/openrtx/src/core/voicePromptUtils.c
+++ b/openrtx/src/core/voicePromptUtils.c
@@ -532,9 +532,9 @@ void vp_announceM17Info(const channel_t* channel, bool isEditing,
     {
         vp_queuePrompt(PROMPT_EDIT);
     }
-    else if (state.m17_dest[0] != '\0')
+    else if (state.settings.m17_dest[0] != '\0')
     {
-        vp_queueString(state.m17_dest, vpAnnounceCommonSymbols);
+        vp_queueString(state.settings.m17_dest, vpAnnounceCommonSymbols);
     }
     else if ((channel != NULL) && (channel->m17.contact_index != 0))
     {

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -1429,7 +1429,7 @@ void ui_updateFSM(bool *sync_rtx)
                         {
                             _ui_textInputConfirm(ui_state.new_callsign);
                             // Save selected dst ID and disable input mode
-                            strncpy(state.m17_dest, ui_state.new_callsign, 10);
+                            strncpy(state.settings.m17_dest, ui_state.new_callsign, 10);
                             ui_state.edit_mode = false;
                             *sync_rtx = true;
                             vp_announceM17Info(NULL,  ui_state.edit_mode, 
@@ -1438,7 +1438,7 @@ void ui_updateFSM(bool *sync_rtx)
                         else if(msg.keys & KEY_HASH)
                         {
                             // Save selected dst ID and disable input mode
-                            strncpy(state.m17_dest, "", 1);
+                            strncpy(state.settings.m17_dest, "", 1);
                             ui_state.edit_mode = false;
                             *sync_rtx = true;
                             vp_announceM17Info(NULL,  ui_state.edit_mode, 
@@ -1614,14 +1614,14 @@ void ui_updateFSM(bool *sync_rtx)
                         {
                             _ui_textInputConfirm(ui_state.new_callsign);
                             // Save selected dst ID and disable input mode
-                            strncpy(state.m17_dest, ui_state.new_callsign, 10);
+                            strncpy(state.settings.m17_dest, ui_state.new_callsign, 10);
                             ui_state.edit_mode = false;
                             *sync_rtx = true;
                         }
                         else if(msg.keys & KEY_HASH)
                         {
                             // Save selected dst ID and disable input mode
-                            strncpy(state.m17_dest, "", 1);
+                            strncpy(state.settings.m17_dest, "", 1);
                             ui_state.edit_mode = false;
                             *sync_rtx = true;
                         }

--- a/openrtx/src/ui/module17/ui.c
+++ b/openrtx/src/ui/module17/ui.c
@@ -817,7 +817,7 @@ void ui_updateFSM(bool *sync_rtx)
                     {
                         _ui_textInputConfirm(ui_state.new_callsign);
                         // Save selected callsign and disable input mode
-                        strncpy(state.m17_dest, ui_state.new_callsign, 10);
+                        strncpy(state.settings.m17_dest, ui_state.new_callsign, 10);
                         *sync_rtx = true;
                         ui_state.edit_mode = false;
                     }


### PR DESCRIPTION
This commit saves the destination callsign in flash memory between reboots
