### PR TITLE
Fixed uninitialized move in Synchronizer

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -82,6 +82,7 @@ openrtx_inc = ['openrtx/include',
                'platform/drivers/USB',
                'platform/drivers/GPIO',
                'platform/drivers/tones',
+               'platform/drivers/audio',
                'platform/drivers/baseband',
                'platform/drivers/backlight',
                'platform/drivers/chSelector']

--- a/openrtx/include/protocols/M17/Synchronizer.hpp
+++ b/openrtx/include/protocols/M17/Synchronizer.hpp
@@ -41,7 +41,7 @@ public:
      * @param sync_word: symbols of the target syncword.
      */
     Synchronizer(std::array< int8_t, SYNCW_SIZE >&& sync_word) :
-        syncword(std::move(sync_word)) { }
+        syncword(std::move(sync_word)), triggered(false) { }
 
     /**
      * Destructor.
@@ -96,7 +96,7 @@ public:
                     index += 1;
                 }
 
-                if(values[index] >= 0)
+                if(peak >= 0)
                     sign = 1;
                 else
                     sign = -1;

--- a/platform/targets/MD-UV3x0/platform.c
+++ b/platform/targets/MD-UV3x0/platform.c
@@ -28,6 +28,7 @@
 #include <peripherals/rtc.h>
 #include <interfaces/audio.h>
 #include <chSelector.h>
+#include <Cx000_dac.h>
 
 #ifdef CONFIG_SCREEN_BRIGHTNESS
 #include <backlight.h>
@@ -62,7 +63,6 @@ void platform_init()
     nvm_init();                      /* Initialise non volatile memory manager */
     nvm_readCalibData(&calibration); /* Load calibration data                  */
     nvm_readHwInfo(&hwInfo);         /* Load hardware information data         */
-    toneGen_init();                  /* Initialise tone generator              */
     rtc_init();                      /* Initialise RTC                         */
     chSelector_init();               /* Initialise channel selector handler    */
     audio_init();                    /* Initialise audio management module     */
@@ -77,7 +77,6 @@ void platform_terminate()
     /* Shut down all the modules */
     adc1_terminate();
     nvm_terminate();
-    toneGen_terminate();
     chSelector_terminate();
     audio_terminate();
 
@@ -190,20 +189,12 @@ void platform_ledOff(led_t led)
 
 void platform_beepStart(uint16_t freq)
 {
-    // calculate appropriate volume.
-    uint8_t vol = platform_getVolumeLevel();
-    // Since beeps have been requested, we do not want to have 0 volume.
-    // We also do not want the volume to be excessive.
-    if (vol < 10)
-        vol = 5;
-    if (vol > 176)
-        vol = 176;
-    toneGen_beepOn((float)freq, vol, 0);
+    Cx000dac_startBeep(freq);
 }
 
 void platform_beepStop()
 {
-    toneGen_beepOff();
+    Cx000dac_stopBeep();
 }
 
 datetime_t platform_getCurrentTime()


### PR DESCRIPTION
While testing M17Netd code under valgrind (which uses OpenRTX's M17 demodulator), it appeared that there are some jumps or moves depending on uninitialized values. This all comes from the `Synchronizer.hpp` file.

I chased it down to:
1. Variable triggered never initialized in `Synchronizer`.
2. In function `Synchronizer::update()`: the return value for the sign of the sample index is read one past the end of the `values` array

The proposed fixes are:
1. Initialize `triggered` to false in the constructor
2. Return the sign of the `peak` variable (which is equivalent to the `values[sampIndex]` variable which is probably what the code should have been reading in the first place?

I'm not 100% sure on the proposed fix for the second issue so please counter-check my work here.
