### PR TITLE
Add a frequency correction option

### DIFF
--- a/openrtx/include/core/input.h
+++ b/openrtx/include/core/input.h
@@ -86,4 +86,13 @@ bool input_isCharPressed(kbd_msg_t msg);
  */
 uint8_t input_getPressedNumber(kbd_msg_t msg);
 
+/**
+ * This function returns the char corresponding to the smallest number that is pressed on the keyboard,
+ * 0 if none is pressed.
+ *
+ * @param msg: the keyboard queue message
+ * @return the char corresponding to the smallest number on the keyboard
+ */
+uint8_t input_getPressedChar(kbd_msg_t msg);
+
 #endif /* INPUT_H */

--- a/openrtx/include/core/input.h
+++ b/openrtx/include/core/input.h
@@ -69,6 +69,15 @@ bool input_scanKeyboard(kbd_msg_t *msg);
 bool input_isNumberPressed(kbd_msg_t msg);
 
 /**
+ * This function returns true if at least one char is pressed on the
+ * keyboard.
+ *
+ * @param msg: the keyboard queue message
+ * @return true if at least a char is pressed on the keyboard
+ */
+bool input_isCharPressed(kbd_msg_t msg);
+
+/**
  * This function returns the smallest number that is pressed on the keyboard,
  * 0 if none is pressed.
  *

--- a/openrtx/include/core/settings.h
+++ b/openrtx/include/core/settings.h
@@ -47,6 +47,7 @@ display_timer_t;
 
 typedef struct
 {
+    int16_t ppm_offset;           // frequency offset for tuning (in tenth of ppm)
     uint8_t brightness;           // Display brightness
     uint8_t contrast;             // Display contrast
     uint8_t sqlLevel;             // Squelch level
@@ -67,6 +68,7 @@ __attribute__((packed)) settings_t;
 
 static const settings_t default_settings =
 {
+    0,                // No frequency offset
     100,              // Brightness
 #ifdef SCREEN_CONTRAST
     DEFAULT_CONTRAST, // Contrast

--- a/openrtx/include/core/settings.h
+++ b/openrtx/include/core/settings.h
@@ -54,6 +54,7 @@ typedef struct
     int8_t  utc_timezone;         // Timezone, in units of half hours
     bool    gps_enabled;          // GPS active
     char    callsign[10];         // Plaintext callsign
+    char    m17_dest[10];         // Plaintext callsign
     uint8_t display_timer   : 4,  // Standby timer
             m17_can         : 4;  // M17 CAN
     uint8_t vpLevel         : 3,  // Voice prompt level
@@ -76,6 +77,7 @@ static const settings_t default_settings =
     0,                // Vox level
     0,                // UTC Timezone
     false,            // GPS enabled
+    "",               // Empty callsign
     "",               // Empty callsign
     TIMER_30S,        // 30 seconds
     0,                // M17 CAN

--- a/openrtx/include/core/state.h
+++ b/openrtx/include/core/state.h
@@ -59,7 +59,6 @@ typedef struct
     bool       gpsDetected;
     bool       backup_eflash;
     bool       restore_eflash;
-    char       m17_dest[10];
     bool       txDisable;
     uint8_t    step_index;
 }

--- a/openrtx/include/core/voicePrompts.h
+++ b/openrtx/include/core/voicePrompts.h
@@ -302,6 +302,13 @@ void vp_queueString(const char* string, vpFlags_t flags);
 void vp_queueInteger(const int value);
 
 /**
+ * Append a signed ppm to the queue.
+ *
+ * @param value: value to be appended (in tenth of PPM).
+ */
+void vp_queuePPM(const int16_t value);
+
+/**
  * Append a text string from the current language to the queue.
  */
 void vp_queueStringTableEntry(const char* const* stringTableStringPtr);

--- a/openrtx/include/interfaces/keyboard.h
+++ b/openrtx/include/interfaces/keyboard.h
@@ -67,10 +67,15 @@ enum key
 
 /**
  * Mask for the numeric keys in a key map
- * Numeric keys: bit0->bit11 = 0xFFF
+ * Numeric keys: bit0->bit9 = 0x3FF
  */
-#define KBD_NUM_MASK 0x0FFF
+#define KBD_NUM_MASK 0x03FF
 
+/**
+ * Mask for the chars keys in a key map
+ * Char keys: bit0->bit11 = 0xFFF
+ */
+#define KBD_CHAR_MASK 0x0FFF
 /**
  * We encode the status of all the keys with a uint32_t value
  * To check which buttons are pressed one can bit-mask the

--- a/openrtx/include/ui/EnglishStrings.h
+++ b/openrtx/include/ui/EnglishStrings.h
@@ -93,6 +93,6 @@ const stringsTable_t englishStrings =
     .usedHeap          = "Used heap",
     .broadcast         = "ALL",
     .radioSettings     = "Radio Settings",
-    .frequencyOffset   = "Frequency Offset"
+    .repeaterSplit     = "Repeater Split",
 };
 #endif  // ENGLISHSTRINGS_H

--- a/openrtx/include/ui/EnglishStrings.h
+++ b/openrtx/include/ui/EnglishStrings.h
@@ -94,5 +94,6 @@ const stringsTable_t englishStrings =
     .broadcast         = "ALL",
     .radioSettings     = "Radio Settings",
     .repeaterSplit     = "Repeater Split",
+    .ppmFreqOffset     = "PPM Freq. Offset"
 };
 #endif  // ENGLISHSTRINGS_H

--- a/openrtx/include/ui/ui_default.h
+++ b/openrtx/include/ui/ui_default.h
@@ -140,6 +140,7 @@ enum settingsRadioItems
     R_SPLIT,
     R_DIRECTION,
     R_STEP,
+    R_PPM
 };
 
 enum settingsM17Items
@@ -224,6 +225,7 @@ typedef struct ui_state_t
 #endif
     char new_callsign[10];
     freq_t new_split;
+    int16_t new_ppm;
     // Which state to return to when we exit menu
     uint8_t last_main_state;
 #if defined(UI_NO_KEYBOARD)

--- a/openrtx/include/ui/ui_default.h
+++ b/openrtx/include/ui/ui_default.h
@@ -137,7 +137,7 @@ enum settingsVoicePromptItems
 
 enum settingsRadioItems
 {
-    R_OFFSET,
+    R_SPLIT,
     R_DIRECTION,
     R_STEP,
 };
@@ -223,7 +223,7 @@ typedef struct ui_state_t
     char new_time_buf[9];
 #endif
     char new_callsign[10];
-    freq_t new_offset;
+    freq_t new_split;
     // Which state to return to when we exit menu
     uint8_t last_main_state;
 #if defined(UI_NO_KEYBOARD)

--- a/openrtx/include/ui/ui_strings.h
+++ b/openrtx/include/ui/ui_strings.h
@@ -98,6 +98,7 @@ typedef struct
     const char* broadcast;
     const char* radioSettings;
     const char* repeaterSplit;
+    const char* ppmFreqOffset;
 }
 stringsTable_t;
 

--- a/openrtx/include/ui/ui_strings.h
+++ b/openrtx/include/ui/ui_strings.h
@@ -97,7 +97,7 @@ typedef struct
     const char* usedHeap;
     const char* broadcast;
     const char* radioSettings;
-    const char* frequencyOffset;
+    const char* repeaterSplit;
 }
 stringsTable_t;
 

--- a/openrtx/src/core/input.c
+++ b/openrtx/src/core/input.c
@@ -86,6 +86,10 @@ bool input_isNumberPressed(kbd_msg_t msg)
     return msg.keys & KBD_NUM_MASK;
 }
 
+bool input_isCharPressed(kbd_msg_t msg){
+    return msg.keys & KBD_CHAR_MASK;
+}
+
 uint8_t input_getPressedNumber(kbd_msg_t msg)
 {
     uint32_t masked_input = msg.keys & KBD_NUM_MASK;

--- a/openrtx/src/core/input.c
+++ b/openrtx/src/core/input.c
@@ -98,3 +98,12 @@ uint8_t input_getPressedNumber(kbd_msg_t msg)
 
     return __builtin_ctz(msg.keys & KBD_NUM_MASK);
 }
+
+uint8_t input_getPressedChar(kbd_msg_t msg)
+{
+    uint32_t masked_input = msg.keys & KBD_CHAR_MASK;
+    if (masked_input == 0)
+        return 0;
+
+    return __builtin_ctz(msg.keys & KBD_CHAR_MASK);
+}

--- a/openrtx/src/core/threads.c
+++ b/openrtx/src/core/threads.c
@@ -107,7 +107,7 @@ void *ui_threadFunc(void *arg)
             rtx_cfg.can = state.settings.m17_can;
             rtx_cfg.canRxEn = state.settings.m17_can_rx;
             strncpy(rtx_cfg.source_address,      state.settings.callsign, 10);
-            strncpy(rtx_cfg.destination_address, state.m17_dest, 10);
+            strncpy(rtx_cfg.destination_address, state.settings.m17_dest, 10);
 
             pthread_mutex_unlock(&rtx_mutex);
 

--- a/openrtx/src/core/threads.c
+++ b/openrtx/src/core/threads.c
@@ -90,8 +90,11 @@ void *ui_threadFunc(void *arg)
             pthread_mutex_lock(&rtx_mutex);
             rtx_cfg.opMode      = state.channel.mode;
             rtx_cfg.bandwidth   = state.channel.bandwidth;
-            rtx_cfg.rxFrequency = state.channel.rx_frequency;
-            rtx_cfg.txFrequency = state.channel.tx_frequency;
+
+            /* Applies frequency offset */
+            rtx_cfg.rxFrequency = state.channel.rx_frequency * (1.0f + (float)state.settings.ppm_offset/1e7);
+            rtx_cfg.txFrequency = state.channel.tx_frequency * (1.0f + (float)state.settings.ppm_offset/1e7);
+
             rtx_cfg.txPower     = power;
             rtx_cfg.sqlLevel    = state.settings.sqlLevel;
             rtx_cfg.rxToneEn    = state.channel.fm.rxToneEn;

--- a/openrtx/src/core/voicePromptUtils.c
+++ b/openrtx/src/core/voicePromptUtils.c
@@ -532,9 +532,9 @@ void vp_announceM17Info(const channel_t* channel, bool isEditing,
     {
         vp_queuePrompt(PROMPT_EDIT);
     }
-    else if (state.m17_dest[0] != '\0')
+    else if (state.settings.m17_dest[0] != '\0')
     {
-        vp_queueString(state.m17_dest, vpAnnounceCommonSymbols);
+        vp_queueString(state.settings.m17_dest, vpAnnounceCommonSymbols);
     }
     else if ((channel != NULL) && (channel->m17.contact_index != 0))
     {

--- a/openrtx/src/core/voicePrompts.c
+++ b/openrtx/src/core/voicePrompts.c
@@ -524,6 +524,19 @@ void vp_queueInteger(const int value)
     vp_queueString(buf, 0);
 }
 
+void vp_queuePPM(const int16_t value)
+{
+    if (state.settings.vpLevel < vpLow)
+        return;
+
+    char buf[11] = {0};  // min: -3276.8, max: 3276.7
+    if (value < 0)
+        vp_queuePrompt(PROMPT_MINUS);
+
+    snprintf(buf, 11, "%d.%dppm", abs(value / 10), abs(value) % 10);
+    vp_queueString(buf, vpAnnounceCommonSymbols);
+}
+
 void vp_queueStringTableEntry(const char* const* stringTableStringPtr)
 {
     /*

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -170,6 +170,7 @@ const char *settings_radio_items[] =
     "Rpt. split",
     "Direction",
     "Step",
+    "Correction",
 };
 
 const char * settings_m17_items[] =
@@ -1212,11 +1213,56 @@ static void _ui_numberInputKeypad(uint32_t *num, kbd_msg_t msg)
     ui_state.last_keypress = now;
 }
 
+static void _ui_signedNumberInputKeypad(int32_t *num, kbd_msg_t msg)
+{
+    long long now = getTick();
+
+#ifdef UI_NO_KEYBOARD
+    // TODO
+#else
+    // Maximum frequency len is uint32_t max value number of decimal digits
+    if(ui_state.input_position >= 6)
+        return;
+
+    if(msg.keys & KEY_HASH)
+    {
+        *num *= -1;
+        vp_announceInputChar('-');
+    }
+    else{
+        // Get currently pressed number key
+        uint8_t num_key = input_getPressedNumber(msg);
+        *num *= 10;
+        *num += num_key;
+        // Announce the character
+        vp_announceInputChar('0' + num_key);
+        // Update reference values
+        ui_state.input_number = num_key;
+    }
+#endif
+
+    ui_state.last_keypress = now;
+}
+
 static void _ui_numberInputDel(uint32_t *num)
 {
     // announce the digit about to be backspaced.
     vp_announceInputChar('0' + *num % 10);
     
+    // Move back input cursor
+    if(ui_state.input_position > 0)
+        ui_state.input_position--;
+    else
+        ui_state.last_keypress = 0;
+
+    ui_state.input_set = 0;
+}
+
+static void _ui_signedNumberInputDel(int32_t *num)
+{
+    // announce the digit about to be backspaced.
+    vp_announceInputChar('0' + *num % 10);
+
     // Move back input cursor
     if(ui_state.input_position > 0)
         ui_state.input_position--;
@@ -2179,6 +2225,70 @@ void ui_updateFSM(bool *sync_rtx)
                                 state.step_index %= n_freq_steps;
                             }
                             break;
+                        case R_PPM:
+                            // Handle PPM offset input
+#if defined(UI_NO_KEYBOARD)
+                            if(msg.long_press && msg.keys & KEY_ENTER)
+                            {
+                                // Long press on UI_NO_KEYBOARD causes digits to advance by one
+                                ui_state.new_ppm /= 10;
+#else
+                            if(msg.keys & KEY_ENTER)
+                            {
+#endif
+                                // Apply new offset
+                                state.settings.ppm_offset = ui_state.new_ppm;
+                                vp_queueStringTableEntry(&currentLanguage->ppmFreqOffset);
+                                vp_queuePPM(ui_state.new_ppm);
+                                ui_state.edit_mode = false;
+                            }
+                            else if(msg.keys & KEY_ESC)
+                            {
+                                // Announce old frequency offset
+                                vp_queueStringTableEntry(&currentLanguage->ppmFreqOffset);
+                                vp_queuePPM(ui_state.new_ppm);
+                            }
+                            else if(msg.keys & KEY_UP || msg.keys & KEY_DOWN ||
+                                    msg.keys & KEY_LEFT || msg.keys & KEY_RIGHT)
+                            {
+                                int32_t tmp = (int32_t)ui_state.new_ppm;
+                                _ui_signedNumberInputDel(&tmp);
+                                ui_state.new_ppm = (int16_t)tmp;
+                            }
+#if defined(UI_NO_KEYBOARD)
+                            else if(msg.keys & KNOB_LEFT || msg.keys & KNOB_RIGHT || msg.keys & KEY_ENTER)
+#else
+                            else if(input_isNumberPressed(msg))
+#endif
+                            {
+                                int32_t tmp = (int32_t)ui_state.new_ppm;
+                                _ui_signedNumberInputKeypad(&tmp, msg);
+                                ui_state.new_ppm = (int16_t)tmp;
+                                ui_state.input_position += 1;
+                            }
+#if !defined(UI_NO_KEYBOARD)
+                            else if(msg.keys & KEY_HASH)
+                            {
+                                ui_state.new_ppm *= -1;
+                                if(ui_state.new_ppm > 0)
+                                {
+                                    ui_state.input_position -= 1;
+                                }
+                                else if(ui_state.new_ppm < 0)
+                                {
+                                    ui_state.input_position += 1;
+                                }
+                                vp_flush();
+                                vp_queuePPM(ui_state.new_ppm);
+                                vp_play();
+                            }
+#endif
+                            else if (msg.long_press && (msg.keys & KEY_F1) && (state.settings.vpLevel > vpBeep))
+                            {
+                                vp_queuePPM(ui_state.new_ppm);
+                                f1Handled=true;
+                            }
+                            break;
                         default:
                             state.ui_screen = SETTINGS_RADIO;
                     }
@@ -2195,6 +2305,8 @@ void ui_updateFSM(bool *sync_rtx)
                     // If we are entering R_SPLIT clear temp offset
                     if (ui_state.menu_selected == R_SPLIT)
                         ui_state.new_split = 0;
+                    else if(ui_state.menu_selected == R_PPM)
+                        ui_state.new_ppm = 0;
                     // Reset input position
                     ui_state.input_position = 0;
                 }

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -1094,7 +1094,7 @@ static void _ui_textInputKeypad(char *buf, uint8_t max_len, kbd_msg_t msg,
         return;
     long long now = getTick();
     // Get currently pressed number key
-    uint8_t num_key = input_getPressedNumber(msg);
+    uint8_t num_key = input_getPressedChar(msg);
     // Get number of symbols related to currently pressed key
     uint8_t num_symbols = 0;
     if(callsign)

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -1429,7 +1429,7 @@ void ui_updateFSM(bool *sync_rtx)
                         {
                             _ui_textInputConfirm(ui_state.new_callsign);
                             // Save selected dst ID and disable input mode
-                            strncpy(state.m17_dest, ui_state.new_callsign, 10);
+                            strncpy(state.settings.m17_dest, ui_state.new_callsign, 10);
                             ui_state.edit_mode = false;
                             *sync_rtx = true;
                             vp_announceM17Info(NULL,  ui_state.edit_mode, 
@@ -1438,7 +1438,7 @@ void ui_updateFSM(bool *sync_rtx)
                         else if(msg.keys & KEY_HASH)
                         {
                             // Save selected dst ID and disable input mode
-                            strncpy(state.m17_dest, "", 1);
+                            strncpy(state.settings.m17_dest, "", 1);
                             ui_state.edit_mode = false;
                             *sync_rtx = true;
                             vp_announceM17Info(NULL,  ui_state.edit_mode, 
@@ -1614,14 +1614,14 @@ void ui_updateFSM(bool *sync_rtx)
                         {
                             _ui_textInputConfirm(ui_state.new_callsign);
                             // Save selected dst ID and disable input mode
-                            strncpy(state.m17_dest, ui_state.new_callsign, 10);
+                            strncpy(state.settings.m17_dest, ui_state.new_callsign, 10);
                             ui_state.edit_mode = false;
                             *sync_rtx = true;
                         }
                         else if(msg.keys & KEY_HASH)
                         {
                             // Save selected dst ID and disable input mode
-                            strncpy(state.m17_dest, "", 1);
+                            strncpy(state.settings.m17_dest, "", 1);
                             ui_state.edit_mode = false;
                             *sync_rtx = true;
                         }

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -167,7 +167,7 @@ const char *settings_gps_items[] =
 
 const char *settings_radio_items[] =
 {
-    "Offset",
+    "Rpt. split",
     "Direction",
     "Step",
 };
@@ -2109,34 +2109,34 @@ void ui_updateFSM(bool *sync_rtx)
                 {
                     switch(ui_state.menu_selected)
                     {
-                        case R_OFFSET:
-                            // Handle offset frequency input
+                        case R_SPLIT:
+                            // Handle split frequency input
 #if defined(UI_NO_KEYBOARD)
                             if(msg.long_press && msg.keys & KEY_ENTER)
                             {
                                 // Long press on UI_NO_KEYBOARD causes digits to advance by one
-                                ui_state.new_offset /= 10;
+                                ui_state.new_split /= 10;
 #else
                             if(msg.keys & KEY_ENTER)
                             {
 #endif
                                 // Apply new offset
-                                state.channel.tx_frequency = state.channel.rx_frequency + ui_state.new_offset;
-                                vp_queueStringTableEntry(&currentLanguage->frequencyOffset);
-                                vp_queueFrequency(ui_state.new_offset);
+                                state.channel.tx_frequency = state.channel.rx_frequency + ui_state.new_split;
+                                vp_queueStringTableEntry(&currentLanguage->repeaterSplit);
+                                vp_queueFrequency(ui_state.new_split);
                                 ui_state.edit_mode = false;
                             }
                             else
                             if(msg.keys & KEY_ESC)
                             {
                                 // Announce old frequency offset
-                                vp_queueStringTableEntry(&currentLanguage->frequencyOffset);
+                                vp_queueStringTableEntry(&currentLanguage->repeaterSplit);
                                 vp_queueFrequency((int32_t)state.channel.tx_frequency - (int32_t)state.channel.rx_frequency);
                             }
                             else if(msg.keys & KEY_UP || msg.keys & KEY_DOWN ||
                                     msg.keys & KEY_LEFT || msg.keys & KEY_RIGHT)
                             {
-                                _ui_numberInputDel(&ui_state.new_offset);
+                                _ui_numberInputDel(&ui_state.new_split);
                             }
 #if defined(UI_NO_KEYBOARD)
                             else if(msg.keys & KNOB_LEFT || msg.keys & KNOB_RIGHT || msg.keys & KEY_ENTER)
@@ -2144,12 +2144,12 @@ void ui_updateFSM(bool *sync_rtx)
                             else if(input_isNumberPressed(msg))
 #endif
                             {
-                                _ui_numberInputKeypad(&ui_state.new_offset, msg);
+                                _ui_numberInputKeypad(&ui_state.new_split, msg);
                                 ui_state.input_position += 1;
                             }
                             else if (msg.long_press && (msg.keys & KEY_F1) && (state.settings.vpLevel > vpBeep))
                             {
-                                vp_queueFrequency(ui_state.new_offset);
+                                vp_queueFrequency(ui_state.new_split);
                                 f1Handled=true;
                             }
                             break;
@@ -2182,8 +2182,8 @@ void ui_updateFSM(bool *sync_rtx)
                         default:
                             state.ui_screen = SETTINGS_RADIO;
                     }
-                    // If ENTER or ESC are pressed, exit edit mode, R_OFFSET is managed separately
-                    if((ui_state.menu_selected != R_OFFSET && msg.keys & KEY_ENTER) || msg.keys & KEY_ESC)
+                    // If ENTER or ESC are pressed, exit edit mode, R_SPLIT is managed separately
+                    if((ui_state.menu_selected != R_SPLIT && msg.keys & KEY_ENTER) || msg.keys & KEY_ESC)
                         ui_state.edit_mode = false;
                 }
                 else if(msg.keys & KEY_UP || msg.keys & KNOB_LEFT)
@@ -2192,9 +2192,9 @@ void ui_updateFSM(bool *sync_rtx)
                     _ui_menuDown(settings_radio_num);
                 else if(msg.keys & KEY_ENTER) {
                     ui_state.edit_mode = true;
-                    // If we are entering R_OFFSET clear temp offset
-                    if (ui_state.menu_selected == R_OFFSET)
-                        ui_state.new_offset = 0;
+                    // If we are entering R_SPLIT clear temp offset
+                    if (ui_state.menu_selected == R_SPLIT)
+                        ui_state.new_split = 0;
                     // Reset input position
                     ui_state.input_position = 0;
                 }

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -1098,7 +1098,11 @@ static void _ui_textInputKeypad(char *buf, uint8_t max_len, kbd_msg_t msg,
     // Get number of symbols related to currently pressed key
     uint8_t num_symbols = 0;
     if(callsign)
+    {
         num_symbols = strlen(symbols_ITU_T_E161_callsign[num_key]);
+        if(num_symbols == 0)
+            return;
+    }
     else
         num_symbols = strlen(symbols_ITU_T_E161[num_key]);
 

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -1450,7 +1450,7 @@ void ui_updateFSM(bool *sync_rtx)
                         else if(msg.keys & KEY_UP || msg.keys & KEY_DOWN ||
                                 msg.keys & KEY_LEFT || msg.keys & KEY_RIGHT)
                             _ui_textInputDel(ui_state.new_callsign);
-                        else if(input_isNumberPressed(msg))
+                        else if(input_isCharPressed(msg))
                             _ui_textInputKeypad(ui_state.new_callsign, 9, msg, true);
                         break;
                     }
@@ -1652,7 +1652,7 @@ void ui_updateFSM(bool *sync_rtx)
                         else if(msg.keys & KEY_UP || msg.keys & KEY_DOWN ||
                                 msg.keys & KEY_LEFT || msg.keys & KEY_RIGHT)
                             _ui_textInputDel(ui_state.new_callsign);
-                        else if(input_isNumberPressed(msg))
+                        else if(input_isCharPressed(msg))
                             _ui_textInputKeypad(ui_state.new_callsign, 9, msg, true);
                         break;
                     }
@@ -2230,7 +2230,7 @@ void ui_updateFSM(bool *sync_rtx)
                             {
                                 _ui_textInputDel(ui_state.new_callsign);
                             }
-                            else if(input_isNumberPressed(msg))
+                            else if(input_isCharPressed(msg))
                             {
                                 _ui_textInputKeypad(ui_state.new_callsign, 9, msg, true);
                             }

--- a/openrtx/src/ui/default/ui_menu.c
+++ b/openrtx/src/ui/default/ui_menu.c
@@ -371,6 +371,9 @@ int _ui_getRadioValueName(char *buf, uint8_t max_len, uint8_t index)
             else
                 snprintf(buf, max_len, "%gMHz", (float) freq_steps[last_state.step_index] / 1000000.0f);
             break;
+        case R_PPM:
+            snprintf(buf, max_len, "%gppm", (float)last_state.settings.ppm_offset / 10.0f);
+            break;
     }
 
     return 0;
@@ -962,6 +965,26 @@ void _ui_drawSettingsRadio(ui_state_t* ui_state)
             snprintf(buf, 17, "%gkHz", (float) ui_state->new_split / 1000.0f);
         else
             snprintf(buf, 17, "%gMHz", (float) ui_state->new_split / 1000000.0f);
+
+        gfx_printLine(1, 1, layout.top_h, SCREEN_HEIGHT - layout.bottom_h,
+                      layout.horizontal_pad, layout.input_font,
+                      TEXT_ALIGN_CENTER, color_white, buf);
+    }
+    else if((ui_state->menu_selected == R_PPM) && (ui_state->edit_mode))
+    {
+        char buf[11] = { 0 };
+        uint16_t rect_width = SCREEN_WIDTH - (layout.horizontal_pad * 2);
+        uint16_t rect_height = (SCREEN_HEIGHT - (layout.top_h + layout.bottom_h))/2;
+        point_t rect_origin = {(SCREEN_WIDTH - rect_width) / 2,
+                               (SCREEN_HEIGHT - rect_height) / 2};
+
+        gfx_drawRect(rect_origin, rect_width, rect_height, color_white, false);
+
+        // Print offset
+        if(ui_state->new_ppm < 0)
+            snprintf(buf, 11, "-%d.%d", abs(ui_state->new_ppm / 10), abs(ui_state->new_ppm) % 10);
+        else
+            snprintf(buf, 11, "%d.%d", ui_state->new_ppm / 10, ui_state->new_ppm % 10);
 
         gfx_printLine(1, 1, layout.top_h, SCREEN_HEIGHT - layout.bottom_h,
                       layout.horizontal_pad, layout.input_font,

--- a/openrtx/src/ui/default/ui_menu.c
+++ b/openrtx/src/ui/default/ui_menu.c
@@ -349,13 +349,14 @@ int _ui_getRadioValueName(char *buf, uint8_t max_len, uint8_t index)
     if(index >= settings_radio_num)
         return -1;
 
-    int32_t offset = 0;
+    int32_t split = 0;
+
     switch(index)
     {
-        case R_OFFSET:
-            offset = abs((int32_t)last_state.channel.tx_frequency -
+        case R_SPLIT:
+            split = abs((int32_t)last_state.channel.tx_frequency -
                          (int32_t)last_state.channel.rx_frequency);
-            snprintf(buf, max_len, "%gMHz", (float) offset / 1000000.0f);
+            snprintf(buf, max_len, "%gMHz", (float) split / 1000000.0f);
             break;
 
         case R_DIRECTION:
@@ -944,7 +945,7 @@ void _ui_drawSettingsRadio(ui_state_t* ui_state)
               color_white, currentLanguage->radioSettings);
 
     // Handle the special case where a frequency is being input
-    if ((ui_state->menu_selected == R_OFFSET) && (ui_state->edit_mode))
+    if ((ui_state->menu_selected == R_SPLIT) && (ui_state->edit_mode))
     {
         char buf[17] = { 0 };
         uint16_t rect_width = SCREEN_WIDTH - (layout.horizontal_pad * 2);
@@ -955,12 +956,12 @@ void _ui_drawSettingsRadio(ui_state_t* ui_state)
         gfx_drawRect(rect_origin, rect_width, rect_height, color_white, false);
 
         // Print frequency with the most sensible unit
-        if (ui_state->new_offset < 1000)
-            snprintf(buf, 17, "%dHz", ui_state->new_offset);
-        else if (ui_state->new_offset < 1000000)
-            snprintf(buf, 17, "%gkHz", (float) ui_state->new_offset / 1000.0f);
+        if (ui_state->new_split < 1000)
+            snprintf(buf, 17, "%dHz", ui_state->new_split);
+        else if (ui_state->new_split < 1000000)
+            snprintf(buf, 17, "%gkHz", (float) ui_state->new_split / 1000.0f);
         else
-            snprintf(buf, 17, "%gMHz", (float) ui_state->new_offset / 1000000.0f);
+            snprintf(buf, 17, "%gMHz", (float) ui_state->new_split / 1000000.0f);
 
         gfx_printLine(1, 1, layout.top_h, SCREEN_HEIGHT - layout.bottom_h,
                       layout.horizontal_pad, layout.input_font,

--- a/openrtx/src/ui/module17/ui.c
+++ b/openrtx/src/ui/module17/ui.c
@@ -699,7 +699,7 @@ void _ui_textInputKeypad(char *buf, uint8_t max_len, kbd_msg_t msg, bool callsig
         return;
     long long now = getTick();
     // Get currently pressed number key
-    uint8_t num_key = input_getPressedNumber(msg);
+    uint8_t num_key = input_getPressedChar(msg);
     // Get number of symbols related to currently pressed key
     uint8_t num_symbols = 0;
     if(callsign)

--- a/openrtx/src/ui/module17/ui.c
+++ b/openrtx/src/ui/module17/ui.c
@@ -817,7 +817,7 @@ void ui_updateFSM(bool *sync_rtx)
                     {
                         _ui_textInputConfirm(ui_state.new_callsign);
                         // Save selected callsign and disable input mode
-                        strncpy(state.m17_dest, ui_state.new_callsign, 10);
+                        strncpy(state.settings.m17_dest, ui_state.new_callsign, 10);
                         *sync_rtx = true;
                         ui_state.edit_mode = false;
                     }

--- a/platform/drivers/baseband/radioUtils.h
+++ b/platform/drivers/baseband/radioUtils.h
@@ -51,7 +51,7 @@ enum Band
  * @return a value from @enum Band identifying the band to which the frequency
  * belong.
  */
-inline Band getBandFromFrequency(const freq_t freq)
+static inline enum Band getBandFromFrequency(const freq_t freq)
 {
     if((freq >= BAND_VHF_LO) && (freq <= BAND_VHF_HI)) return BND_VHF;
     if((freq >= BAND_UHF_LO) && (freq <= BAND_UHF_HI)) return BND_UHF;


### PR DESCRIPTION
This pull request adds a frequency correction setting in the menus.
This option can be found in Settings -> Radio -> Correction.

For now, this option does not behaves correctly on a device without a keyboard (UI_NO_KEYBOARD define).
This is because a function called `static void _ui_signedNumberInputKeypad(int32_t *num, kbd_msg_t msg)` have been added and the UI_NO_KEYBOARD option is not supported yet.

Press the hash key to make the entered value negative/positive.

The setting previously called "Offset" in the radio settings menu have also been renamed "Rpt. Split" to avoid confusion.

Finally, I fixed an issue with the keys "star" and "hash" being considered as numeric keys. The only numeric keys are now 0-9. The keys 0-9 and star and hash are now considered as char keys (masks and functions have been created accordingly).