### PR TITLE
Volume change wakes up display

### DIFF
--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -1,8 +1,9 @@
 /***************************************************************************
- *   Copyright (C) 2020 - 2023 by Federico Amedeo Izzo IU2NUO,             *
+ *   Copyright (C) 2020 - 2025 by Federico Amedeo Izzo IU2NUO,             *
  *                                Niccolò Izzo IU2KIN                      *
  *                                Frederik Saraci IU2NRO                   *
  *                                Silvano Seva IU2KWO                      *
+ *                                Grzegorz Kaczmarek SP6HFE                *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -2466,7 +2467,9 @@ void ui_updateFSM(bool *sync_rtx)
         }
 #endif //            CONFIG_GPS
 
-        if (txOngoing || rtx_rxSquelchOpen())
+        if (txOngoing ||
+            rtx_rxSquelchOpen() ||
+            (state.volume != last_state.volume))
         {
             _ui_exitStandby(now);
             return;


### PR DESCRIPTION
This PR adds a reaction to changing volume so it wakes-up the display when it was put to sleep.
Instead of touching the keyboard to see what is the state of the TRX it is simply possible to do it by moving a volume knob by a little.
Such a behavior save from not intended changes in operation when pushing buttons just to lit-up the backlight to see information on a screen.

Maybe there should be an option in the menu for enabling/disabling this feature but as EE storage seems not fully supported functionality is always on.