### PR TITLE
Add smallscreen and mod17 linux binaries to artifacts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,8 @@ jobs:
           path: |
             ${{github.workspace}}/build_arm/openrtx_*_wrap
             ${{github.workspace}}/build_linux/openrtx_linux
+            ${{github.workspace}}/build_linux/openrtx_linux_smallscreen
+            ${{github.workspace}}/build_linux/openrtx_linux_mod17
   unit-test:
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
This adds the already build smallscreen and mod17 linux binaries to the github actions artifacts.