### PR TITLE
Update radio_tool.wrap

### DIFF
--- a/subprojects/radio_tool.wrap
+++ b/subprojects/radio_tool.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/v0l/radio_tool
-revision = 070f8cab45f67424803fe8079cca4cd989caf330
+revision = head
 patch_directory = radio_tool
 
 [provide]


### PR DESCRIPTION
change version to newest one - 'head' instead of revision number, found that when trying to compile v0.3.5 to get register data dump, as in discussion on Matrix,  last change in radio_tool master is from 5 Oct 2023, more over year old so it should be pretty stable