### PR TITLE
Fix compiler warnings for linux and mduv3x0 targets

### DIFF
--- a/openrtx/src/core/audio_codec.c
+++ b/openrtx/src/core/audio_codec.c
@@ -57,8 +57,10 @@ static uint64_t         dataBuffer[BUF_SIZE];
 static const uint8_t micGainPre  = 4;
 static const uint8_t micGainPost = 3;
 #else
+#ifndef PLATFORM_LINUX
 static const uint8_t micGainPre  = 8;
 static const uint8_t micGainPost = 4;
+#endif
 #endif
 
 static void *encodeFunc(void *arg);
@@ -189,7 +191,7 @@ static void *encodeFunc(void *arg)
 {
 
     streamId        iStream;
-    pathId          iPath = (pathId) arg;
+    pathId          iPath = *((pathId*) arg);
     stream_sample_t audioBuf[320];
     struct CODEC2   *codec2;
     filter_state_t  dcrState;
@@ -269,7 +271,7 @@ static void *encodeFunc(void *arg)
 static void *decodeFunc(void *arg)
 {
     streamId        oStream;
-    pathId          oPath = (pathId) arg;
+    pathId          oPath = *((pathId*) arg);
     stream_sample_t audioBuf[320];
     struct CODEC2   *codec2;
 
@@ -411,7 +413,7 @@ static bool startThread(const pathId path, void *(*func) (void *))
     #endif
 
     // Start thread
-    int ret = pthread_create(&codecThread, &codecAttr, func, ((void *) audioPath));
+    int ret = pthread_create(&codecThread, &codecAttr, func, &audioPath);
     if(ret < 0)
         running = false;
 

--- a/openrtx/src/core/voicePromptUtils.c
+++ b/openrtx/src/core/voicePromptUtils.c
@@ -177,7 +177,7 @@ void vp_announcePower(const uint32_t power, const vpQueueFlags_t flags)
     // Compute x.y format avoiding to pull in floating point math.
     // Remember that power is expressed in mW!
     char buffer[16] = "\0";
-    sniprintf(buffer, 16, "%lu.%lu", (power / 1000), (power % 1000) / 100);
+    sniprintf(buffer, 16, "%lu.%lu", (power / 1000lu), (power % 1000lu) / 100lu);
 
     vp_queueString(buffer, vpAnnounceCommonSymbols);
     vp_queuePrompt(PROMPT_WATTS);

--- a/openrtx/src/rtx/OpMode_M17.cpp
+++ b/openrtx/src/rtx/OpMode_M17.cpp
@@ -78,6 +78,7 @@ void OpMode_M17::disable()
 
 void OpMode_M17::update(rtxStatus_t *const status, const bool newCfg)
 {
+    (void) newCfg;
     #if defined(PLATFORM_MD3x0) || defined(PLATFORM_MDUV3x0)
     //
     // Invert TX phase for all MDx models.

--- a/openrtx/src/ui/default/ui_main.c
+++ b/openrtx/src/ui/default/ui_main.c
@@ -193,7 +193,7 @@ void _ui_drawFrequency()
 
     // Print big numbers frequency
     char freq_str[16] = {0};
-    sniprintf(freq_str, sizeof(freq_str), "%lu.%lu", (freq / 1000000), (freq % 1000000));
+    sniprintf(freq_str, sizeof(freq_str), "%lu.%lu", (freq / 1000000lu), (freq % 1000000lu));
     stripTrailingZeroes(freq_str);
 
     gfx_print(layout.line3_large_pos, layout.line3_large_font, TEXT_ALIGN_CENTER,

--- a/openrtx/src/ui/default/ui_menu.c
+++ b/openrtx/src/ui/default/ui_menu.c
@@ -19,9 +19,9 @@
  ***************************************************************************/
 
 #include <stdio.h>
-#include <stdint.h>
 #include <string.h>
 #include <stdlib.h>
+#include <inttypes.h>
 #include <utils.h>
 #include <ui/ui_default.h>
 #include <interfaces/nvmem.h>
@@ -516,7 +516,7 @@ int _ui_getInfoValueName(char *buf, uint8_t max_len, uint8_t index)
             sniprintf(buf, max_len, "%d%%", last_state.charge);
             break;
         case 3: // RSSI
-            sniprintf(buf, max_len, "%ddBm", last_state.rssi);
+            sniprintf(buf, max_len, "%"PRIu32"dBm", last_state.rssi);
             break;
         case 4: // Heap usage
             sniprintf(buf, max_len, "%dB", getHeapSize() - getCurrentFreeHeap());

--- a/platform/drivers/display/display_libSDL.c
+++ b/platform/drivers/display/display_libSDL.c
@@ -43,6 +43,7 @@ extern chan_t fb_sync;       /* Shared channel to send a frame buffer update */
 /* Custom SDL Event to adjust backlight */
 extern Uint32 SDL_Backlight_Event;
 
+#ifndef CONFIG_PIX_FMT_RGB565
 /**
  * @internal
  * Internal helper function which fetches pixel at position (x, y) from framebuffer
@@ -52,6 +53,7 @@ static uint32_t fetchPixelFromFb(unsigned int x, unsigned int y, void *fb)
 {
     (void) x;
     (void) y;
+    (void) fb;
     uint32_t pixel = 0;
 
     #ifdef CONFIG_PIX_FMT_BW
@@ -78,7 +80,7 @@ static uint32_t fetchPixelFromFb(unsigned int x, unsigned int y, void *fb)
 
     return pixel;
 }
-
+#endif
 
 void display_init()
 {


### PR DESCRIPTION
Whilst following the instructions for compiling for the targets mentioned in the title, I noticed some compilation warnings. This didn't prevent the compilation to succeed, but I figured I'd see if I can help by tidying these up.

All warnings during normal compilation for these targets are now gone for me with this changeset. If any clarification or rationale is needed for the changes I'll happily elaborate. If these's any contribution guidelines I've missed and violated, please let me know.

I do not currently have hardware to test on.