### PR TITLE
Fix meson setup for windows

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -707,12 +707,22 @@ foreach t : targets
   # ttwrplus is a Zephyr target, we compile it using west and package it in uf2 format
   if name == 'openrtx_ttwrplus'
 
-      txt = custom_target('Copy CMakeLists.txt',
-                          input            : 'CMakeLists.txt',
-                          output           : 'CMakeLists.txt',
-                          command          : ['cp', '@INPUT@', '@OUTPUT@'],
-                          install          : false,
-                          build_by_default : true)
+      if build_machine.system() == 'linux'
+        txt = custom_target('Copy CMakeLists.txt',
+                    input : 'CMakeLists.txt',
+                    output :  'CMakeLists.txt',
+                    command : ['cp', '@INPUT@', '@OUTPUT@'],
+                    install : false,
+                    build_by_default : true)
+      elif build_machine.system() == 'windows'
+        txt = custom_target('Copy CMakeLists.txt',
+                    input : 'CMakeLists.txt',
+                    output :  'CMakeLists.txt',
+                    command : ['xcopy', '@INPUT@', '@OUTPUT@'],
+                    install : false,
+                    build_by_default : true)
+      endif
+      
 
       bin = custom_target(name,
                           input   : txt,


### PR DESCRIPTION
This commit fixes an error on windows when using meson setup.

The problem is that the cp command does not really exist on windows. The fix involves using xcopy when the platform is Windows.
