### PR TITLE
Fixed maximum audio for MDUV3x0 out of bounds

### DIFF
--- a/platform/drivers/audio/audio_MDx.cpp
+++ b/platform/drivers/audio/audio_MDx.cpp
@@ -90,7 +90,7 @@ static void *audio_thread(void *arg)
         if(state.volume != oldVolume)
         {
             // Apply new volume level, map 0 - 255 range into -31 to 31
-            int8_t gain = ((int8_t) (state.volume / 4)) - 31;
+            int8_t gain = ((int8_t) (state.volume / 4)) - 32;
             C6000.setDacGain(gain);
 
             oldVolume = state.volume;


### PR DESCRIPTION
The maximum volume was setting the HR-C6000 gain to 32 instead of 31 maximum. The minimum now goes down to -32 but there is a bounds check in the HR-C6000 driver to turn off the DAC if the volume is below or equal to -31 so it should not be a problem.