### PR TITLE
Properly tear down rtxlink and the chardev when terminating OpenRTX

### DIFF
--- a/openrtx/src/core/openrtx.c
+++ b/openrtx/src/core/openrtx.c
@@ -95,6 +95,7 @@ void *openrtx_run()
 
     // Device thread terminated, complete shutdown sequence
     state_terminate();
+    rtxlink_terminate();
     platform_terminate();
 
     return NULL;

--- a/openrtx/src/core/rtxlink.c
+++ b/openrtx/src/core/rtxlink.c
@@ -136,7 +136,10 @@ void rtxlink_task()
 
 void rtxlink_terminate()
 {
+    if(cDev == NULL)
+        return;
 
+    chardev_terminate(cDev);
 }
 
 int rtxlink_send(const enum ProtocolID proto, const void *data, const size_t len)


### PR DESCRIPTION
This will properly tear down rtxlink, call cardev terminate and allow for the symlink removal (see other pull request of today)