### PR TITLE
Use `-std=gnu17` to allow building with gcc 15

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -351,7 +351,7 @@ linux_small_def   = linux_def + {'CONFIG_SCREEN_WIDTH': '128', 'CONFIG_SCREEN_HE
 linux_mod17_src = linux_src + ui_src_module17
 linux_mod17_def = linux_def + {'CONFIG_SCREEN_WIDTH': '128', 'CONFIG_SCREEN_HEIGHT': '64', 'CONFIG_PIX_FMT_BW': ''}
 
-linux_c_args   = ['-ffunction-sections', '-fdata-sections']
+linux_c_args   = ['-ffunction-sections', '-fdata-sections', '-std=gnu17']
 linux_cpp_args = ['-ffunction-sections', '-fdata-sections', '-std=c++14']
 linux_l_args   = ['-lm', '-lreadline']
 


### PR DESCRIPTION
gcc 15 uses C23 by default now.
The project does not yet compile with C23.
Thus we set the standard back to C17, as it was the default before gcc 15.