### PR TITLE
Moduke17 Keyboard: Do not enable SMBus timeout while using the I2C mode

### DIFF
--- a/platform/drivers/keyboard/cap1206.c
+++ b/platform/drivers/keyboard/cap1206.c
@@ -27,7 +27,7 @@ int cap1206_init(const struct i2cDevice *i2c)
 
     // Config 1 register, enable SMB timeout
     data[0] = CAP1206_CONFIG_1;
-    data[1] = CAP1206_CONFIG_1_TIMEOUT | CAP1206_CONFIG_1_DIS_DIG_NOISE;
+    data[1] = /*CAP1206_CONFIG_1_TIMEOUT |*/ CAP1206_CONFIG_1_DIS_DIG_NOISE;
     ret = i2c_write(i2c, CAP1206_ADDR, data, 2, true);
     if(ret < 0)
     {


### PR DESCRIPTION
Enabling SMBus timeout in the capacitive touch sensor and not in the MCU would cause the CTS to reset and the MCU expecting the transaction to keep going, locking-up the device. Timeout should be re-enabled when SMBus will be implemented.

LGTM