### PR TITLE
Allow skipping key lock when only hash key is pressed

### DIFF
--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -1430,7 +1430,7 @@ void ui_updateFSM(bool *sync_rtx)
                 // Break out of the FSM if the keypad is locked but allow the
                 // use of the hash key in FM mode for the 1750Hz tone.
                 bool skipLock =  (state.channel.mode == OPMODE_FM)
-                              && ((msg.keys & KEY_HASH) != 0);
+                              && ((msg.keys & KEY_HASH) == KEY_HASH);
 
                 if ((ui_state.input_locked == true) && (skipLock == false))
                     break;


### PR DESCRIPTION
This improves 3a2bac3e7e0670d5e5f743d465cb10678c5cd7e8 by only skipping the key lock when the only key pressed is the hash key.

This fixes some issues where it was possible to get key presses past the key lock when holding the hash key.