### PR TITLE
Add CS7000/CS700P/DM1701 to actions build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,12 +34,13 @@ jobs:
           cd ${{github.workspace}}
           meson setup build_linux
           meson setup --cross-file cross_arm.txt build_arm
+          meson setup --cross-file cross_cm7.txt build_cm7
       - name: Compile linux
         run: |
           meson compile -C build_linux openrtx_linux
           meson compile -C build_linux openrtx_linux_smallscreen
           meson compile -C build_linux openrtx_linux_mod17
-      - name: Compile arm targets
+      - name: Compile arm cortex m4 targets
         run: |
           export PATH=$PATH:/tmp/OpenGD77/tools/Python/FirmwareLoader:/tmp/OpenGD77/firmware/tools
           echo $PATH
@@ -49,6 +50,13 @@ jobs:
           meson compile -C build_arm openrtx_gd77_wrap
           meson compile -C build_arm openrtx_dm1801_wrap
           meson compile -C build_arm openrtx_mod17_wrap
+          meson compile -C build_arm openrtx_cs7000_wrap
+          meson compile -C build_arm openrtx_dm1701_wrap
+      - name: Compile arm cortex m7 targets
+        run: |
+          export PATH=$PATH:/tmp/OpenGD77/tools/Python/FirmwareLoader:/tmp/OpenGD77/firmware/tools
+          echo $PATH
+          meson compile -C build_cm7 openrtx_cs7000p_wrap
       - uses: actions/upload-artifact@v4
         with:
           name: release-bins


### PR DESCRIPTION
Add the new targets CS7000, CS7000P and DM1701 to the GitHub actions build.