### PR TITLE
Fix issue with changing last character in callsign

### DIFF
--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -1093,11 +1093,12 @@ static void _ui_textInputReset(char *buf)
 static void _ui_textInputKeypad(char *buf, uint8_t max_len, kbd_msg_t msg,
                          bool callsign)
 {
-    if(ui_state.input_position >= max_len)
-        return;
     long long now = getTick();
     // Get currently pressed number key
     uint8_t num_key = input_getPressedNumber(msg);
+
+    bool key_timeout = ((now - ui_state.last_keypress) >= input_longPressTimeout);
+    bool same_key = ui_state.input_number == num_key;
     // Get number of symbols related to currently pressed key
     uint8_t num_symbols = 0;
     if(callsign)
@@ -1105,11 +1106,14 @@ static void _ui_textInputKeypad(char *buf, uint8_t max_len, kbd_msg_t msg,
     else
         num_symbols = strlen(symbols_ITU_T_E161[num_key]);
 
+    if((ui_state.input_position > max_len) || ((ui_state.input_position == max_len) && (key_timeout || !same_key)))
+        return;
+
     // Skip keypad logic for first keypress
     if(ui_state.last_keypress != 0)
     {
         // Same key pressed and timeout not expired: cycle over chars of current key
-        if((ui_state.input_number == num_key) && ((now - ui_state.last_keypress) < input_longPressTimeout))
+        if(same_key && !key_timeout)
         {
             ui_state.input_set = (ui_state.input_set + 1) % num_symbols;
         }

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -1106,7 +1106,8 @@ static void _ui_textInputKeypad(char *buf, uint8_t max_len, kbd_msg_t msg,
     else
         num_symbols = strlen(symbols_ITU_T_E161[num_key]);
 
-    if((ui_state.input_position > max_len) || ((ui_state.input_position == max_len) && (key_timeout || !same_key)))
+    // Return if max length is reached or finished editing last character
+    if((ui_state.input_position >= max_len) || ((ui_state.input_position == (max_len-1)) && (key_timeout || !same_key)))
         return;
 
     // Skip keypad logic for first keypress


### PR DESCRIPTION
When editing the callsign on a device with keypad, when entering the last character the same key did not rotate through the possible values.
We do not need to return early when we are at the last character and the same key is pressed multiple times.

Additionally this fixes an issue which allowed users entering n+1 characters on a n character string.