### PR TITLE
Add button info to module 17 callsign entry

### DIFF
--- a/openrtx/src/ui/module17/ui_main.c
+++ b/openrtx/src/ui/module17/ui_main.c
@@ -158,9 +158,20 @@ void _ui_drawModeInfo(ui_state_t* ui_state)
                 // Print M17 Destination ID on line 2
                 gfx_print(layout.line3_pos, layout.line3_font, TEXT_ALIGN_CENTER,
                           color_white, "%s", dst);
-                // Menu
-                gfx_print(layout.line5_pos, layout.line5_font, TEXT_ALIGN_RIGHT,
-                          color_white, "Menu");
+                if (ui_state->edit_mode)
+                {
+                    // Print Button Info
+                    gfx_print(layout.line5_pos, layout.line5_font, TEXT_ALIGN_LEFT,
+                              color_white, "Cancel");
+                    gfx_print(layout.line5_pos, layout.line5_font, TEXT_ALIGN_RIGHT,
+                              color_white, "Accept");
+                }
+                else
+                {
+                    // Menu
+                    gfx_print(layout.line5_pos, layout.line5_font, TEXT_ALIGN_RIGHT,
+                              color_white, "Menu");
+                }
                 break;
             }
         }

--- a/openrtx/src/ui/module17/ui_menu.c
+++ b/openrtx/src/ui/module17/ui_menu.c
@@ -552,6 +552,11 @@ void _ui_drawSettingsM17(ui_state_t* ui_state)
         gfx_printLine(1, 1, layout.top_h, SCREEN_HEIGHT - layout.bottom_h,
                       layout.horizontal_pad, layout.input_font,
                       TEXT_ALIGN_CENTER, color_white, ui_state->new_callsign);
+        // Print Button Info
+        gfx_print(layout.line5_pos, layout.line5_font, TEXT_ALIGN_LEFT,
+                  color_white, "Cancel");
+        gfx_print(layout.line5_pos, layout.line5_font, TEXT_ALIGN_RIGHT,
+                  color_white, "Accept");
     }
     else
     {


### PR DESCRIPTION
This  adds some text to the bottom of the screen when editing callsigns on the module 17 to show the function of the enter and escape buttons.
