### PR TITLE
MD9600: Fix Keyboard not working after ADC changes

### DIFF
--- a/platform/drivers/keyboard/keyboard_MD9600.c
+++ b/platform/drivers/keyboard/keyboard_MD9600.c
@@ -178,8 +178,8 @@ keyboard_t kbd_getKeys()
     */
 
     /* Retrieve row/coloumn voltage measurements. */
-    uint16_t row = ((uint16_t) adc_getVoltage(&adc1, ADC_SW2_CH) / 1000);
-    uint16_t col = ((uint16_t) adc_getVoltage(&adc1, ADC_SW1_CH) / 1000);
+    uint16_t row = (uint16_t) (adc_getVoltage(&adc1, ADC_SW2_CH) / 1000);
+    uint16_t col = (uint16_t) (adc_getVoltage(&adc1, ADC_SW1_CH) / 1000);
 
     /* Map row voltage to row index. */
     uint8_t rowIdx = 0xFF;


### PR DESCRIPTION
The MD9600 microphone keyboard was non functional after the ADC platform changes, due to changes on how to calculate the row and column voltage.

This pull request fixes this by first calculating the value and then casting to uint16.
Before, the adc value was larger than uint16 and got cut off, which resulted in the keyboard not working.