### PR TITLE
Stream Frame Number in M17 mode rollover fix

### DIFF
--- a/openrtx/src/protocols/M17/M17FrameEncoder.cpp
+++ b/openrtx/src/protocols/M17/M17FrameEncoder.cpp
@@ -83,7 +83,7 @@ uint16_t M17FrameEncoder::encodeStreamFrame(const payload_t& payload,
     M17StreamFrame streamFrame;
 
     streamFrame.setFrameNumber(streamFrameNumber);
-    streamFrameNumber = (streamFrameNumber + 1) & 0x07FF;
+    streamFrameNumber = (streamFrameNumber + 1) & 0x7FFF;
     if(isLast) streamFrame.lastFrame();
     std::copy(payload.begin(), payload.end(), streamFrame.payload().begin());
 


### PR DESCRIPTION
The M17 Specification document sets the maximum value for the Frame Number (FN) to 0x7FFF, therefore adding 1 should roll the counter over to 0x0000. The code within `M17FrameEncoder::encodeStreamFrame()` rolls over `streamFrameNumber` at 0x07FF instead, likely causing sync problems when interoperating with other M17 implementations. The fix proposed in this PR is to replace the maximum value with the right one.