### PR TITLE
Fixed a comment in the `M17FrameDecoder::decodeStream()` function

### DIFF
--- a/openrtx/src/protocols/M17/M17FrameDecoder.cpp
+++ b/openrtx/src/protocols/M17/M17FrameDecoder.cpp
@@ -136,7 +136,7 @@ void M17FrameDecoder::decodeStream(const std::array< uint8_t, 46 >& data)
         // Mark this segment as present
         lsfSegmentMap |= 1 << segmentNum;
 
-        // Check if we have received all the five LICH segments
+        // Check if we have received all the six LICH segments
         if(lsfSegmentMap == 0x3F)
         {
             if(lsfFromLich.valid()) lsf = lsfFromLich;


### PR DESCRIPTION
As per the M17 Specification document, the LSF frame contents are divided into **six** LICH chunks, not five. The code itself has the value right. only the comment is misleading.