### PR TITLE
Improve the callsign input of module17 UI

### DIFF
--- a/openrtx/src/ui/module17/ui.c
+++ b/openrtx/src/ui/module17/ui.c
@@ -166,7 +166,7 @@ static const char *symbols_ITU_T_E161_callsign[] =
     ""
 };
 
-static const char symbols_callsign[] = "_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890/- ";
+static const char symbols_callsign[] = "_ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890/-.";
 
 // Calculate number of menu entries
 const uint8_t menu_num = sizeof(menu_items)/sizeof(menu_items[0]);
@@ -738,13 +738,19 @@ void _ui_textInputArrows(char *buf, uint8_t max_len, kbd_msg_t msg)
 
     if (msg.keys & KEY_RIGHT)
     {
-        ui_state.input_position = (ui_state.input_position + 1) % max_len;
-        ui_state.input_set = 0;
+        if (ui_state.input_position < (max_len-1)) {
+            ui_state.input_position = ui_state.input_position + 1;
+            ui_state.input_set = 1;
+        }
     }
     else if (msg.keys & KEY_LEFT)
     {
-        ui_state.input_position = (ui_state.input_position - 1) % max_len;
-        ui_state.input_set = 0;
+        if (ui_state.input_position > 0) {
+            buf[ui_state.input_position] = '\0';
+            ui_state.input_position = ui_state.input_position - 1;
+        }
+        // get index of current selected character in symbol table
+        ui_state.input_set = strcspn(symbols_callsign, &buf[ui_state.input_position]);
     }
     else if (msg.keys & KEY_UP)
         ui_state.input_set = (ui_state.input_set + 1) % num_symbols;


### PR DESCRIPTION
This will change the behavior of the left and right button in callsign input: The right button will add a new character to the input starting at `A`. The right button will stop at the maximum allowed length. The left button will delete the current character.
The left button will go back one character and make it editable again. The left button will not do anything when only one character is displayed.