### PR TITLE
Fix ttwrplus build after nvm changes

### DIFF
--- a/platform/drivers/NVM/flash_zephyr.c
+++ b/platform/drivers/NVM/flash_zephyr.c
@@ -49,10 +49,11 @@ int zephirFlash_init(const struct nvmDevice* dev)
     const struct flash_parameters *info = flash_get_parameters(TO_DEV_HANDLE(dev->priv));
 
     // TODO: erase size and erase cycles to be retrieved from the real device.
-    dev->info->write_size   = info->write_block_size;
-    dev->info->erase_size   = 4096;
-    dev->info->erase_cycles = 100000;
-    dev->info->device_info  = NVM_FLASH | NVM_WRITE | NVM_BITWRITE | NVM_ERASE;
+    struct nvmInfo *nvm_info = (struct nvmInfo *) dev->info;
+    nvm_info->write_size   = info->write_block_size;
+    nvm_info->erase_size   = 4096;
+    nvm_info->erase_cycles = 100000;
+    nvm_info->device_info  = NVM_FLASH | NVM_WRITE | NVM_BITWRITE | NVM_ERASE;
 
     return 0;
 }

--- a/platform/drivers/NVM/flash_zephyr.h
+++ b/platform/drivers/NVM/flash_zephyr.h
@@ -44,7 +44,7 @@ extern const struct nvmOps zephyr_flash_ops;
 static struct nvmInfo nvm_devInfo_##name;           \
 static const struct nvmDevice name =                \
 {                                                   \
-    .priv   = DEVICE_DT_GET(DT_ALIAS(alias))        \
+    .priv   = DEVICE_DT_GET(DT_ALIAS(alias)),       \
     .ops    = &zephyr_flash_ops,                    \
     .info   = &nvm_devInfo_##name,                  \
     .size   = sz                                    \

--- a/platform/drivers/audio/audio_ttwrplus.c
+++ b/platform/drivers/audio/audio_ttwrplus.c
@@ -19,6 +19,7 @@
  ***************************************************************************/
 
 #include <interfaces/audio.h>
+#include "SA8x8.h"
 
 const struct audioDevice outputDevices[] =
 {


### PR DESCRIPTION
This will allow the ttwr plus target to build again.
The nvm device info assignment is comment out, as the info field is marked as `const`.