### PR TITLE
Add callsign squelch for incoming M17 transmissions

### DIFF
--- a/openrtx/include/rtx/OpMode_M17.hpp
+++ b/openrtx/include/rtx/OpMode_M17.hpp
@@ -121,6 +121,19 @@ private:
      */
     void txState(rtxStatus_t *const status);
 
+    /**
+     * Computes if the destination callsign matches with the user's callsign.
+     * The comparison does not take into account the country prefixes (strips the '/'
+     * and whatever is in front from all callsigns). It does take into account the
+     * dash and whatever is after it. It will also return true if the destCallsign
+     * is "ALL".
+     *
+     * \param myCallsign plain text callsign from the user
+     * \param destCallsign plain text destination callsign
+     * \return a bool that is true in case of match, false in case of mismatch.
+     */
+    bool callsignCompare(const std::string& myCallsign, const std::string& destCallsign);
+
 
     bool startRx;                      ///< Flag for RX management.
     bool startTx;                      ///< Flag for TX management.

--- a/openrtx/src/rtx/OpMode_M17.cpp
+++ b/openrtx/src/rtx/OpMode_M17.cpp
@@ -370,13 +370,22 @@ bool OpMode_M17::callsignCompare(const std::string& myCallsign, const std::strin
     if(destCallsign == "ALL")
         return true;
 
-    myCallsign.find('/');
-    std::string truncatedMyCall = myCallsign.substr(
-        myCallsign.find_first_of('/')+1
-    );
-    std::string truncatedDstCall = destCallsign.substr(
-        destCallsign.find_first_of('/')+1
-    );
+    int myCSFirstSlash = myCallsign.find_first_of('/');
+    int destCSFirstSlash = destCallsign.find_first_of('/');
+    std::string truncatedMyCall;
+    std::string truncatedDstCall;
+
+    if(myCSFirstSlash > 2){
+        truncatedMyCall = myCallsign;
+    }else{
+        truncatedMyCall = myCallsign.substr(myCSFirstSlash+1);
+    }
+
+    if(destCSFirstSlash > 2){
+        truncatedDstCall = destCallsign;
+    }else{
+        truncatedDstCall = destCallsign.substr(destCSFirstSlash+1);
+    }
 
     if(truncatedDstCall == truncatedMyCall)
         return true;


### PR DESCRIPTION
This PR makes it so that M17 transmission with a destination callsign that is neither ALL nor broadcast will not be heard.

The way it checks for a callsign is that it removes an eventual prefix that may be there but should be less than or equal to 2 characters long. This makes it so that XY/AB1ABC will match AB1ABC and vice versa (but AB1ABC/P will not match AB1ABC).
If this behavior is not desired I can remove it.