### PR TITLE
Add github workflow for zephyr targets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,39 @@ jobs:
             ${{github.workspace}}/build_linux/openrtx_linux
             ${{github.workspace}}/build_linux/openrtx_linux_smallscreen
             ${{github.workspace}}/build_linux/openrtx_linux_mod17
+  build-zephyr:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: app
+      - name: install-deps
+        run: |
+          sudo apt update
+          sudo apt install -y git pkg-config build-essential meson libsdl2-dev libreadline-dev dfu-util cmake libusb-1.0-0 libusb-1.0-0-dev libcodec2-dev codec2
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+      - name: Setup Zephyr project
+        uses: zephyrproject-rtos/action-zephyr-setup@v1
+        with:
+          app-path: app
+          toolchains: xtensa-espressif_esp32s3_zephyr-elf
+          sdk-version: 0.17.0
+      - name: Compile zephyr
+        run: |
+          cd app
+          meson setup build
+          meson compile -C build openrtx_ttwrplus_uf2
+        shell: bash
+      - uses: actions/upload-artifact@v4
+        with:
+          name: zephyr-release-bins
+          path: |
+            app/build/openrtx_*.uf2
   unit-test:
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
This adds a new build step to the github workflow.
This build step will build the t-twr plus zephyr target.
It uses the `zephyrproject-rtos/action-zephyr-setup@v1` action to setup the zephyr sdk.

The resulting uf2 file is uploaded as an artifact.

This will fix #242
