### PR TITLE
Add missing GPS source for md9600

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -424,6 +424,7 @@ mduv3x0_def += openrtx_def + stm32f405_def
 ##
 md9600_src = ['platform/targets/MD-9600/platform.c',
               'platform/targets/MD-9600/hwconfig.c',
+              'platform/drivers/GPS/GPS_MDx.cpp',
               'platform/drivers/display/ST7567_MD9600.c',
               'platform/drivers/keyboard/keyboard_MD9600.c',
               'platform/drivers/backlight/backlight_MDx.c',


### PR DESCRIPTION
After e469c856cccb26639ab71837c9b92707597c9908 the source file for the GPS was not included for the MD9600.
This adds it back in.