### PR TITLE
Implement a CAT command to control PTT

### DIFF
--- a/openrtx/include/core/state.h
+++ b/openrtx/include/core/state.h
@@ -60,6 +60,7 @@ typedef struct
     bool       backup_eflash;
     bool       restore_eflash;
     bool       txDisable;
+    bool       ptt;
     uint8_t    step_index;
 }
 state_t;

--- a/openrtx/include/rtx/rtx.h
+++ b/openrtx/include/rtx/rtx.h
@@ -38,7 +38,8 @@ typedef struct
             txDisable : 1,  /**< Disable TX operation          */
             scan      : 1,  /**< Scan enabled                  */
             opStatus  : 2,  /**< Operating status (OFF, ...)   */
-            _padding  : 2;  /**< Padding to 8 bits             */
+            ptt       : 1,  /**< Override platform PTT button  */
+            _padding  : 1;  /**< Padding to 8 bits             */
 
     freq_t rxFrequency;     /**< RX frequency, in Hz           */
     freq_t txFrequency;     /**< TX frequency, in Hz           */

--- a/openrtx/src/core/openrtx.c
+++ b/openrtx/src/core/openrtx.c
@@ -95,6 +95,7 @@ void *openrtx_run()
 
     // Device thread terminated, complete shutdown sequence
     state_terminate();
+    rtxlink_terminate();
     platform_terminate();
 
     return NULL;

--- a/openrtx/src/core/rtxlink.c
+++ b/openrtx/src/core/rtxlink.c
@@ -136,7 +136,10 @@ void rtxlink_task()
 
 void rtxlink_terminate()
 {
+    if(cDev == NULL)
+        return;
 
+    chardev_terminate(cDev);
 }
 
 int rtxlink_send(const enum ProtocolID proto, const void *data, const size_t len)

--- a/openrtx/src/core/rtxlink_cat.c
+++ b/openrtx/src/core/rtxlink_cat.c
@@ -51,6 +51,7 @@ enum catCommand
     CAT_OP_MODE      = 0x4F4D,
     CAT_M17_CALLSIGN = 0x4D43,
     CAT_M17_DEST     = 0x4D44,
+    CAT_PTT          = 0x5054,
 
     // Miscellaneous CAT command
     CAT_POWER_CYCLE  = 0x5043,
@@ -136,6 +137,13 @@ static size_t catCommandGet(const uint8_t *args, const size_t len,
             ret += 1;
             break;
 
+        case CAT_PTT:
+
+            status = rtx_getCurrentStatus();
+            reply[1] = status.opStatus;
+            ret += 1;
+            break;
+
         case CAT_M17_CALLSIGN:
 
             status = rtx_getCurrentStatus();
@@ -167,6 +175,8 @@ static void catConfigureRtx(void)
     rtxStatus_t rtx_cfg;
 
     pthread_mutex_lock(&rtx_mutex);
+    rtx_cfg.opStatus    = state.rtxStatus;
+    rtx_cfg.ptt         = state.ptt;
     rtx_cfg.opMode      = state.channel.mode;
     rtx_cfg.bandwidth   = state.channel.bandwidth;
     rtx_cfg.rxFrequency = state.channel.rx_frequency;
@@ -248,6 +258,17 @@ static size_t catCommandSet(const uint8_t *args, const size_t len,
             }
             pthread_mutex_unlock(&state_mutex);
             catConfigureRtx();
+            break;
+
+        case CAT_PTT:
+
+            if (args[2] <= RTX_TX)
+            {
+                pthread_mutex_lock(&state_mutex);
+                state.ptt = args[2] == TX ? 1 : 0;
+                pthread_mutex_unlock(&state_mutex);
+                catConfigureRtx();
+            }
             break;
 
         case CAT_M17_CALLSIGN:

--- a/openrtx/src/core/rtxlink_cat.c
+++ b/openrtx/src/core/rtxlink_cat.c
@@ -175,7 +175,6 @@ static void catConfigureRtx(void)
     rtxStatus_t rtx_cfg;
 
     pthread_mutex_lock(&rtx_mutex);
-    rtx_cfg.opStatus    = state.rtxStatus;
     rtx_cfg.ptt         = state.ptt;
     rtx_cfg.opMode      = state.channel.mode;
     rtx_cfg.bandwidth   = state.channel.bandwidth;

--- a/openrtx/src/rtx/OpMode_FM.cpp
+++ b/openrtx/src/rtx/OpMode_FM.cpp
@@ -138,8 +138,10 @@ void OpMode_FM::update(rtxStatus_t *const status, const bool newCfg)
     }
 
     // TX logic
-    if(platform_getPttStatus() && (status->opStatus != TX) &&
-                                  (status->txDisable == 0))
+    if(platform_getPttStatus())
+        status->ptt = 0;
+    if((status->ptt || platform_getPttStatus()) && (status->opStatus != TX) &&
+                                                   (status->txDisable == 0))
     {
         audioPath_release(rxAudioPath);
         radio_disableRtx();
@@ -150,7 +152,7 @@ void OpMode_FM::update(rtxStatus_t *const status, const bool newCfg)
         status->opStatus = TX;
     }
 
-    if(!platform_getPttStatus() && (status->opStatus == TX))
+    if((!status->ptt && !platform_getPttStatus()) && (status->opStatus == TX))
     {
         audioPath_release(txAudioPath);
         radio_disableRtx();

--- a/openrtx/src/rtx/OpMode_M17.cpp
+++ b/openrtx/src/rtx/OpMode_M17.cpp
@@ -108,6 +108,9 @@ void OpMode_M17::update(rtxStatus_t *const status, const bool newCfg)
     invertRxPhase = (mod17CalData.rx_invert == 1) ? true : false;
     #endif
 
+    if(platform_getPttStatus())
+        status->ptt = 0;
+
     // Main FSM logic
     switch(status->opStatus)
     {
@@ -164,8 +167,7 @@ void OpMode_M17::offState(rtxStatus_t *const status)
         status->opStatus = RX;
         return;
     }
-
-    if(platform_getPttStatus() && (status->txDisable == 0))
+    if((status->ptt || platform_getPttStatus()) && (status->txDisable == 0))
     {
         startTx = true;
         status->opStatus = TX;
@@ -281,7 +283,7 @@ void OpMode_M17::rxState(rtxStatus_t *const status)
 
     locked = lock;
 
-    if(platform_getPttStatus())
+    if(status->ptt || platform_getPttStatus())
     {
         demodulator.stopBasebandSampling();
         locked = false;
@@ -342,7 +344,7 @@ void OpMode_M17::txState(rtxStatus_t *const status)
     codec_popFrame(dataFrame.data(),     true);
     codec_popFrame(dataFrame.data() + 8, true);
 
-    if(platform_getPttStatus() == false)
+    if((status->ptt == 0) && (platform_getPttStatus() == false))
     {
         lastFrame = true;
         startRx   = true;

--- a/platform/mcu/x86_64/drivers/pty.c
+++ b/platform/mcu/x86_64/drivers/pty.c
@@ -50,6 +50,13 @@ static int pty_init(const struct chardev *dev)
 
     *((int *)dev->data) = ptyFd;
 
+    char *pty_link = getenv("OPENRTX_PTY_LINK");
+    if (pty_link != NULL) {
+        if (symlink(ptsname(ptyFd), pty_link))
+            return errno;
+        else
+            printf("Linked pseudoTTY to %s\n", pty_link);
+    }
     return 0;
 }
 
@@ -61,6 +68,10 @@ static int pty_terminate(const struct chardev *dev)
 
     close(ptyFd);
     *((int *)dev->data) = -1;
+
+    char *pty_link = getenv("OPENRTX_PTY_LINK");
+    if (pty_link != NULL)
+        unlink(pty_link);
 
     return 0;
 }


### PR DESCRIPTION
This implements the GPT (get-ptt) and SPT (set-ptt) CAT commands.

You can enable/disable PTT over CAT.  If you enabled it over CAT, and then press and release the PTT button on the real device, it will stop transmitting (button overrides CAT).  If you press the hardware PTT button, and send the CAT command to disable PTT, nothing happens, i.e. the hardware PTT button always "wins" over the CAT command.

Tested on openrtx_linux with trx-control.