### PR TITLE
Add a volume bar in the bottom over the other bars

### DIFF
--- a/openrtx/include/core/graphics.h
+++ b/openrtx/include/core/graphics.h
@@ -303,10 +303,12 @@ void gfx_drawBattery(point_t start, uint16_t width, uint16_t height,
  * @param height: Smeter height
  * @param rssi: rssi level in dBm
  * @param squelch: squelch level in percentage
+ * @param volume: speaker volume level in percentage
+ * @param drawVolume: whether the volume bar should be drawn
  * @param color: color of the squelch bar
  */
 void gfx_drawSmeter(point_t start, uint16_t width, uint16_t height, float rssi,
-                    float squelch, color_t color);
+                    float squelch, float volume, bool drawVolume, color_t color);
 
 /**
  * Function to draw Smeter + level meter of arbitrary size.
@@ -317,9 +319,11 @@ void gfx_drawSmeter(point_t start, uint16_t width, uint16_t height, float rssi,
  * @param height: Smeter height
  * @param rssi: rssi level in dBm
  * @param level: level in range {0, 255}
+* @param volume: speaker volume level in percentage
+* @param drawVolume: whether the volume bar should be drawn
  */
 void gfx_drawSmeterLevel(point_t start, uint16_t width, uint16_t height,
-                         float rssi, uint8_t level);
+                         float rssi, uint8_t level, float volume, bool drawVolume);
 
 /**
  * Function to draw GPS SNR bar graph of arbitrary size.

--- a/openrtx/src/ui/default/ui_main.c
+++ b/openrtx/src/ui/default/ui_main.c
@@ -249,6 +249,7 @@ void _ui_drawMainBottom()
     // Squelch bar
     float rssi = last_state.rssi;
     float squelch = last_state.settings.sqlLevel / 16.0f;
+    float volume = platform_getVolumeLevel() / 255.0f;
     uint16_t meter_width = SCREEN_WIDTH - 2 * layout.horizontal_pad;
     uint16_t meter_height = layout.bottom_h;
     point_t meter_pos = { layout.horizontal_pad,
@@ -262,6 +263,8 @@ void _ui_drawMainBottom()
                            meter_height,
                            rssi,
                            squelch,
+                           volume,
+                           true,
                            yellow_fab413);
             break;
         case OPMODE_DMR:
@@ -269,14 +272,18 @@ void _ui_drawMainBottom()
                                 meter_width,
                                 meter_height,
                                 rssi,
-                                mic_level);
+                                mic_level,
+                                volume,
+                                true);
             break;
         case OPMODE_M17:
             gfx_drawSmeterLevel(meter_pos,
                                 meter_width,
                                 meter_height,
                                 rssi,
-                                mic_level);
+                                mic_level,
+                                volume,
+                                true);
             break;
     }
 }

--- a/openrtx/src/ui/module17/ui_main.c
+++ b/openrtx/src/ui/module17/ui_main.c
@@ -239,6 +239,8 @@ void _ui_drawMainBottom()
     // Squelch bar
     float rssi = last_state.rssi;
     float squelch = last_state.settings.sqlLevel / 16.0f;
+    // Module17 0.1e does not know the volume level, so we will never draw it
+    float volume = platform_getVolumeLevel() / 255.0f;
     uint16_t meter_width = SCREEN_WIDTH - 2 * layout.horizontal_pad;
     uint16_t meter_height = layout.bottom_h;
     point_t meter_pos = { layout.horizontal_pad,
@@ -252,6 +254,8 @@ void _ui_drawMainBottom()
                            meter_height,
                            rssi,
                            squelch,
+                           volume,
+                           false,
                            yellow_fab413);
             break;
         case OPMODE_DMR:
@@ -259,14 +263,18 @@ void _ui_drawMainBottom()
                                 meter_width,
                                 meter_height,
                                 rssi,
-                                mic_level);
+                                mic_level,
+                                volume,
+                                false);
             break;
         case OPMODE_M17:
             /*gfx_drawSmeterLevel(meter_pos,
                                 meter_width,
                                 meter_height,
                                 rssi,
-                                mic_level);*/
+                                mic_level,
+                                volume,
+                                false);*/
             break;
     }
 }


### PR DESCRIPTION
This adds the current volume of the speaker as a bar above the S meter in the bottom.
The function to draw the meters has the option to not draw the volume bar, which at the moment is only used on the module 17 as we do not have a way to get the volume.


![](https://user-images.githubusercontent.com/49691247/280525354-4a654077-e063-46d0-89d4-fcfabf13e193.png)

![](https://user-images.githubusercontent.com/49691247/280525353-72e2e247-3bb0-4d82-acab-f3dc58f68c26.png)


This will fix #190