### PR TITLE
Multiple linux targets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,8 +36,8 @@ jobs:
           meson setup --cross-file cross_arm.txt build_arm
       - name: Compile linux
         run: |
-          meson compile -C build_linux openrtx_linux_default_large
-          meson compile -C build_linux openrtx_linux_default_small
+          meson compile -C build_linux openrtx_linux
+          meson compile -C build_linux openrtx_linux_smallscreen
           meson compile -C build_linux openrtx_linux_mod17
       - name: Compile arm targets
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,10 @@ jobs:
           meson setup build_linux
           meson setup --cross-file cross_arm.txt build_arm
       - name: Compile linux
-        run: meson compile -C build_linux openrtx_linux
+        run: |
+          meson compile -C build_linux openrtx_linux_default_large
+          meson compile -C build_linux openrtx_linux_default_small
+          meson compile -C build_linux openrtx_linux_mod17
       - name: Compile arm targets
         run: |
           export PATH=$PATH:/tmp/OpenGD77/tools/Python/FirmwareLoader:/tmp/OpenGD77/firmware/tools

--- a/meson.build
+++ b/meson.build
@@ -826,8 +826,8 @@ endforeach
 ## ----------------------------------- Unit Tests ------------------------------
 ##
 
-unit_test_opts = {'c_args'             : linux_c_args,
-                  'cpp_args'           : linux_cpp_args,
+unit_test_opts = {'c_args'             : linux_default_large_c_args,
+                  'cpp_args'           : linux_default_large_cpp_args,
                   'include_directories': linux_inc,
                   'dependencies'       : [sdl_dep, threads_dep, pulse_dep, codec2_dep],
                   'link_args'          : linux_l_args}

--- a/meson.build
+++ b/meson.build
@@ -279,25 +279,25 @@ linux_inc = ['platform/targets/linux',
 
 linux_def = {'PLATFORM_LINUX': '', 'VP_USE_FILESYSTEM':''}
 
-#
-# Standard UI
-#
-linux_src += ui_src_default
-linux_def += {'SCREEN_WIDTH': '160', 'SCREEN_HEIGHT': '128', 'PIX_FMT_RGB565': ''}
-
-#
-# Module17 UI
-#
-# linux_src += ui_src_module17
-# linux_def += {'SCREEN_WIDTH': '128', 'SCREEN_HEIGHT': '64', 'PIX_FMT_BW': ''}
-
-
 sdl_dep     = dependency('SDL2',     required: false)
 threads_dep = dependency('threads',  required: false)
 pulse_dep   = dependency('libpulse', required: false)
 linux_src  += openrtx_src
 linux_inc  += openrtx_inc
 linux_def  += openrtx_def
+
+#
+# Standard UI
+#
+linux_default_src = linux_src + ui_src_default
+linux_default_large_def = linux_def + {'SCREEN_WIDTH': '160', 'SCREEN_HEIGHT': '128', 'PIX_FMT_RGB565': ''}
+linux_default_small_def = linux_def + {'SCREEN_WIDTH': '128', 'SCREEN_HEIGHT': '64', 'PIX_FMT_BW': ''}
+
+#
+# Module17 UI
+#
+linux_mod17_src = linux_src + ui_src_module17
+linux_mod17_def = linux_def + {'SCREEN_WIDTH': '128', 'SCREEN_HEIGHT': '64', 'PIX_FMT_BW': ''}
 
 linux_c_args   = ['-ffunction-sections', '-fdata-sections']
 linux_cpp_args = ['-ffunction-sections', '-fdata-sections', '-std=c++14']
@@ -427,13 +427,40 @@ mod17_def += openrtx_def + stm32f405_def + miosix_cm4f_def
 ## -------------------------- Compilation arguments ----------------------------
 ##
 
-foreach k, v : linux_def
+linux_default_large_c_args = linux_c_args
+linux_default_large_cpp_args = linux_cpp_args
+linux_default_small_c_args = linux_c_args
+linux_default_small_cpp_args = linux_cpp_args
+linux_mod17_c_args = linux_c_args
+linux_mod17_cpp_args = linux_cpp_args
+
+foreach k, v : linux_default_large_def
   if v == ''
-    linux_c_args   += '-D@0@'.format(k)
-    linux_cpp_args += '-D@0@'.format(k)
+    linux_default_large_c_args   += '-D@0@'.format(k)
+    linux_default_large_cpp_args += '-D@0@'.format(k)
   else
-    linux_c_args   += '-D@0@=@1@'.format(k, v)
-    linux_cpp_args += '-D@0@=@1@'.format(k, v)
+    linux_default_large_c_args   += '-D@0@=@1@'.format(k, v)
+    linux_default_large_cpp_args += '-D@0@=@1@'.format(k, v)
+  endif
+endforeach
+
+foreach k, v : linux_default_small_def
+  if v == ''
+    linux_default_small_c_args   += '-D@0@'.format(k)
+    linux_default_small_cpp_args += '-D@0@'.format(k)
+  else
+    linux_default_small_c_args   += '-D@0@=@1@'.format(k, v)
+    linux_default_small_cpp_args += '-D@0@=@1@'.format(k, v)
+  endif
+endforeach
+
+foreach k, v : linux_mod17_def
+  if v == ''
+    linux_mod17_c_args   += '-D@0@'.format(k)
+    linux_mod17_cpp_args += '-D@0@'.format(k)
+  else
+    linux_mod17_c_args   += '-D@0@=@1@'.format(k, v)
+    linux_mod17_cpp_args += '-D@0@=@1@'.format(k, v)
   endif
 endforeach
 
@@ -491,13 +518,31 @@ foreach k, v : mod17_def
   endif
 endforeach
 
-linux_opts = {
-  'sources'            : linux_src,
+linux_default_large_opts = {
+  'sources'            : linux_default_src,
   'include_directories': linux_inc,
   'dependencies'       : [sdl_dep, threads_dep, pulse_dep, codec2_dep],
-  'c_args'             : linux_c_args,
-  'cpp_args'           : linux_cpp_args,
+  'c_args'             : linux_default_large_c_args,
+  'cpp_args'           : linux_default_large_cpp_args,
   'link_args'          : linux_l_args
+}
+
+linux_default_small_opts = {
+    'sources'            : linux_default_src,
+    'include_directories': linux_inc,
+    'dependencies'       : [sdl_dep, threads_dep, pulse_dep, codec2_dep],
+    'c_args'             : linux_default_small_c_args,
+    'cpp_args'           : linux_default_small_cpp_args,
+    'link_args'          : linux_l_args
+}
+
+linux_mod17_opts = {
+    'sources'            : linux_mod17_src,
+    'include_directories': linux_inc,
+    'dependencies'       : [sdl_dep, threads_dep, pulse_dep, codec2_dep],
+    'c_args'             : linux_mod17_c_args,
+    'cpp_args'           : linux_mod17_cpp_args,
+    'link_args'          : linux_l_args
 }
 
 md3x0_opts = {
@@ -575,8 +620,18 @@ ttwrplus_opts = {
 
 targets = [
   {
-    'name'     : 'linux',
-    'opts'     : linux_opts,
+    'name'     : 'linux_default_large',
+    'opts'     : linux_default_large_opts,
+    'flashable': false
+  },
+  {
+    'name'     : 'linux_default_small',
+    'opts'     : linux_default_small_opts,
+    'flashable': false
+  },
+  {
+    'name'     : 'linux_mod17',
+    'opts'     : linux_mod17_opts,
     'flashable': false
   },
   {

--- a/meson.build
+++ b/meson.build
@@ -290,8 +290,10 @@ linux_def  += openrtx_def
 # Standard UI
 #
 linux_default_src = linux_src + ui_src_default
-linux_default_large_def = linux_def + {'SCREEN_WIDTH': '160', 'SCREEN_HEIGHT': '128', 'PIX_FMT_RGB565': ''}
-linux_default_small_def = linux_def + {'SCREEN_WIDTH': '128', 'SCREEN_HEIGHT': '64', 'PIX_FMT_BW': ''}
+linux_default_large_def = linux_def + {'SCREEN_WIDTH': '160', 'SCREEN_HEIGHT': '128', 'PIX_FMT_RGB565': '',
+                                       'GPS_PRESENT': '', 'RTC_PRESENT': ''}
+linux_default_small_def = linux_def + {'SCREEN_WIDTH': '128', 'SCREEN_HEIGHT': '64', 'PIX_FMT_BW': '',
+                                       'GPS_PRESENT': '', 'RTC_PRESENT': ''}
 
 #
 # Module17 UI

--- a/meson.build
+++ b/meson.build
@@ -622,12 +622,12 @@ ttwrplus_opts = {
 
 targets = [
   {
-    'name'     : 'linux_default_large',
+    'name'     : 'linux',
     'opts'     : linux_default_large_opts,
     'flashable': false
   },
   {
-    'name'     : 'linux_default_small',
+    'name'     : 'linux_smallscreen',
     'opts'     : linux_default_small_opts,
     'flashable': false
   },

--- a/platform/targets/linux/hwconfig.h
+++ b/platform/targets/linux/hwconfig.h
@@ -22,12 +22,6 @@
 extern "C" {
 #endif
 
-/* Device has a working real time clock */
-#define RTC_PRESENT
-
-/* Device supports an optional GPS chip */
-#define GPS_PRESENT
-
 /* Screen has adjustable brightness */
 #define SCREEN_BRIGHTNESS
 

--- a/platform/targets/linux/platform.c
+++ b/platform/targets/linux/platform.c
@@ -38,7 +38,8 @@ static const hwInfo_t hwInfo =
     .uhf_maxFreq = 480,
     .uhf_minFreq = 400,
     .uhf_band    = 1,
-    .name        = "Linux"
+    .name        = "Linux",
+    .hw_version  = 1
 };
 
 


### PR DESCRIPTION
This PR separates the linux targets.
This allows to build 3 different linux executables.
The old linux target.
The `_smallscreen` target uses the smaller screen size and the black and white screen config.
The `_mod17` target behaves like the Module 17 0.1e.
For this the hardware config of the linux target was adjusted to not include the GPS and RTC defines.
They are now defined for each target separately, as the Module 17 does not have those.
Additionally the hwversion for the linux build is set to 1.
This does not change anything for the default UI, but in the mod17 UI it shows the menus like revision 0.1e.

I am open for better naming of the default ui targets.

Once this is merged, I can update the documentation for the website. 