### PR TITLE
Display callsign on splash screen

### DIFF
--- a/openrtx/include/core/ui.h
+++ b/openrtx/include/core/ui.h
@@ -35,7 +35,7 @@ void ui_init();
  * @param centered: if true the logo will be printed at the center of
  * the screen, otherwise it will be printed at the top of the screen.
  */
-void ui_drawSplashScreen(bool centered);
+void ui_drawSplashScreen(bool centered, bool show_callsign);
 
 /**
  * This function updates the local copy of the radio state

--- a/openrtx/src/core/openrtx.c
+++ b/openrtx/src/core/openrtx.c
@@ -69,7 +69,7 @@ void openrtx_init()
 
     // Display splash screen, turn on backlight after a suitable time to
     // hide random pixels during render process
-    ui_drawSplashScreen(true);
+    ui_drawSplashScreen(true, true);
     gfx_render();
     sleepFor(0u, 30u);
     display_setBacklightLevel(state.settings.brightness);

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -1242,6 +1242,7 @@ void ui_drawSplashScreen(bool centered)
 {
     gfx_clearScreen();
     point_t splash_origin = {0,0};
+    point_t callsign_origin = {0,0};
 
     if(centered)
         splash_origin.y = SCREEN_HEIGHT / 2 - 6;
@@ -1249,6 +1250,10 @@ void ui_drawSplashScreen(bool centered)
         splash_origin.y = SCREEN_HEIGHT / 5;
     gfx_print(splash_origin, FONT_SIZE_12PT, TEXT_ALIGN_CENTER, yellow_fab413,
               "O P N\nR T X");
+
+    callsign_origin.y = SCREEN_HEIGHT - 10;
+    gfx_print(callsign_origin, FONT_SIZE_8PT, TEXT_ALIGN_CENTER, color_white,
+              state.settings.callsign);
 
     vp_announceSplashScreen();
 }

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -1238,7 +1238,7 @@ void ui_init()
     ui_state = (const struct ui_state_t){ 0 };
 }
 
-void ui_drawSplashScreen(bool centered)
+void ui_drawSplashScreen(bool centered, bool show_callsign)
 {
     gfx_clearScreen();
     point_t splash_origin = {0,0};
@@ -1251,10 +1251,12 @@ void ui_drawSplashScreen(bool centered)
     gfx_print(splash_origin, FONT_SIZE_12PT, TEXT_ALIGN_CENTER, yellow_fab413,
               "O P N\nR T X");
 
+    if(show_callsign)
+    {
     callsign_origin.y = SCREEN_HEIGHT - 10;
     gfx_print(callsign_origin, FONT_SIZE_8PT, TEXT_ALIGN_CENTER, color_white,
               state.settings.callsign);
-
+    }
     vp_announceSplashScreen();
 }
 

--- a/openrtx/src/ui/default/ui_menu.c
+++ b/openrtx/src/ui/default/ui_menu.c
@@ -769,7 +769,7 @@ void _ui_drawMenuAbout()
     gfx_clearScreen();
     point_t openrtx_pos = {layout.horizontal_pad, layout.line3_large_h};
     if(SCREEN_HEIGHT >= 100)
-        ui_drawSplashScreen(false);
+        ui_drawSplashScreen(false, false);
     else
         gfx_print(openrtx_pos, layout.line3_large_font, TEXT_ALIGN_CENTER,
                   color_white, currentLanguage->openRTX);

--- a/openrtx/src/ui/module17/ui.c
+++ b/openrtx/src/ui/module17/ui.c
@@ -314,16 +314,24 @@ void ui_init()
     ui_state = (const struct ui_state_t){ 0 };
 }
 
-void ui_drawSplashScreen(bool centered)
+void ui_drawSplashScreen(bool centered, bool show_callsign)
 {
     gfx_clearScreen();
     point_t splash_origin = {0,0};
+    point_t callsign_origin = {0,0};
 
     if(centered)
         splash_origin.y = SCREEN_HEIGHT / 2 - 6;
     else
         splash_origin.y = SCREEN_HEIGHT / 5;
     gfx_print(splash_origin, FONT_SIZE_12PT, TEXT_ALIGN_CENTER, yellow_fab413, "O P N\nR T X");
+
+    if(show_callsign)
+    {
+    callsign_origin.y = SCREEN_HEIGHT - 10;
+    gfx_print(callsign_origin, FONT_SIZE_8PT, TEXT_ALIGN_CENTER, color_white,
+              state.settings.callsign);
+    }
 }
 
 freq_t _ui_freq_add_digit(freq_t freq, uint8_t pos, uint8_t number)

--- a/openrtx/src/ui/module17/ui_menu.c
+++ b/openrtx/src/ui/module17/ui_menu.c
@@ -434,7 +434,7 @@ void _ui_drawMenuAbout()
     gfx_clearScreen();
     point_t openrtx_pos = {layout.horizontal_pad, layout.line3_h};
     if(SCREEN_HEIGHT >= 100)
-        ui_drawSplashScreen(false);
+        ui_drawSplashScreen(false, false);
     else
         gfx_print(openrtx_pos, layout.line3_font, TEXT_ALIGN_CENTER,
                   color_white, "OpenRTX");


### PR DESCRIPTION
This pull request displays the user's callsign on the splash screen. 
The callsign is displayed under the OpenRTX logo, 10 pixels above the bottom of the screen, in white 8pt font.