### PR TITLE
Add sink mute/unmute and mute speaker when M17 is idle

### DIFF
--- a/openrtx/include/interfaces/audio.h
+++ b/openrtx/include/interfaces/audio.h
@@ -179,6 +179,20 @@ void audio_connect(const enum AudioSource source, const enum AudioSink sink);
 void audio_disconnect(const enum AudioSource source, const enum AudioSink sink);
 
 /**
+ * Mute an audio sink.
+ *
+ * @param sink: identifier of the output audio peripheral.
+ */
+void audio_mute_sink(const enum AudioSink sink);
+
+/**
+ * Unmute an audio sink.
+ *
+ * @param sink: identifier of the output audio peripheral.
+ */
+void audio_unmute_sink(const enum AudioSink sink);
+
+/**
  * Check if two audio paths are compatible that is, if they can be open at the
  * same time.
  *

--- a/openrtx/src/rtx/OpMode_M17.cpp
+++ b/openrtx/src/rtx/OpMode_M17.cpp
@@ -60,6 +60,7 @@ void OpMode_M17::enable()
     extendedCall = false;
     startRx      = true;
     startTx      = false;
+    audio_mute_sink(SINK_SPK);
 }
 
 void OpMode_M17::disable()
@@ -185,6 +186,7 @@ void OpMode_M17::rxState(rtxStatus_t *const status)
         demodulator.invertPhase(invertRxPhase);
 
         radio_enableRx();
+        audio_mute_sink(SINK_SPK);
 
         startRx = false;
     }
@@ -209,6 +211,7 @@ void OpMode_M17::rxState(rtxStatus_t *const status)
             pthSts = audioPath_getStatus(rxAudioPath);
         }
 
+        audio_unmute_sink(SINK_SPK);
         // Start codec2 module if not already up
         if(codec_running() == false)
             codec_startDecode(rxAudioPath);
@@ -296,6 +299,7 @@ void OpMode_M17::rxState(rtxStatus_t *const status)
         extendedCall  = false;
         status->M17_link[0] = '\0';
         status->M17_refl[0] = '\0';
+        audio_mute_sink(SINK_SPK);
     }
 }
 

--- a/platform/drivers/audio/audio_GDx.c
+++ b/platform/drivers/audio/audio_GDx.c
@@ -89,3 +89,13 @@ bool audio_checkPathCompatibility(const enum AudioSource p1Source,
 
     return pathCompatibilityMatrix[p1Index][p2Index] == 1;
 }
+
+void audio_mute_sink(const enum AudioSink sink)
+{
+    (void) sink;
+}
+
+void audio_unmute_sink(const enum AudioSink sink)
+{
+    (void) sink;
+}

--- a/platform/drivers/audio/audio_MDx.c
+++ b/platform/drivers/audio/audio_MDx.c
@@ -92,7 +92,7 @@ void audio_init()
 
     gpio_setMode(BEEP_OUT, INPUT);
 
-    gpio_setPin(SPK_MUTE);          // Speaker muted
+    audio_mute_sink(SINK_SPK);
     #ifndef PLATFORM_MD9600
     gpio_clearPin(AUDIO_AMP_EN);    // Audio PA off
     #ifndef MDx_ENABLE_SWD
@@ -106,7 +106,7 @@ void audio_init()
 
 void audio_terminate()
 {
-    gpio_setPin(SPK_MUTE);          // Speaker muted
+    audio_mute_sink(SINK_SPK);
     #ifndef PLATFORM_MD9600
     gpio_clearPin(AUDIO_AMP_EN);    // Audio PA off
     #ifndef MDx_ENABLE_SWD
@@ -152,7 +152,7 @@ void audio_connect(const enum AudioSource source, const enum AudioSink sink)
         gpio_setPin(AUDIO_AMP_EN);
         #endif
         sleepFor(0, 10);
-        gpio_clearPin(SPK_MUTE);
+        audio_mute_sink(SINK_SPK);
     }
 }
 
@@ -162,7 +162,7 @@ void audio_disconnect(const enum AudioSource source, const enum AudioSink sink)
 
     if(sink == SINK_SPK)
     {
-        gpio_setPin(SPK_MUTE);
+        audio_mute_sink(SINK_SPK);
         #ifndef PLATFORM_MD9600
         gpio_clearPin(AUDIO_AMP_EN);
         #endif
@@ -202,4 +202,31 @@ bool audio_checkPathCompatibility(const enum AudioSource p1Source,
     uint8_t p2Index = (p2Source * 3) + p2Sink;
 
     return pathCompatibilityMatrix[p1Index][p2Index] == 1;
+}
+
+
+void audio_mute_sink(const enum AudioSink sink)
+{
+    switch (sink)
+    {
+        case SINK_SPK:
+            gpio_setPin(SPK_MUTE);
+            break;
+        case SINK_RTX:
+        case SINK_MCU:
+            break;
+    }
+}
+
+void audio_unmute_sink(const enum AudioSink sink)
+{
+    switch (sink)
+    {
+        case SINK_SPK:
+            gpio_clearPin(SPK_MUTE);
+            break;
+        case SINK_RTX:
+        case SINK_MCU:
+            break;
+    }
 }

--- a/platform/drivers/audio/audio_Mod17.c
+++ b/platform/drivers/audio/audio_Mod17.c
@@ -61,7 +61,7 @@ void audio_init()
     gpio_setMode(AUDIO_MIC,   INPUT_ANALOG);
     gpio_setMode(BASEBAND_RX, INPUT_ANALOG);
 
-    gpio_setPin(SPK_MUTE);      // Off  = logic high
+    audio_mute_sink(SINK_SPK);
     gpio_clearPin(MIC_MUTE);    // Off  = logic low
     max9814_setGain(0);         // 40 dB gain
 
@@ -71,7 +71,7 @@ void audio_init()
 
 void audio_terminate()
 {
-    gpio_setPin(SPK_MUTE);
+    audio_mute_sink(SINK_SPK);
     gpio_clearPin(MIC_MUTE);
 
     stm32dac_terminate();
@@ -84,7 +84,7 @@ void audio_connect(const enum AudioSource source, const enum AudioSink sink)
         gpio_setPin(MIC_MUTE);
 
     if(sink == SINK_SPK)
-        gpio_clearPin(SPK_MUTE);
+        audio_unmute_sink(SINK_SPK);
 }
 
 void audio_disconnect(const enum AudioSource source, const enum AudioSink sink)
@@ -93,7 +93,7 @@ void audio_disconnect(const enum AudioSource source, const enum AudioSink sink)
         gpio_clearPin(MIC_MUTE);
 
     if(sink == SINK_SPK)
-        gpio_setPin(SPK_MUTE);
+        audio_mute_sink(SINK_SPK);
 }
 
 bool audio_checkPathCompatibility(const enum AudioSource p1Source,
@@ -106,4 +106,30 @@ bool audio_checkPathCompatibility(const enum AudioSource p1Source,
     uint8_t p2Index = (p2Source * 3) + p2Sink;
 
     return pathCompatibilityMatrix[p1Index][p2Index] == 1;
+}
+
+void audio_mute_sink(const enum AudioSink sink)
+{
+    switch (sink)
+    {
+        case SINK_SPK:
+            gpio_setPin(SPK_MUTE);
+            break;
+        case SINK_RTX:
+        case SINK_MCU:
+            break;
+    }
+}
+
+void audio_unmute_sink(const enum AudioSink sink)
+{
+    switch (sink)
+    {
+        case SINK_SPK:
+            gpio_clearPin(SPK_MUTE);
+            break;
+        case SINK_RTX:
+        case SINK_MCU:
+            break;
+    }
 }

--- a/platform/drivers/audio/audio_linux.c
+++ b/platform/drivers/audio/audio_linux.c
@@ -125,3 +125,13 @@ bool audio_checkPathCompatibility(const enum AudioSource p1Source,
 
     return pathCompatibilityMatrix[p1Index][p2Index] == 1;
 }
+
+void audio_mute_sink(const enum AudioSink sink)
+{
+    (void) sink;
+}
+
+void audio_unmute_sink(const enum AudioSink sink)
+{
+    (void) sink;
+}

--- a/platform/drivers/audio/audio_ttwrplus.c
+++ b/platform/drivers/audio/audio_ttwrplus.c
@@ -89,3 +89,13 @@ bool audio_checkPathCompatibility(const enum AudioSource p1Source,
     // Disallow all the other path combinations
     return false;
 }
+
+void audio_mute_sink(const enum AudioSink sink)
+{
+    (void) sink;
+}
+
+void audio_unmute_sink(const enum AudioSink sink)
+{
+    (void) sink;
+}


### PR DESCRIPTION
This adds a wrapper for platform specific mute/unmute logic.
I implemented the functions to mute/unmute for the MD* and Module17 devices.

The mute/unmute functions are used in the M17 OpMode to mute the speaker when not receiving valid M17.

This will fix #209