### PR TITLE
DM-1701 fixes allowing for proper M17 RF signal generation

### DIFF
--- a/openrtx/include/protocols/M17/M17Modulator.hpp
+++ b/openrtx/include/protocols/M17/M17Modulator.hpp
@@ -113,7 +113,12 @@ private:
     static constexpr size_t M17_SAMPLES_PER_SYMBOL = M17_TX_SAMPLE_RATE / M17_SYMBOL_RATE;
     static constexpr size_t M17_FRAME_SAMPLES      = M17_FRAME_SYMBOLS * M17_SAMPLES_PER_SYMBOL;
 
+    //M17 deviation fix for DM-1701
+    #if defined(PLATFORM_DM1701)
+    static constexpr float  M17_RRC_GAIN          = 18000.0f;
+    #else
     static constexpr float  M17_RRC_GAIN          = 23000.0f;
+    #endif
     static constexpr float  M17_RRC_OFFSET        = 0.0f;
 
     std::array< int8_t, M17_FRAME_SYMBOLS > symbols;

--- a/platform/drivers/baseband/AT1846S_UV3x0.cpp
+++ b/platform/drivers/baseband/AT1846S_UV3x0.cpp
@@ -168,7 +168,8 @@ void AT1846S::setOpMode(const AT1846S_OpMode mode)
         i2c_writeReg16(0x41, 0x4731);
         i2c_writeReg16(0x42, 0x1036);
         i2c_writeReg16(0x43, 0x00BB);
-        i2c_writeReg16(0x58, 0xBCFD);   // Bit 0  = 1: CTCSS LPF bandwidth to 250Hz
+        i2c_writeReg16(0x58, 0xBCFF);   // Bit 0  = 1: CTCSS LPF bandwidth to 250Hz
+                                        // Bit 1  = 1: "voice HPF bypass"
                                         // Bit 3  = 1: bypass CTCSS HPF
                                         // Bit 4  = 1: bypass CTCSS LPF
                                         // Bit 5  = 1: bypass voice LPF

--- a/platform/drivers/baseband/radio_UV3x0.cpp
+++ b/platform/drivers/baseband/radio_UV3x0.cpp
@@ -124,7 +124,11 @@ void radio_setOpmode(const enum opmode mode)
             at1846s.setOpMode(AT1846S_OpMode::DMR); // AT1846S in DMR mode, disables RX filter
             at1846s.setBandwidth(AT1846S_BW::_25);  // Set bandwidth to 25kHz for proper deviation
             C6000.fmMode();                         // HR_C6000 in FM mode
+            #if defined(PLATFORM_DM1701)
+            C6000.setInputGain(-6);                 // Input gain in dB, found experimentally
+            #else
             C6000.setInputGain(+6);                 // Input gain in dB, found experimentally
+            #endif
             break;
 
         default:


### PR DESCRIPTION
The proposed changes reduce the deviation of the M17 baseband signal by lowering the RRC filter's gain and the input gain of the HR_C6000 chip. The changes are applied at compile-time and are based on `#ifdef`s. Additionally, one of the AT1846S registers (0x58) is modified to allow high-pass filter bypass in DMR mode. See the [RDA1846 Programming manual](https://github.com/ZdenekBrichacek/PCB-2way_Radio-AT1846/blob/master/RDA1846_Programming_manual.pdf), page 16 for details.