### PR TITLE
Predictable pty

### DIFF
--- a/platform/mcu/x86_64/drivers/pty.c
+++ b/platform/mcu/x86_64/drivers/pty.c
@@ -50,6 +50,13 @@ static int pty_init(const struct chardev *dev)
 
     *((int *)dev->data) = ptyFd;
 
+    char *pty_link = getenv("OPENRTX_PTY_LINK");
+    if (pty_link != NULL) {
+        if (symlink(ptsname(ptyFd), pty_link))
+            return errno;
+        else
+            printf("Linked pseudoTTY to %s\n", pty_link);
+    }
     return 0;
 }
 
@@ -61,6 +68,10 @@ static int pty_terminate(const struct chardev *dev)
 
     close(ptyFd);
     *((int *)dev->data) = -1;
+
+    char *pty_link = getenv("OPENRTX_PTY_LINK");
+    if (pty_link != NULL)
+        unlink(pty_link);
 
     return 0;
 }


### PR DESCRIPTION
On Linux, if the environment variable OPENRTX_PTY_LINK is set to a writeable path, create a symlink there that points to the CAT device.  This is similar to what socat(1) does with the "link" option.