### PR TITLE
Allow git commit as version to fix artifacts not showing any version info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ set(OPENRTX_ROOT ${CMAKE_CURRENT_LIST_DIR})
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(openrtx)
 
-execute_process(COMMAND git describe --tags --dirty
+execute_process(COMMAND git describe --tags --dirty --always
                 OUTPUT_VARIABLE GIT_VER_ID
                 ERROR_QUIET
                 OUTPUT_STRIP_TRAILING_WHITESPACE)

--- a/meson.build
+++ b/meson.build
@@ -138,7 +138,7 @@ subdir('lib/miosix-kernel')
 ##
 ## Current git commit or tag
 ##
-r = run_command('git', 'describe', '--tags', '--dirty')
+r = run_command('git', 'describe', '--tags', '--dirty', '--always')
 if r.returncode() != 0
   # it failed
 endif


### PR DESCRIPTION
At the moment the github action artifacts have no version listed on the info screen. We use the `--always` flag, as this allows `git describe` to show only the commit if nothing else is available.

The alternative solution would be to always checkout more of the repository, instead of only a single commit.