### PR TITLE
Ensure RSSI is int32

### DIFF
--- a/openrtx/src/ui/default/ui_menu.c
+++ b/openrtx/src/ui/default/ui_menu.c
@@ -516,7 +516,7 @@ int _ui_getInfoValueName(char *buf, uint8_t max_len, uint8_t index)
             sniprintf(buf, max_len, "%d%%", last_state.charge);
             break;
         case 3: // RSSI
-            sniprintf(buf, max_len, "%"PRIu32"dBm", last_state.rssi);
+            sniprintf(buf, max_len, "%"PRIi32"dBm", last_state.rssi);
             break;
         case 4: // Heap usage
             sniprintf(buf, max_len, "%dB", getHeapSize() - getCurrentFreeHeap());


### PR DESCRIPTION
This will fix the RSSI display in the info section.
The format string used uint32 before which underflowed.