### PR TITLE
Mitigate Codec2's idle noise when using 12-bit ADCs

### DIFF
--- a/openrtx/src/core/audio_codec.c
+++ b/openrtx/src/core/audio_codec.c
@@ -325,7 +325,14 @@ static void *decodeFunc(void *arg)
 
         if(newData)
         {
-            codec2_decode(codec2, audioBuf, ((uint8_t *) &frame));
+            if(codec2_get_energy(codec2, ((uint8_t *) &frame)) > 120)
+            {
+                codec2_decode(codec2, audioBuf, ((uint8_t *) &frame));
+            }
+            else
+            {
+                memset((uint8_t*)audioBuf, 0, codec2_samples_per_frame(codec2)*sizeof(audioBuf[0])); 
+            }
 
             #ifdef PLATFORM_MD3x0
             // Bump up volume a little bit, as on MD3x0 is quite low


### PR DESCRIPTION
Make sure that the `decodeFunc()` only decodes Codec2 data if the encoded frame energy exceeds a certain threshold. This guarantees that no noise is decoded and played back at the speaker. After applying this modification, the decoded speech is much clearer, as there is no noise in between words or at idle (silence). The idle noise effect is especially emphasized when 12-bit ADCs are used at the transmitter side.