### PR TITLE
M17 Meta Text

### DIFF
--- a/openrtx/include/core/settings.h
+++ b/openrtx/include/core/settings.h
@@ -16,6 +16,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, see <http://www.gnu.org/licenses/>   *
+ *                                                                         *
+ *   (2025) Modified by KD0OSS for new modes on Module17                   *
  ***************************************************************************/
 
 #ifndef SETTINGS_H
@@ -62,6 +64,7 @@ typedef struct
             _reserved       : 3;
     bool    m17_can_rx;           // Check M17 CAN on RX
     char    m17_dest[10];         // M17 destination
+    char    M17_meta_text[53];    // M17 Meta Text to send
 }
 __attribute__((packed)) settings_t;
 
@@ -86,7 +89,8 @@ static const settings_t default_settings =
     1,                            // Automatic latch of macro menu enabled
     0,                            // not used
     false,                        // Check M17 CAN on RX
-    ""                            // Empty M17 destination
+    "",                            // Empty M17 destination
+    "OpenRTX"                     // Default M17 meta text
 };
 
 #endif /* SETTINGS_H */

--- a/openrtx/include/protocols/M17/M17LinkSetupFrame.hpp
+++ b/openrtx/include/protocols/M17/M17LinkSetupFrame.hpp
@@ -102,6 +102,13 @@ public:
     void setType(streamType_t type);
 
     /**
+     * Set metadata text field.
+     *
+     * @param text: 14 bytes of text to be written
+     */
+    void setMetaText(uint8_t *text);
+
+    /**
      * Get metadata field.
      *
      * @return a reference to frame's metadata field, allowing for both read and
@@ -114,6 +121,12 @@ public:
      * field.
      */
     void updateCrc();
+
+    /**
+     * Compute a new CRC over the content and update the corresponding
+     * field.
+     */
+    uint16_t m17Crc(const void *data, const size_t len);
 
     /**
      * Check if frame data is valid that is, if the CRC computed over the LSF

--- a/openrtx/include/rtx/rtx.h
+++ b/openrtx/include/rtx/rtx.h
@@ -16,6 +16,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, see <http://www.gnu.org/licenses/>   *
+ *                                                                         *
+ *   (2025) Modified by KD0OSS for new modes on Module17                   *
  ***************************************************************************/
 
 #ifndef RTX_H
@@ -66,6 +68,7 @@ typedef struct
     char     M17_src[10];              /**  M17 LSF source             */
     char     M17_link[10];             /**  M17 LSF traffic originator */
     char     M17_refl[10];             /**  M17 LSF reflector module   */
+    char     M17_Meta_Text[53];        /**< M17 Meta Text                */
 }
 rtxStatus_t;
 

--- a/openrtx/include/ui/ui_default.h
+++ b/openrtx/include/ui/ui_default.h
@@ -15,6 +15,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, see <http://www.gnu.org/licenses/>   *
+ *                                                                         *
+ *   (2025) Modified by KD0OSS for new modes on Module17                   *
  ***************************************************************************/
 
 #ifndef UI_DEFAULT_H
@@ -148,6 +150,7 @@ enum settingsRadioItems
 enum settingsM17Items
 {
     M17_CALLSIGN = 0,
+    M17_METATEXT,
     M17_CAN,
     M17_CAN_RX
 };
@@ -193,6 +196,7 @@ typedef struct layout_t
     symbolSize_t line4_symbol_size;
     fontSize_t bottom_font;
     fontSize_t input_font;
+    fontSize_t message_font;
     fontSize_t menu_font;
 } layout_t;
 
@@ -207,6 +211,7 @@ typedef struct ui_state_t
     uint8_t menu_selected;
     // If true we can change a menu entry value with UP/DOWN
     bool edit_mode;
+    bool edit_message;
     bool input_locked;
     // Variables used for VFO input
     uint8_t input_number;
@@ -224,6 +229,7 @@ typedef struct ui_state_t
     char new_time_buf[9];
 #endif
     char new_callsign[10];
+    char new_message[822];
     freq_t new_offset;
     // Which state to return to when we exit menu
     uint8_t last_main_state;

--- a/openrtx/include/ui/ui_mod17.h
+++ b/openrtx/include/ui/ui_mod17.h
@@ -15,6 +15,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, see <http://www.gnu.org/licenses/>   *
+ *                                                                         *
+ *   (2025) Modified by KD0OSS for new modes on Module17                   *
  ***************************************************************************/
 
 #ifndef UI_MOD17_H
@@ -123,6 +125,7 @@ enum settingsGPSItems
 enum m17Items
 {
     M_CALLSIGN = 0,
+    M_METATEXT,
     M_CAN,
     M_CAN_RX
 };
@@ -180,6 +183,7 @@ typedef struct layout_t
     symbolSize_t line5_symbol_font;
     fontSize_t bottom_font;
     fontSize_t input_font;
+    fontSize_t message_font;
     fontSize_t menu_font;
     fontSize_t mode_font_big;
     fontSize_t mode_font_small;
@@ -196,6 +200,7 @@ typedef struct ui_state_t
     uint8_t menu_selected;
     // If true we can change a menu entry value with UP/DOWN
     bool edit_mode;
+    bool edit_message;
     // Variables used for VFO input
     uint8_t input_number;
     uint8_t input_position;
@@ -212,6 +217,7 @@ typedef struct ui_state_t
     char new_time_buf[9];
 #endif
     char new_callsign[10];
+    char new_message[822];
     // Which state to return to when we exit menu
     uint8_t last_main_state;
 }

--- a/openrtx/src/core/state.c
+++ b/openrtx/src/core/state.c
@@ -52,6 +52,9 @@ void state_init()
     {
         state.settings = default_settings;
         strncpy(state.settings.callsign, "OPNRTX", 10);
+#ifdef CONFIG_M17
+        strncpy(state.settings.M17_meta_text, "OPENRTX", 53);
+#endif
     }
 
     /*

--- a/openrtx/src/protocols/M17/M17LinkSetupFrame.cpp
+++ b/openrtx/src/protocols/M17/M17LinkSetupFrame.cpp
@@ -76,6 +76,12 @@ void M17LinkSetupFrame::setType(streamType_t type)
     data.type  = type;
 }
 
+// Added by KD0OSS (2025)
+void M17LinkSetupFrame::setMetaText(uint8_t *text)
+{
+    memcpy(data.meta.raw_data, text, 14);
+}
+
 meta_t& M17LinkSetupFrame::metadata()
 {
     return data.meta;
@@ -86,6 +92,13 @@ void M17LinkSetupFrame::updateCrc()
     // Compute CRC over the first 28 bytes, then store it in big endian format.
     uint16_t crc = crc16(&data, 28);
     data.crc     = __builtin_bswap16(crc);
+}
+
+uint16_t M17LinkSetupFrame::m17Crc(const void *data, const size_t len)
+{
+    // Compute CRC over len bytes, then store it in big endian format.
+    uint16_t crc = crc16(data, len);
+    return __builtin_bswap16(crc);
 }
 
 bool M17LinkSetupFrame::valid() const

--- a/openrtx/src/rtx/OpMode_M17.cpp
+++ b/openrtx/src/rtx/OpMode_M17.cpp
@@ -16,6 +16,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, see <http://www.gnu.org/licenses/>   *
+ *                                                                         *
+ *   (2025) Modified by KD0OSS for new modes on Module17                   *
  ***************************************************************************/
 
 #include <interfaces/platform.h>
@@ -23,14 +25,20 @@
 #include <interfaces/audio.h>
 #include <interfaces/radio.h>
 #include <M17/M17Callsign.hpp>
+#include <core/state.h>
 #include <OpMode_M17.hpp>
 #include <audio_codec.h>
+#include <vector>
 #include <errno.h>
+#include <stdlib.h>
+#include <math.h>
+#include <gps.h>
+//#include <drivers/USART3_MOD17.h> // for debugging
 #include <rtx.h>
+//#include <drivers/usb_vcom.h>
 
 #ifdef PLATFORM_MOD17
 #include <calibInfo_Mod17.h>
-#include <interfaces/platform.h>
 
 extern mod17Calib_t mod17CalData;
 #endif
@@ -55,11 +63,12 @@ void OpMode_M17::enable()
     codec_init();
     modulator.init();
     demodulator.init();
-    locked       = false;
-    dataValid    = false;
-    extendedCall = false;
-    startRx      = true;
-    startTx      = false;
+    locked                 = false;
+    dataValid              = false;
+    extendedCall           = false;
+    startRx                = true;
+    startTx                = false;
+    gpsEnabled             = true;
 }
 
 void OpMode_M17::disable()
@@ -172,7 +181,9 @@ void OpMode_M17::offState(rtxStatus_t *const status)
 
 void OpMode_M17::rxState(rtxStatus_t *const status)
 {
-    if(startRx)
+	uint8_t pthSts;
+
+	if(startRx)
     {
         demodulator.startBasebandSampling();
 
@@ -184,7 +195,7 @@ void OpMode_M17::rxState(rtxStatus_t *const status)
     bool newData = demodulator.update(invertRxPhase);
     bool lock    = demodulator.isLocked();
 
-    // Reset frame decoder when transitioning from unlocked to locked state.
+            // Reset frame decoder when transitioning from unlocked to locked state.
     if((lock == true) && (locked == false))
     {
         decoder.reset();
@@ -204,38 +215,79 @@ void OpMode_M17::rxState(rtxStatus_t *const status)
             if(status->lsfOk)
             {
                 dataValid = true;
+                frameCnt++;
 
-                // Retrieve stream source and destination data
+                        // Retrieve stream source and destination data
                 std::string dst = lsf.getDestination();
                 std::string src = lsf.getSource();
 
-                // Retrieve extended callsign data
+                        // Retrieve extended callsign data
                 streamType_t streamType = lsf.getType();
 
                 if((streamType.fields.encType    == M17_ENCRYPTION_NONE) &&
-                   (streamType.fields.encSubType == M17_META_EXTD_CALLSIGN))
+                    (streamType.fields.encSubType == M17_META_EXTD_CALLSIGN))
                 {
-                    extendedCall = true;
-
                     meta_t& meta = lsf.metadata();
                     std::string exCall1 = decode_callsign(meta.extended_call_sign.call1);
                     std::string exCall2 = decode_callsign(meta.extended_call_sign.call2);
 
-                    //
-                    // The source callsign only contains the last link when
-                    // receiving extended callsign data: in order to always store
-                    // the true source of a transmission, we need to store the first
-                    // extended callsign in M17_src.
-                    //
+                            //
+                            // The source callsign only contains the last link when
+                            // receiving extended callsign data: in order to always store
+                            // the true source of a transmission, we need to store the first
+                            // extended callsign in M17_src.
+                            //
                     strncpy(status->M17_src,  exCall1.c_str(), 10);
                     strncpy(status->M17_refl, exCall2.c_str(), 10);
 
                     extendedCall = true;
+                    if(frameCnt == 6)
+                        frameCnt = 0;
+
+                            // no metatext present
+                    memset(status->M17_Meta_Text, 0, 53);
+                }
+                // Check if metatext is present
+                else if((streamType.fields.encType    == M17_ENCRYPTION_NONE) &&
+                         (streamType.fields.encSubType == M17_META_TEXT) &&
+                         lsf.valid() && frameCnt == 6)
+                {
+                    frameCnt = 0;
+                    meta_t& meta = lsf.metadata();
+                    uint8_t blk_len = (meta.raw_data[0] & 0xf0) >> 4;
+                    uint8_t blk_id = (meta.raw_data[0] & 0x0f);
+                    if(blk_id == 1)
+                    {  // On first block reset everything
+                        memset(status->M17_Meta_Text, 0, 53);
+                        memset(textBuffer, 0, 53);
+                        textOffset = 0;
+                        blk_id_tot = 0;
+                        textStarted = true;
+                    }
+                    // check if first valid metatext block is found
+                    if(textStarted)
+                    {
+                        // Check for valid block id
+                        if(blk_id <= 0x0f)
+                        {
+                            blk_id_tot += blk_id;
+                            memcpy(textBuffer+textOffset, meta.raw_data+1, 13);
+                            textOffset += 13;
+                            // Check for completed text message
+                            if((blk_len == blk_id_tot) || textOffset == 52)
+                            {
+                                memcpy(status->M17_Meta_Text, textBuffer, textOffset);
+                                textOffset = 0;
+                                blk_id_tot = 0;
+                                textStarted = false;
+                            }
+                        }
+                    }
                 }
 
-                // Set source and destination fields.
-                // If we have received an extended callsign the src will be the RF link address
-                // The M17_src will already be stored from the extended callsign
+                        // Set source and destination fields.
+                        // If we have received an extended callsign the src will be the RF link address
+                        // The M17_src will already be stored from the extended callsign
                 strncpy(status->M17_dst, dst.c_str(), 10);
 
                 if(extendedCall)
@@ -243,35 +295,38 @@ void OpMode_M17::rxState(rtxStatus_t *const status)
                 else
                     strncpy(status->M17_src, src.c_str(), 10);
 
-                // Check CAN on RX, if enabled.
-                // If check is disabled, force match to true.
+                        // Check CAN on RX, if enabled.
+                        // If check is disabled, force match to true.
                 bool canMatch =  (streamType.fields.CAN == status->can)
-                              || (status->canRxEn == false);
+                                || (status->canRxEn == false);
 
-                // Check if the destination callsign of the incoming transmission
-                // matches with ours
+                        // Check if the destination callsign of the incoming transmission
+                        // matches with ours
                 bool callMatch = compareCallsigns(std::string(status->source_address), dst);
 
                 // Open audio path only if CAN and callsign match
-                uint8_t pthSts = audioPath_getStatus(rxAudioPath);
-                if((pthSts == PATH_CLOSED) && (canMatch == true) && (callMatch == true))
+                if((type == M17FrameType::STREAM) && (canMatch == true) && (callMatch == true))
                 {
-                    rxAudioPath = audioPath_request(SOURCE_MCU, SINK_SPK, PRIO_RX);
                     pthSts = audioPath_getStatus(rxAudioPath);
-                }
+			if(pthSts == PATH_CLOSED)
+			{
+			    rxAudioPath = audioPath_request(SOURCE_MCU, SINK_SPK, PRIO_RX);
+			    pthSts = audioPath_getStatus(rxAudioPath);
+			}
 
-                // Extract audio data and sent it to codec
-                if((type == M17FrameType::STREAM) && (pthSts == PATH_OPEN))
-                {
-                    // (re)start codec2 module if not already up
-                    if(codec_running() == false)
-                        codec_startDecode(rxAudioPath);
+			// Extract audio data and sent it to codec
+			if((type == M17FrameType::STREAM) && (pthSts == PATH_OPEN))
+			{
+				// (re)start codec2 module if not already up
+				if(codec_running() == false)
+					codec_startDecode(rxAudioPath);
 
-                    M17StreamFrame sf = decoder.getStreamFrame();
-                    codec_pushFrame(sf.payload().data(),     false);
-                    codec_pushFrame(sf.payload().data() + 8, false);
+				M17StreamFrame sf = decoder.getStreamFrame();
+				codec_pushFrame(sf.payload().data(),     false);
+				codec_pushFrame(sf.payload().data() + 8, false);
+			}
                 }
-            }
+            } // if LSF OK
         }
     }
 
@@ -284,40 +339,80 @@ void OpMode_M17::rxState(rtxStatus_t *const status)
         status->opStatus = OFF;
     }
 
-    // Force invalidation of LSF data as soon as lock is lost (for whatever cause)
+            // Force invalidation of LSF data as soon as lock is lost (for whatever cause)
     if(locked == false)
     {
         status->lsfOk = false;
         dataValid     = false;
         extendedCall  = false;
+        textStarted   = false;
+        memset(textBuffer, 0, 52);
         status->M17_link[0] = '\0';
         status->M17_refl[0] = '\0';
-
-        codec_stop(rxAudioPath);
-        audioPath_release(rxAudioPath);
+ //       if(codec_running() == true)
+		codec_stop(rxAudioPath);
+  //      if(pthSts == PATH_OPEN)
+            audioPath_release(rxAudioPath);
     }
 }
 
 void OpMode_M17::txState(rtxStatus_t *const status)
 {
+    static streamType_t type;
     frame_t m17Frame;
 
     if(startTx)
     {
         startTx = false;
+        lsfFragCount = 6;
+
+        // reset metatext so nothing left over from previous contact
+        memset(status->M17_Meta_Text, 0, 53);
 
         std::string src(status->source_address);
         std::string dst(status->destination_address);
-        M17LinkSetupFrame lsf;
 
         lsf.clear();
         lsf.setSource(src);
         if(!dst.empty()) lsf.setDestination(dst);
 
-        streamType_t type;
-        type.fields.dataMode = M17_DATAMODE_STREAM;     // Stream
-        type.fields.dataType = M17_DATATYPE_VOICE;      // Voice data
-        type.fields.CAN      = status->can;             // Channel access number
+        type.fields.dataMode   = M17_DATAMODE_STREAM;     // Stream
+        type.fields.dataType   = M17_DATATYPE_VOICE;      // Voice data
+        type.fields.CAN        = status->can;             // Channel access number
+        if(strlen(state.settings.M17_meta_text) > 0)      // have text to send
+        {
+            type.fields.encType    = M17_ENCRYPTION_NONE; // No encryption
+            type.fields.encSubType = M17_META_TEXT;       // Meta text
+
+		uint8_t buf[14];
+		memset(buf, 32, 14); // set to all spaces
+		// this should return number of meta blocks needed
+		uint8_t msglen = ceilf((float)strlen(state.settings.M17_meta_text) / 13.0f);
+		// set control byte upper nibble for number of text blocks
+		// 0001 = 1 blk. 0011 = 2 blks, 0111 = 3 blks, 1111 = 4 blks
+		buf[0] = (0x0f >> (4 - msglen)) << 4;
+
+		// check if less than 13 characters remain
+		uint8_t len = (uint8_t)(strlen(state.settings.M17_meta_text) - (last_text_blk * 13));
+		// if over 13 then limit to 13
+		if(len > 13)
+			len = 13;
+		memcpy(buf+1, state.settings.M17_meta_text+(last_text_blk * 13), len);
+
+		// set control byte lower nibble to block id
+		// 0001 = blk1, 0010 = blk2, 0100 = blk3, 1000 = blk4
+		buf[0] += (1 << last_text_blk++);
+		lsf.setMetaText(buf);
+		encoder.encodeLsf(lsf, m17Frame);
+
+		// if all blocks sent then reset
+		if(last_text_blk == msglen)
+		{
+			last_text_blk = 0;
+		}
+        }
+        else
+		last_text_blk = 0xff;   // no text to send
 
         lsf.setType(type);
         lsf.updateCrc();
@@ -335,6 +430,105 @@ void OpMode_M17::txState(rtxStatus_t *const status)
         modulator.sendFrame(m17Frame);
     }
 
+    // 0xff indicates no text to send
+    if(last_text_blk != 0xff) // send meta text
+    {
+	if (lsfFragCount == 6)
+	{
+		lsfFragCount = 0;
+
+		uint8_t buf[14];
+		memset(buf, 32, 14); // set to all spaces
+		// this should return number of meta blocks needed
+		uint8_t msglen = ceilf((float)strlen(state.settings.M17_meta_text) / 13.0f);
+		// set control byte upper nibble for number of text blocks
+		// 0001 = 1 blk. 0011 = 2 blks, 0111 = 3 blks, 1111 = 4 blks
+		buf[0] = (0x0f >> (4 - msglen)) << 4;
+
+		// check if less than 13 characters remain
+		uint8_t len = (uint8_t)(strlen(state.settings.M17_meta_text) - (last_text_blk * 13));
+		// if over 13 then limit to 13
+		if(len > 13)
+			len = 13;
+		memcpy(buf+1, state.settings.M17_meta_text+(last_text_blk * 13), len);
+
+		// set control byte lower nibble to block id
+		// 0001 = blk1, 0010 = blk2, 0100 = blk3, 1000 = blk4
+		buf[0] += (1 << last_text_blk++);
+		lsf.setMetaText(buf);
+		type.fields.encSubType = M17_META_TEXT;
+		lsf.setType(type);
+            lsf.updateCrc();
+		encoder.encodeLsf(lsf, m17Frame);
+
+		// if all blocks sent then reset
+		if(last_text_blk == msglen)
+		{
+			last_text_blk = 0;
+		}
+	}
+	else
+		lsfFragCount++;
+    }
+
+    // Wait at least 5 seconds between GPS transmissions
+    if((gpsTimer == -1) || ((gpsTimer >= 150) && (last_text_blk == 0xff || last_text_blk == 0)))
+    {
+        gpsTimer = 0;
+
+        gps_t gps_data;
+        pthread_mutex_lock(&state_mutex);
+        gps_data = state.gps_data;
+        pthread_mutex_unlock(&state_mutex);
+
+        if(gps_data.fix_type > 0) //Valid GPS fix
+        {
+		uint8_t gnss[14] = {0};
+
+		gnss[0] = (M17_GNSS_SOURCE_OPENRTX<<4) | M17_GNSS_STATION_HANDHELD; //OpenRTX source, portable station
+
+            gnss[1] &= ~((uint8_t)0xF0); //zero out gnss data validity field
+
+            gnss[1] &= ~((uint8_t)0x7<<1); //Radius = 0
+            gnss[1] &= ~((uint8_t)0<<4); //Radius invalid
+
+            gnss[1] |= ((uint16_t)gps_data.tmg_true>>8)&1; //Bearing
+            gnss[2] = ((uint16_t)gps_data.tmg_true)&0xFF;
+
+            int32_t lat_tmp, lon_tmp;
+            rtx_to_q(&lat_tmp, &lon_tmp, gps_data.latitude, gps_data.longitude);
+            for(uint8_t i=0; i<3; i++)
+            {
+                gnss[3+i] = *((uint8_t*)&lat_tmp+2-i);
+                gnss[6+i] = *((uint8_t*)&lon_tmp+2-i);
+            }
+            gnss[1] |= (1<<7); //Lat/lon valid
+
+            uint16_t alt = (uint16_t)1000 + gps_data.altitude*2;
+			gnss[9] = alt>>8;
+            gnss[10] = alt&0xFF;
+			gnss[1] |= (1<<6); //Altitude valid
+
+            uint16_t speed = (uint16_t)gps_data.speed*2;
+			gnss[11] = speed>>4;
+            gnss[12] = (speed&0xFF)<<4;
+			gnss[1] |= (1<<5); //Speed and Bearing valid
+
+            gnss[12] &= ~((uint8_t)0x0F);
+            gnss[13] = 0;
+
+		lsf.setMetaText((uint8_t*)&gnss);
+
+		type.fields.encSubType = M17_META_GNSS;
+		lsf.setType(type);
+		lsf.updateCrc();
+		encoder.encodeLsf(lsf, m17Frame);
+        }
+    }
+
+    if(gpsEnabled)
+	gpsTimer++;
+
     payload_t dataFrame;
     bool      lastFrame = false;
 
@@ -346,6 +540,10 @@ void OpMode_M17::txState(rtxStatus_t *const status)
     {
         lastFrame = true;
         startRx   = true;
+        if(strlen(state.settings.M17_meta_text) > 0) //do we have text to send
+            last_text_blk = 0;
+        else
+		last_text_blk = 0xff;
         status->opStatus = OFF;
     }
 
@@ -357,6 +555,7 @@ void OpMode_M17::txState(rtxStatus_t *const status)
         encoder.encodeEotFrame(m17Frame);
         modulator.sendFrame(m17Frame);
         modulator.stop();
+        gpsTimer = -1;
     }
 }
 
@@ -379,6 +578,38 @@ bool OpMode_M17::compareCallsigns(const std::string& localCs,
 
     if(truncatedLocal == truncatedIncoming)
         return true;
+    else
+    {
+	// Remove any appended characters from callsign
+        int spacePos = truncatedLocal.find_first_of(' ');
+        if(spacePos >= 4)
+            truncatedLocal = truncatedLocal.substr(0, spacePos);
+
+        spacePos = truncatedIncoming.find_first_of(' ');
+        if(spacePos >= 4)
+            truncatedIncoming = truncatedIncoming.substr(0, spacePos);
+
+        if(truncatedLocal == truncatedIncoming)
+            return true;
+    }
 
     return false;
+}
+
+void OpMode_M17::rtx_to_q(int32_t* qlat, int32_t* qlon, int32_t lat, int32_t lon)
+{
+	if(qlat!=NULL && qlon!=NULL)
+	{
+		*qlat = lat / 10 - lat / 147 + lat / 105646;  // 90e6/(2^23-1) - 1/(1/10 - 1/147 + 1/105646)  = ~0
+		*qlon = lon / 21 - lon / 985 - lon / 2237284; //180e6/(2^23-1) - 1/(1/21 - 1/985 - 1/2237284) = ~0
+	}
+}
+
+void OpMode_M17::q_to_rtx(int32_t* lat, int32_t* lon, int32_t qlat, int32_t qlon)
+{
+	if(lat!=NULL && lon!=NULL)
+	{
+		*lat = qlat * 11 - qlat / 4 - qlat / 47 + qlat / 8777; // 90e6/(2^23-1) - (11 - 1/4 - 1/47 + 1/8777) = ~0
+		*lon = qlon * 21 + qlon / 2 - qlon / 23 + qlon / 867;  //180e6/(2^23-1) - (21 + 1/2 - 1/23 + 1/867)  = ~0
+	}
 }

--- a/openrtx/src/rtx/rtx.cpp
+++ b/openrtx/src/rtx/rtx.cpp
@@ -16,6 +16,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, see <http://www.gnu.org/licenses/>   *
+ *                                                                         *
+ *   (2025) Modified by KD0OSS for DSTAR/P25 use on Module17/OpenRTX       *
  ***************************************************************************/
 
 #include <interfaces/radio.h>
@@ -66,6 +68,7 @@ void rtx_init(pthread_mutex_t *m)
     rtxStatus.M17_dst[0]    = '\0';
     rtxStatus.M17_link[0]   = '\0';
     rtxStatus.M17_refl[0]   = '\0';
+    rtxStatus.M17_Meta_Text[0] = '\0';
     currMode = &noMode;
 
     /*

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -17,6 +17,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, see <http://www.gnu.org/licenses/>   *
+ *                                                                         *
+ *   (2025) Modified by KD0OSS for new modes on Module17                   *
  ***************************************************************************/
 
 /*
@@ -120,140 +122,142 @@ extern bool _ui_drawMacroMenu(ui_state_t* ui_state);
 extern void _ui_reset_menu_anouncement_tracking();
 
 const char *menu_items[] =
-{
-    "Banks",
-    "Channels",
-    "Contacts",
+    {
+        "Banks",
+        "Channels",
+        "Contacts",
 #ifdef CONFIG_GPS
-    "GPS",
+        "GPS",
 #endif
-    "Settings",
-    "Info",
-    "About"
+        "Settings",
+        "Info",
+        "About"
 };
 
 const char *settings_items[] =
-{
-    "Display",
+    {
+        "Display",
 #ifdef CONFIG_RTC
-    "Time & Date",
+        "Time & Date",
 #endif
 #ifdef CONFIG_GPS
-    "GPS",
+        "GPS",
 #endif
-    "Radio",
+        "Radio",
 #ifdef CONFIG_M17
-    "M17",
+        "M17",
 #endif
-    "Accessibility",
-    "Default Settings"
+        "Accessibility",
+        "Default Settings"
 };
 
 const char *display_items[] =
-{
+    {
 #ifdef CONFIG_SCREEN_BRIGHTNESS
-    "Brightness",
+        "Brightness",
 #endif
 #ifdef CONFIG_SCREEN_CONTRAST
-    "Contrast",
+        "Contrast",
 #endif
-    "Timer"
+        "Timer"
 };
 
 #ifdef CONFIG_GPS
 const char *settings_gps_items[] =
-{
-    "GPS Enabled",
-    "GPS Set Time",
-    "UTC Timezone"
+    {
+        "GPS Enabled",
+        "GPS Set Time",
+        "UTC Timezone"
 };
 #endif
 
 const char *settings_radio_items[] =
-{
-    "Offset",
-    "Direction",
-    "Step",
+    {
+        "Offset",
+        "Direction",
+        "Step",
 };
 
 const char * settings_m17_items[] =
-{
-    "Callsign",
-    "CAN",
-    "CAN RX Check"
+    {
+        "Callsign",
+        "Meta Txt",
+        "CAN",
+        "CAN RX Check"
 };
 
 const char * settings_accessibility_items[] =
-{
-    "Macro Latch",
-    "Voice",
-    "Phonetic"
+    {
+        "Macro Latch",
+        "Voice",
+        "Phonetic"
 };
 
 const char *backup_restore_items[] =
-{
-    "Backup",
-    "Restore"
+    {
+        "Backup",
+        "Restore"
 };
 
 const char *info_items[] =
-{
-    "",
-    "Bat. Voltage",
-    "Bat. Charge",
-    "RSSI",
-    "Used heap",
-    "Band",
-    "VHF",
-    "UHF",
-    "Hw Version",
+    {
+        "",
+        "Bat. Voltage",
+        "Bat. Charge",
+        "RSSI",
+        "Used heap",
+        "Band",
+        "VHF",
+        "UHF",
+        "Hw Version",
 #ifdef PLATFORM_TTWRPLUS
-    "Radio",
-    "Radio FW",
+        "Radio",
+        "Radio FW",
 #endif
 };
 
 const char *authors[] =
-{
-    "Niccolo' IU2KIN",
-    "Silvano IU2KWO",
-    "Federico IU2NUO",
-    "Fred IU2NRO",
-    "Joseph VK7JS",
-    "Morgan ON4MOD",
-    "Marco DM4RCO"
+    {
+        "Niccolo' IU2KIN",
+        "Silvano IU2KWO",
+        "Federico IU2NUO",
+        "Fred IU2NRO",
+        "Joseph VK7JS",
+        "Morgan ON4MOD",
+        "Marco DM4RCO",
+        "Rick KD0OSS"
 };
 
 static const char *symbols_ITU_T_E161[] =
-{
-    " 0",
-    ",.?1",
-    "abc2ABC",
-    "def3DEF",
-    "ghi4GHI",
-    "jkl5JKL",
-    "mno6MNO",
-    "pqrs7PQRS",
-    "tuv8TUV",
-    "wxyz9WXYZ",
-    "-/*",
-    "#"
+    {
+        " 0",
+        ",.?1",
+        "abc2ABC",
+        "def3DEF",
+        "ghi4GHI",
+        "jkl5JKL",
+        "mno6MNO",
+        "pqrs7PQRS",
+        "tuv8TUV",
+        "wxyz9WXYZ",
+        "-/*",
+        "#"
 };
 
 static const char *symbols_ITU_T_E161_callsign[] =
-{
-    "0 ",
-    "1",
-    "ABC2",
-    "DEF3",
-    "GHI4",
-    "JKL5",
-    "MNO6",
-    "PQRS7",
-    "TUV8",
-    "WXYZ9",
-    "-/",
-    ""
+    {
+        "0 ",
+        "1",
+        "ABC2",
+        "DEF3",
+        "GHI4",
+        "JKL5",
+        "MNO6",
+        "PQRS7",
+        "TUV8",
+        "WXYZ9",
+        "-/",
+        ""
 };
 
 // Calculate number of menu entries
@@ -301,11 +305,11 @@ static void _ui_calculateLayout(layout_t *layout)
     // Compensate for fonts printing below the start position
     static const uint16_t text_v_offset = 1;
 
-    // Calculate UI layout depending on vertical resolution
-    // Tytera MD380, MD-UV380
-    #if CONFIG_SCREEN_HEIGHT > 127
+            // Calculate UI layout depending on vertical resolution
+            // Tytera MD380, MD-UV380
+#if CONFIG_SCREEN_HEIGHT > 127
 
-    // Height and padding shown in diagram at beginning of file
+            // Height and padding shown in diagram at beginning of file
     static const uint16_t top_h = 16;
     static const uint16_t top_pad = 4;
     static const uint16_t line1_h = 20;
@@ -321,7 +325,7 @@ static void _ui_calculateLayout(layout_t *layout)
     static const uint16_t big_line_v_pad = 6;
     static const uint16_t horizontal_pad = 4;
 
-    // Top bar font: 8 pt
+            // Top bar font: 8 pt
     static const fontSize_t   top_font = FONT_SIZE_8PT;
     static const symbolSize_t top_symbol_size = SYMBOLS_SIZE_8PT;
     // Text line font: 8 pt
@@ -333,6 +337,8 @@ static void _ui_calculateLayout(layout_t *layout)
     static const symbolSize_t line3_symbol_size = SYMBOLS_SIZE_8PT;
     static const fontSize_t line4_font = FONT_SIZE_8PT;
     static const symbolSize_t line4_symbol_size = SYMBOLS_SIZE_8PT;
+    // Message font
+    const fontSize_t message_font = FONT_SIZE_6PT;
     // Frequency line font: 16 pt
     static const fontSize_t line3_large_font = FONT_SIZE_16PT;
     // Bottom bar font: 8 pt
@@ -342,10 +348,10 @@ static void _ui_calculateLayout(layout_t *layout)
     // Menu font
     static const fontSize_t menu_font = FONT_SIZE_8PT;
 
-    // Radioddity GD-77
-    #elif CONFIG_SCREEN_HEIGHT > 63
+            // Radioddity GD-77
+#elif CONFIG_SCREEN_HEIGHT > 63
 
-    // Height and padding shown in diagram at beginning of file
+            // Height and padding shown in diagram at beginning of file
     static const uint16_t top_h = 11;
     static const uint16_t top_pad = 1;
     static const uint16_t line1_h = 10;
@@ -361,7 +367,7 @@ static void _ui_calculateLayout(layout_t *layout)
     static const uint16_t big_line_v_pad = 0;
     static const uint16_t horizontal_pad = 4;
 
-    // Top bar font: 6 pt
+            // Top bar font: 6 pt
     static const fontSize_t   top_font = FONT_SIZE_6PT;
     static const symbolSize_t top_symbol_size = SYMBOLS_SIZE_6PT;
     // Middle line fonts: 5, 8, 8 pt
@@ -374,6 +380,8 @@ static void _ui_calculateLayout(layout_t *layout)
     static const fontSize_t line3_large_font = FONT_SIZE_10PT;
     static const fontSize_t line4_font = FONT_SIZE_6PT;
     static const symbolSize_t line4_symbol_size = SYMBOLS_SIZE_6PT;
+    // Message font
+    const fontSize_t message_font = FONT_SIZE_6PT;
     // Bottom bar font: 6 pt
     static const fontSize_t bottom_font = FONT_SIZE_6PT;
     // TimeDate/Frequency input font
@@ -381,10 +389,10 @@ static void _ui_calculateLayout(layout_t *layout)
     // Menu font
     static const fontSize_t menu_font = FONT_SIZE_6PT;
 
-    // Radioddity RD-5R
-    #elif CONFIG_SCREEN_HEIGHT > 47
+            // Radioddity RD-5R
+#elif CONFIG_SCREEN_HEIGHT > 47
 
-    // Height and padding shown in diagram at beginning of file
+            // Height and padding shown in diagram at beginning of file
     static const uint16_t top_h = 11;
     static const uint16_t top_pad = 1;
     static const uint16_t line1_h = 0;
@@ -400,7 +408,7 @@ static void _ui_calculateLayout(layout_t *layout)
     static const uint16_t big_line_v_pad = 0;
     static const uint16_t horizontal_pad = 4;
 
-    // Top bar font: 6 pt
+            // Top bar font: 6 pt
     static const fontSize_t   top_font = FONT_SIZE_6PT;
     static const symbolSize_t top_symbol_size = SYMBOLS_SIZE_6PT;
     // Middle line fonts: 16, 16
@@ -408,6 +416,8 @@ static void _ui_calculateLayout(layout_t *layout)
     static const fontSize_t line3_font = FONT_SIZE_6PT;
     static const fontSize_t line4_font = FONT_SIZE_6PT;
     static const fontSize_t line3_large_font = FONT_SIZE_12PT;
+    // Message font
+    const fontSize_t message_font = FONT_SIZE_6PT;
     // TimeDate/Frequency input font
     static const fontSize_t input_font = FONT_SIZE_8PT;
     // Menu font
@@ -416,11 +426,11 @@ static void _ui_calculateLayout(layout_t *layout)
     static const fontSize_t line1_font = 0;
     static const fontSize_t bottom_font = 0;
 
-    #else
-    #error Unsupported vertical resolution!
-    #endif
+#else
+#error Unsupported vertical resolution!
+#endif
 
-    // Calculate printing positions
+            // Calculate printing positions
     static const uint16_t top_pos   = top_h - status_v_pad - text_v_offset;
     static const uint16_t line1_pos = top_h + top_pad + line1_h - small_line_v_pad - text_v_offset;
     static const uint16_t line2_pos = top_h + top_pad + line1_h + line2_h - small_line_v_pad - text_v_offset;
@@ -430,42 +440,43 @@ static void _ui_calculateLayout(layout_t *layout)
     static const uint16_t bottom_pos = CONFIG_SCREEN_HEIGHT - bottom_pad - status_v_pad - text_v_offset;
 
     layout_t new_layout =
-    {
-        hline_h,
-        top_h,
-        line1_h,
-        line2_h,
-        line3_h,
-        line3_large_h,
-        line4_h,
-        menu_h,
-        bottom_h,
-        bottom_pad,
-        status_v_pad,
-        horizontal_pad,
-        text_v_offset,
-        {horizontal_pad, top_pos},
-        {horizontal_pad, line1_pos},
-        {horizontal_pad, line2_pos},
-        {horizontal_pad, line3_pos},
-        {horizontal_pad, line3_large_pos},
-        {horizontal_pad, line4_pos},
-        {horizontal_pad, bottom_pos},
-        top_font,
-        top_symbol_size,
-        line1_font,
-        line1_symbol_size,
-        line2_font,
-        line2_symbol_size,
-        line3_font,
-        line3_symbol_size,
-        line3_large_font,
-        line4_font,
-        line4_symbol_size,
-        bottom_font,
-        input_font,
-        menu_font
-    };
+        {
+            hline_h,
+            top_h,
+            line1_h,
+            line2_h,
+            line3_h,
+            line3_large_h,
+            line4_h,
+            menu_h,
+            bottom_h,
+            bottom_pad,
+            status_v_pad,
+            horizontal_pad,
+            text_v_offset,
+            {horizontal_pad, top_pos},
+            {horizontal_pad, line1_pos},
+            {horizontal_pad, line2_pos},
+            {horizontal_pad, line3_pos},
+            {horizontal_pad, line3_large_pos},
+            {horizontal_pad, line4_pos},
+            {horizontal_pad, bottom_pos},
+            top_font,
+            top_symbol_size,
+            line1_font,
+            line1_symbol_size,
+            line2_font,
+            line2_symbol_size,
+            line3_font,
+            line3_symbol_size,
+            line3_large_font,
+            line4_font,
+            line4_symbol_size,
+            bottom_font,
+            input_font,
+            message_font,
+            menu_font
+        };
 
     memcpy(layout, &new_layout, sizeof(layout_t));
 }
@@ -566,23 +577,23 @@ static bool _ui_freq_check_limits(freq_t freq)
     {
         // hwInfo_t frequencies are in MHz
         if(freq >= (hwinfo->vhf_minFreq * 1000000) &&
-           freq <= (hwinfo->vhf_maxFreq * 1000000))
-        valid = true;
+            freq <= (hwinfo->vhf_maxFreq * 1000000))
+            valid = true;
     }
     if(hwinfo->uhf_band)
     {
         // hwInfo_t frequencies are in MHz
         if(freq >= (hwinfo->uhf_minFreq * 1000000) &&
-           freq <= (hwinfo->uhf_maxFreq * 1000000))
-        valid = true;
+            freq <= (hwinfo->uhf_maxFreq * 1000000))
+            valid = true;
     }
     return valid;
 }
 
 static bool _ui_channel_valid(channel_t* channel)
 {
-return _ui_freq_check_limits(channel->rx_frequency) &&
-       _ui_freq_check_limits(channel->tx_frequency);
+    return _ui_freq_check_limits(channel->rx_frequency) &&
+           _ui_freq_check_limits(channel->tx_frequency);
 }
 
 static bool _ui_drawDarkOverlay()
@@ -646,7 +657,7 @@ static void _ui_fsm_confirmVFOInput(bool *sync_rtx)
         }
         // Apply new frequencies if they are valid
         if(_ui_freq_check_limits(ui_state.new_rx_frequency) &&
-           _ui_freq_check_limits(ui_state.new_tx_frequency))
+            _ui_freq_check_limits(ui_state.new_tx_frequency))
         {
             state.channel.rx_frequency = ui_state.new_rx_frequency;
             state.channel.tx_frequency = ui_state.new_tx_frequency;
@@ -715,7 +726,7 @@ static void _ui_fsm_insertVFONumber(kbd_msg_t msg, bool *sync_rtx)
         {
             // Save both inserted frequencies
             if(_ui_freq_check_limits(ui_state.new_rx_frequency) &&
-               _ui_freq_check_limits(ui_state.new_tx_frequency))
+                _ui_freq_check_limits(ui_state.new_tx_frequency))
             {
                 state.channel.rx_frequency = ui_state.new_rx_frequency;
                 state.channel.tx_frequency = ui_state.new_tx_frequency;
@@ -737,8 +748,8 @@ static void _ui_changeBrightness(int variation)
 {
     state.settings.brightness += variation;
 
-    // Max value for brightness is 100, min value is set to 5 to avoid complete
-    //  display shutdown.
+            // Max value for brightness is 100, min value is set to 5 to avoid complete
+            //  display shutdown.
     if(state.settings.brightness > 100) state.settings.brightness = 100;
     if(state.settings.brightness < 5)   state.settings.brightness = 5;
 
@@ -751,10 +762,10 @@ static void _ui_changeContrast(int variation)
 {
     if(variation >= 0)
         state.settings.contrast =
-        (255 - state.settings.contrast < variation) ? 255 : state.settings.contrast + variation;
+            (255 - state.settings.contrast < variation) ? 255 : state.settings.contrast + variation;
     else
         state.settings.contrast =
-        (state.settings.contrast < -variation) ? 0 : state.settings.contrast + variation;
+            (state.settings.contrast < -variation) ? 0 : state.settings.contrast + variation;
 
     display_setContrast(state.settings.contrast);
 }
@@ -791,16 +802,16 @@ static void _ui_changeVoiceLevel(int variation)
 {
     if ((state.settings.vpLevel == vpNone && variation < 0) ||
         (state.settings.vpLevel == vpHigh && variation > 0))
-        {
-            return;
-        }
+    {
+        return;
+    }
 
     state.settings.vpLevel += variation;
 
-    // Force these flags to ensure the changes are spoken for levels 1 through 3.
+            // Force these flags to ensure the changes are spoken for levels 1 through 3.
     vpQueueFlags_t flags = vpqInit
-                         | vpqAddSeparatingSilence
-                         | vpqPlayImmediately;
+                           | vpqAddSeparatingSilence
+                           | vpqPlayImmediately;
 
     if (!vp_isPlaying())
     {
@@ -843,17 +854,17 @@ static bool _ui_checkStandby(long long time_since_last_event)
         case TIMER_4M:
         case TIMER_5M:
             return time_since_last_event >=
-                (60000 * (state.settings.display_timer - (TIMER_1M - 1)));
+                   (60000 * (state.settings.display_timer - (TIMER_1M - 1)));
         case TIMER_15M:
         case TIMER_30M:
         case TIMER_45M:
             return time_since_last_event >=
-                (60000 * 15 * (state.settings.display_timer - (TIMER_15M - 1)));
+                   (60000 * 15 * (state.settings.display_timer - (TIMER_15M - 1)));
         case TIMER_1H:
             return time_since_last_event >= 60 * 60 * 1000;
     }
 
-    // unreachable code
+            // unreachable code
     return false;
 }
 
@@ -883,7 +894,7 @@ static bool _ui_exitStandby(long long now)
 
 static void _ui_fsm_menuMacro(kbd_msg_t msg, bool *sync_rtx)
 {
-    // If there is no keyboard left and right select the menu entry to edit
+   // If there is no keyboard left and right select the menu entry to edit
 #if defined(CONFIG_UI_NO_KEYBOARD)
     if (msg.keys & KNOB_LEFT)
     {
@@ -975,14 +986,14 @@ static void _ui_fsm_menuMacro(kbd_msg_t msg, bool *sync_rtx)
             }
             break;
         case 5:
-            // Cycle through radio modes
-            #ifdef CONFIG_M17
+// Cycle through radio modes
+#ifdef CONFIG_M17
             if(state.channel.mode == OPMODE_FM)
                 state.channel.mode = OPMODE_M17;
             else if(state.channel.mode == OPMODE_M17)
                 state.channel.mode = OPMODE_FM;
             else //catch any invalid states so they don't get locked out
-            #endif
+#endif
                 state.channel.mode = OPMODE_FM;
             *sync_rtx = true;
             vp_announceRadioMode(state.channel.mode, queueFlags);
@@ -1052,6 +1063,9 @@ static void _ui_fsm_menuMacro(kbd_msg_t msg, bool *sync_rtx)
 
 static void _ui_menuUp(uint8_t menu_entries)
 {
+    if(ui_state.menu_selected > menu_entries - 1)
+        ui_state.menu_selected = 1;
+
     if(ui_state.menu_selected > 0)
         ui_state.menu_selected -= 1;
     else
@@ -1061,6 +1075,9 @@ static void _ui_menuUp(uint8_t menu_entries)
 
 static void _ui_menuDown(uint8_t menu_entries)
 {
+    if(ui_state.menu_selected > menu_entries - 1)
+        ui_state.menu_selected = menu_entries - 1;
+
     if(ui_state.menu_selected < menu_entries - 1)
         ui_state.menu_selected += 1;
     else
@@ -1073,6 +1090,10 @@ static void _ui_menuBack(uint8_t prev_state)
     if(ui_state.edit_mode)
     {
         ui_state.edit_mode = false;
+    }
+    else if(ui_state.edit_message)
+    {
+        ui_state.edit_message = false;
     }
     else
     {
@@ -1090,13 +1111,28 @@ static void _ui_textInputReset(char *buf)
     ui_state.input_position = 0;
     ui_state.input_set = 0;
     ui_state.last_keypress = 0;
-    memset(buf, 0, 9);
+    if(ui_state.edit_message)
+        memset(buf, 0, 822);
+    else
+        memset(buf, 0, 9);
     buf[0] = '_';
 }
 
-static void _ui_textInputKeypad(char *buf, uint8_t max_len, kbd_msg_t msg,
-                         bool callsign)
+#ifdef CONFIG_T9
+// for T9 keying
+static char *addCode(char *code, char symbol)
 {
+    code[strlen(code)] = symbol;
+
+    return getWord(dict_en, code);
+}
+#endif
+
+static void _ui_textInputKeypad(char *buf, uint16_t max_len, kbd_msg_t msg,
+                                bool callsign)
+{
+    static char code[15]="";
+
     long long now = getTick();
     // Get currently pressed number key
     uint8_t num_key = input_getPressedChar(msg);
@@ -1114,11 +1150,11 @@ static void _ui_textInputKeypad(char *buf, uint8_t max_len, kbd_msg_t msg,
     else
         num_symbols = strlen(symbols_ITU_T_E161[num_key]);
 
-    // Return if max length is reached or finished editing last character
+            // Return if max length is reached or finished editing last character
     if((ui_state.input_position >= max_len) || ((ui_state.input_position == (max_len-1)) && (key_timeout || !same_key)))
         return;
 
-    // Skip keypad logic for first keypress
+            // Skip keypad logic for first keypress
     if(ui_state.last_keypress != 0)
     {
         // Same key pressed and timeout not expired: cycle over chars of current key
@@ -1160,7 +1196,7 @@ static void _ui_textInputDel(char *buf)
     // not want to exclude it, but when editing callsign, we do not want to say
     // underline since it means the field is empty.
     if(buf[ui_state.input_position]
-    && buf[ui_state.input_position]!='_')
+        && buf[ui_state.input_position]!='_')
         vp_announceInputChar(buf[ui_state.input_position]);
 
     buf[ui_state.input_position] = '\0';
@@ -1168,7 +1204,7 @@ static void _ui_textInputDel(char *buf)
     if(ui_state.input_position > 0)
     {
         ui_state.input_position--;
-    // If we deleted the initial character, reset starting condition
+        // If we deleted the initial character, reset starting condition
     }
     else
         ui_state.last_keypress = 0;
@@ -1200,29 +1236,29 @@ static void _ui_numberInputKeypad(uint32_t *num, kbd_msg_t msg)
         }
     }
 
-    // If enter is pressed, advance to the next digit
+            // If enter is pressed, advance to the next digit
     if (msg.keys & KEY_ENTER)
         *num *= 10;
 
-    // Announce the character
+            // Announce the character
     vp_announceInputChar('0' + *num % 10);
 
-    // Update reference values
+            // Update reference values
     ui_state.input_number = *num % 10;
 #else
     // Maximum frequency len is uint32_t max value number of decimal digits
     if(ui_state.input_position >= 10)
         return;
 
-    // Get currently pressed number key
+            // Get currently pressed number key
     uint8_t num_key = input_getPressedNumber(msg);
     *num *= 10;
     *num += num_key;
 
-    // Announce the character
+            // Announce the character
     vp_announceInputChar('0' + num_key);
 
-    // Update reference values
+            // Update reference values
     ui_state.input_number = num_key;
 #endif
 
@@ -1234,7 +1270,7 @@ static void _ui_numberInputDel(uint32_t *num)
     // announce the digit about to be backspaced.
     vp_announceInputChar('0' + *num % 10);
 
-    // Move back input cursor
+            // Move back input cursor
     if(ui_state.input_position > 0)
         ui_state.input_position--;
     else
@@ -1259,17 +1295,17 @@ void ui_drawSplashScreen()
 {
     gfx_clearScreen();
 
-    #if CONFIG_SCREEN_HEIGHT > 64
+#if CONFIG_SCREEN_HEIGHT > 64
     static const point_t    logo_orig = {0, (CONFIG_SCREEN_HEIGHT / 2) - 6};
     static const point_t    call_orig = {0, CONFIG_SCREEN_HEIGHT - 8};
     static const fontSize_t logo_font = FONT_SIZE_12PT;
     static const fontSize_t call_font = FONT_SIZE_8PT;
-    #else
+#else
     static const point_t    logo_orig = {0, 19};
     static const point_t    call_orig = {0, CONFIG_SCREEN_HEIGHT - 8};
     static const fontSize_t logo_font = FONT_SIZE_8PT;
     static const fontSize_t call_font = FONT_SIZE_6PT;
-    #endif
+#endif
 
     gfx_print(logo_orig, logo_font, TEXT_ALIGN_CENTER, yellow_fab413, "O P N\nR T X");
     gfx_print(call_orig, call_font, TEXT_ALIGN_CENTER, color_white, state.settings.callsign);
@@ -1350,20 +1386,20 @@ void ui_updateFSM(bool *sync_rtx)
     // Check for events
     if(evQueue_wrPos == evQueue_rdPos) return;
 
-    // Pop an event from the queue
+            // Pop an event from the queue
     uint8_t newTail = (evQueue_rdPos + 1) % MAX_NUM_EVENTS;
     event_t event   = evQueue[evQueue_rdPos];
     evQueue_rdPos   = newTail;
 
-    // There is some event to process, we need an UI redraw.
-    // UI redraw request is cancelled if we're in standby mode.
+            // There is some event to process, we need an UI redraw.
+            // UI redraw request is cancelled if we're in standby mode.
     redraw_needed = true;
     if(standby) redraw_needed = false;
 
-    // Check if battery has enough charge to operate.
-    // Check is skipped if there is an ongoing transmission, since the voltage
-    // drop caused by the RF PA power absorption causes spurious triggers of
-    // the low battery alert.
+            // Check if battery has enough charge to operate.
+            // Check is skipped if there is an ongoing transmission, since the voltage
+            // drop caused by the RF PA power absorption causes spurious triggers of
+            // the low battery alert.
     bool txOngoing = platform_getPttStatus();
 #if !defined(PLATFORM_TTWRPLUS)
     if ((!state.emergency) && (!txOngoing) && (state.charge <= 0))
@@ -1378,7 +1414,7 @@ void ui_updateFSM(bool *sync_rtx)
     }
 #endif // PLATFORM_TTWRPLUS
 
-    // Unlatch and exit from macro menu on PTT press
+            // Unlatch and exit from macro menu on PTT press
     if(macro_latched && txOngoing)
     {
         macro_latched = false;
@@ -1453,17 +1489,17 @@ void ui_updateFSM(bool *sync_rtx)
                     *sync_rtx = true;
                 }
 
-                // Break out of the FSM if the keypad is locked but allow the
-                // use of the hash key in FM mode for the 1750Hz tone.
+                        // Break out of the FSM if the keypad is locked but allow the
+                        // use of the hash key in FM mode for the 1750Hz tone.
                 bool skipLock =  (state.channel.mode == OPMODE_FM)
-                              && (msg.keys == KEY_HASH);
+                                && (msg.keys == KEY_HASH);
 
                 if ((ui_state.input_locked == true) && (skipLock == false))
                     break;
 
                 if(ui_state.edit_mode)
                 {
-                    #ifdef CONFIG_M17
+#ifdef CONFIG_M17
                     if(state.channel.mode == OPMODE_M17)
                     {
                         if(msg.keys & KEY_ENTER)
@@ -1489,127 +1525,160 @@ void ui_updateFSM(bool *sync_rtx)
                             // Discard selected dst ID and disable input mode
                             ui_state.edit_mode = false;
                         else if(msg.keys & KEY_UP || msg.keys & KEY_DOWN ||
-                                msg.keys & KEY_LEFT || msg.keys & KEY_RIGHT)
+                                 msg.keys & KEY_LEFT || msg.keys & KEY_RIGHT)
                             _ui_textInputDel(ui_state.new_callsign);
                         else if(input_isCharPressed(msg))
                             _ui_textInputKeypad(ui_state.new_callsign, 9, msg, true);
                         break;
                     }
-                    #endif
+#endif
                 }
                 else
-                {
-                    if(msg.keys & KEY_ENTER)
+                    if(ui_state.edit_message)
                     {
-                        // Save current main state
-                        ui_state.last_main_state = state.ui_screen;
-                        // Open Menu
-                        state.ui_screen = MENU_TOP;
-                        // The selected item will be announced when the item is first selected.
-                    }
-                    else if(msg.keys & KEY_ESC)
-                    {
-                        // Save VFO channel
-                        state.vfo_channel = state.channel;
-                        int result = _ui_fsm_loadChannel(state.channel_index, sync_rtx);
-                        // Read successful and channel is valid
-                        if(result != -1)
-                        {
-                            // Switch to MEM screen
-                            state.ui_screen = MAIN_MEM;
-                            // anounce the active channel name.
-                            vp_announceChannelName(&state.channel,
-                                                   state.channel_index,
-                                                   queueFlags);
-                        }
-                    }
-                    else if(msg.keys & KEY_HASH)
-                    {
-                        #ifdef CONFIG_M17
-                        // Only enter edit mode when using M17
+#ifdef CONFIG_M17
                         if(state.channel.mode == OPMODE_M17)
                         {
-                            // Enable dst ID input
-                            ui_state.edit_mode = true;
-                            // Reset text input variables
-                            _ui_textInputReset(ui_state.new_callsign);
-                            vp_announceM17Info(NULL,  ui_state.edit_mode,
-                                               queueFlags);
-                        }
-                        else
-                        #endif
-                        {
-                            if(!state.tone_enabled)
+                            if(msg.keys & KEY_ENTER)
                             {
-                                state.tone_enabled = true;
+                                _ui_textInputConfirm(ui_state.new_message);
+                                // Save selected message and disable input mode
+                                strncpy(state.settings.M17_meta_text, ui_state.new_message, 52);
+                                ui_state.edit_message = false;
                                 *sync_rtx = true;
                             }
+                            else if(msg.keys & KEY_HASH)
+                            {
+                                // Save selected message and disable input mode
+                                strncpy(state.settings.M17_meta_text, "", 1);
+                                ui_state.edit_message = false;
+                                *sync_rtx = true;
+                            }
+                            else if(msg.keys & KEY_ESC)
+                                // Discard selected message and disable input mode
+                                ui_state.edit_message = false;
+                            else if(msg.keys & KEY_UP || msg.keys & KEY_DOWN ||
+                                     msg.keys & KEY_LEFT || msg.keys & KEY_RIGHT)
+                                _ui_textInputDel(ui_state.new_message);
+                            else if(input_isCharPressed(msg))
+                                _ui_textInputKeypad(ui_state.new_message, 52, msg, true);
+                            break;
                         }
+#endif
                     }
-                    else if(msg.keys & KEY_UP || msg.keys & KNOB_RIGHT)
+                    else
                     {
-                        // Increment TX and RX frequency of 12.5KHz
-                        if(_ui_freq_check_limits(state.channel.rx_frequency + freq_steps[state.step_index]) &&
-                           _ui_freq_check_limits(state.channel.tx_frequency + freq_steps[state.step_index]))
+                        if(msg.keys & KEY_ENTER)
                         {
-                            state.channel.rx_frequency += freq_steps[state.step_index];
-                            state.channel.tx_frequency += freq_steps[state.step_index];
-                            *sync_rtx = true;
-                            vp_announceFrequencies(state.channel.rx_frequency,
-                                                   state.channel.tx_frequency,
-                                                   queueFlags);
+                            // Save current main state
+                            ui_state.last_main_state = state.ui_screen;
+                            // Open Menu
+                            state.ui_screen = MENU_TOP;
+                            // The selected item will be announced when the item is first selected.
                         }
-                    }
-                    else if(msg.keys & KEY_DOWN || msg.keys & KNOB_LEFT)
-                    {
-                        // Decrement TX and RX frequency of 12.5KHz
-                        if(_ui_freq_check_limits(state.channel.rx_frequency - freq_steps[state.step_index]) &&
-                           _ui_freq_check_limits(state.channel.tx_frequency - freq_steps[state.step_index]))
+                        else if(msg.keys & KEY_ESC)
                         {
-                            state.channel.rx_frequency -= freq_steps[state.step_index];
-                            state.channel.tx_frequency -= freq_steps[state.step_index];
-                            *sync_rtx = true;
-                            vp_announceFrequencies(state.channel.rx_frequency,
-                                                   state.channel.tx_frequency,
-                                                   queueFlags);
+                            // Save VFO channel
+                            state.vfo_channel = state.channel;
+                            int result = _ui_fsm_loadChannel(state.channel_index, sync_rtx);
+                            // Read successful and channel is valid
+                            if(result != -1)
+                            {
+                                // Switch to MEM screen
+                                state.ui_screen = MAIN_MEM;
+                                // anounce the active channel name.
+                                vp_announceChannelName(&state.channel,
+                                                       state.channel_index,
+                                                       queueFlags);
+                            }
                         }
-                    }
-                    else if(msg.keys & KEY_F1)
-                    {
-                        if (state.settings.vpLevel > vpBeep)
-                        {// quick press repeat vp, long press summary.
-                            if (msg.long_press)
-                                vp_announceChannelSummary(&state.channel, 0,
-                                                          state.bank, vpAllInfo);
+                        else if(msg.keys & KEY_HASH)
+                        {
+#ifdef CONFIG_M17
+                           // Only enter edit mode when using M17
+                            if(state.channel.mode == OPMODE_M17)
+                            {
+                                // Enable dst ID input
+                                ui_state.edit_mode = true;
+                                // Reset text input variables
+                                _ui_textInputReset(ui_state.new_callsign);
+                                vp_announceM17Info(NULL,  ui_state.edit_mode,
+                                                   queueFlags);
+                            }
                             else
-                                vp_replayLastPrompt();
-                            f1Handled = true;
+#endif
+                            {
+                                if(!state.tone_enabled)
+                                {
+                                    state.tone_enabled = true;
+                                    *sync_rtx = true;
+                                }
+                            }
+                        }
+                        else if(msg.keys & KEY_UP || msg.keys & KNOB_RIGHT)
+                        {
+                            // Increment TX and RX frequency of 12.5KHz
+                            if(_ui_freq_check_limits(state.channel.rx_frequency + freq_steps[state.step_index]) &&
+                                _ui_freq_check_limits(state.channel.tx_frequency + freq_steps[state.step_index]))
+                            {
+                                state.channel.rx_frequency += freq_steps[state.step_index];
+                                state.channel.tx_frequency += freq_steps[state.step_index];
+                                *sync_rtx = true;
+                                vp_announceFrequencies(state.channel.rx_frequency,
+                                                       state.channel.tx_frequency,
+                                                       queueFlags);
+                            }
+                        }
+                        else if(msg.keys & KEY_DOWN || msg.keys & KNOB_LEFT)
+                        {
+                            // Decrement TX and RX frequency of 12.5KHz
+                            if(_ui_freq_check_limits(state.channel.rx_frequency - freq_steps[state.step_index]) &&
+                                _ui_freq_check_limits(state.channel.tx_frequency - freq_steps[state.step_index]))
+                            {
+                                state.channel.rx_frequency -= freq_steps[state.step_index];
+                                state.channel.tx_frequency -= freq_steps[state.step_index];
+                                *sync_rtx = true;
+                                vp_announceFrequencies(state.channel.rx_frequency,
+                                                       state.channel.tx_frequency,
+                                                       queueFlags);
+                            }
+                        }
+                        else if(msg.keys & KEY_F1)
+                        {
+                            if (state.settings.vpLevel > vpBeep)
+                            {// quick press repeat vp, long press summary.
+                                if (msg.long_press)
+                                    vp_announceChannelSummary(&state.channel, 0,
+                                                              state.bank, vpAllInfo);
+                                else
+                                    vp_replayLastPrompt();
+                                f1Handled = true;
+                            }
+                        }
+                        else if(input_isNumberPressed(msg))
+                        {
+                            // Open Frequency input screen
+                            state.ui_screen = MAIN_VFO_INPUT;
+                            // Reset input position and selection
+                            ui_state.input_position = 1;
+                            ui_state.input_set = SET_RX;
+                            // do not play  because we will also announce the number just entered.
+                            vp_announceInputReceiveOrTransmit(false, vpqInit);
+                            vp_queueInteger(input_getPressedNumber(msg));
+                            vp_play();
+
+                            ui_state.new_rx_frequency = 0;
+                            ui_state.new_tx_frequency = 0;
+                            // Save pressed number to calculare frequency and show in GUI
+                            ui_state.input_number = input_getPressedNumber(msg);
+                            // Calculate portion of the new frequency
+                            ui_state.new_rx_frequency = _ui_freq_add_digit(ui_state.new_rx_frequency,
+                                                                           ui_state.input_position,
+                                                                           ui_state.input_number);
                         }
                     }
-                    else if(input_isNumberPressed(msg))
-                    {
-                        // Open Frequency input screen
-                        state.ui_screen = MAIN_VFO_INPUT;
-                        // Reset input position and selection
-                        ui_state.input_position = 1;
-                        ui_state.input_set = SET_RX;
-                        // do not play  because we will also announce the number just entered.
-                        vp_announceInputReceiveOrTransmit(false, vpqInit);
-                        vp_queueInteger(input_getPressedNumber(msg));
-                        vp_play();
-
-                        ui_state.new_rx_frequency = 0;
-                        ui_state.new_tx_frequency = 0;
-                        // Save pressed number to calculare frequency and show in GUI
-                        ui_state.input_number = input_getPressedNumber(msg);
-                        // Calculate portion of the new frequency
-                        ui_state.new_rx_frequency = _ui_freq_add_digit(ui_state.new_rx_frequency,
-                                                                       ui_state.input_position,
-                                                                       ui_state.input_number);
-                    }
-                }
             }
-                break;
+            break;
             // VFO frequency input screen
             case MAIN_VFO_INPUT:
                 if(msg.keys & KEY_ENTER)
@@ -1681,10 +1750,10 @@ void ui_updateFSM(bool *sync_rtx)
                                 if (msg.long_press)
                                 {
                                     vp_announceChannelSummary(
-                                            &state.channel,
-                                            state.channel_index,
-                                            state.bank,
-                                            vpAllInfo);
+                                        &state.channel,
+                                        state.channel_index,
+                                        state.bank,
+                                        vpAllInfo);
                                 }
                                 else
                                 {
@@ -1695,7 +1764,7 @@ void ui_updateFSM(bool *sync_rtx)
                             }
                         }
                         else if(msg.keys & KEY_UP || msg.keys & KEY_DOWN ||
-                                msg.keys & KEY_LEFT || msg.keys & KEY_RIGHT)
+                                 msg.keys & KEY_LEFT || msg.keys & KEY_RIGHT)
                             _ui_textInputDel(ui_state.new_callsign);
                         else if(input_isCharPressed(msg))
                             _ui_textInputKeypad(ui_state.new_callsign, 9, msg, true);
@@ -1703,75 +1772,125 @@ void ui_updateFSM(bool *sync_rtx)
                     }
                 }
                 else
-                {
-                    if(msg.keys & KEY_ENTER)
+                    // M17 Destination message input
+                    if(ui_state.edit_message)
                     {
-                        // Save current main state
-                        ui_state.last_main_state = state.ui_screen;
-                        // Open Menu
-                        state.ui_screen = MENU_TOP;
-                    }
-                    else if(msg.keys & KEY_ESC)
-                    {
-                        // Restore VFO channel
-                        state.channel = state.vfo_channel;
-                        // Update RTX configuration
-                        *sync_rtx = true;
-                        // Switch to VFO screen
-                        state.ui_screen = MAIN_VFO;
-                    }
-                    else if(msg.keys & KEY_HASH)
-                    {
-                        // Only enter edit mode when using M17
-                        if(state.channel.mode == OPMODE_M17)
+                        if(msg.keys & KEY_ENTER)
                         {
-                            // Enable dst ID input
-                            ui_state.edit_mode = true;
-                            // Reset text input variables
-                            _ui_textInputReset(ui_state.new_callsign);
+                            _ui_textInputConfirm(ui_state.new_message);
+                            // Save selected message and disable input mode
+                            strncpy(state.settings.M17_meta_text, ui_state.new_message, 52);
+                            ui_state.edit_message = false;
+                            *sync_rtx = true;
                         }
-                        else
+                        else if(msg.keys & KEY_HASH)
                         {
-                            if(!state.tone_enabled)
+                            // Save selected message and disable input mode
+                            strncpy(state.settings.M17_meta_text, "", 1);
+                            ui_state.edit_message = false;
+                            *sync_rtx = true;
+                        }
+                        else if(msg.keys & KEY_ESC)
+                            // Discard selected message and disable input mode
+                            ui_state.edit_message = false;
+                        else if(msg.keys & KEY_F1)
+                        {
+                            if (state.settings.vpLevel > vpBeep)
                             {
-                                state.tone_enabled = true;
-                                *sync_rtx = true;
+                                // Quick press repeat vp, long press summary.
+                                if (msg.long_press)
+                                {
+                                    vp_announceChannelSummary(
+                                        &state.channel,
+                                        state.channel_index,
+                                        state.bank,
+                                        vpAllInfo);
+                                }
+                                else
+                                {
+                                    vp_replayLastPrompt();
+                                }
+
+                                f1Handled = true;
                             }
                         }
+                        else if(msg.keys & KEY_UP || msg.keys & KEY_DOWN ||
+                                 msg.keys & KEY_LEFT || msg.keys & KEY_RIGHT)
+                            _ui_textInputDel(ui_state.new_message);
+                        else if(input_isCharPressed(msg))
+                            _ui_textInputKeypad(ui_state.new_message, 52, msg, true);
+                        break;
                     }
-                    else if(msg.keys & KEY_F1)
+                    else
                     {
-                        if (state.settings.vpLevel > vpBeep)
-                        {// quick press repeat vp, long press summary.
-                            if (msg.long_press)
+                        if(msg.keys & KEY_ENTER)
+                        {
+                            // Save current main state
+                            ui_state.last_main_state = state.ui_screen;
+                            // Open Menu
+                            state.ui_screen = MENU_TOP;
+                        }
+                        else if(msg.keys & KEY_ESC)
+                        {
+                            // Restore VFO channel
+                            state.channel = state.vfo_channel;
+                            // Update RTX configuration
+                            *sync_rtx = true;
+                            // Switch to VFO screen
+                            state.ui_screen = MAIN_VFO;
+                        }
+                        else if(msg.keys & KEY_HASH)
+                        {
+                            // Only enter edit mode when using M17
+                            if(state.channel.mode == OPMODE_M17)
                             {
-                                vp_announceChannelSummary(&state.channel,
-                                                          state.channel_index+1,
-                                                          state.bank, vpAllInfo);
+                                // Enable dst ID input
+                                ui_state.edit_mode = true;
+                                // Reset text input variables
+                                _ui_textInputReset(ui_state.new_callsign);
                             }
                             else
                             {
-                                vp_replayLastPrompt();
+                                if(!state.tone_enabled)
+                                {
+                                    state.tone_enabled = true;
+                                    *sync_rtx = true;
+                                }
                             }
+                        }
+                        else if(msg.keys & KEY_F1)
+                        {
+                            if (state.settings.vpLevel > vpBeep)
+                            {// quick press repeat vp, long press summary.
+                                if (msg.long_press)
+                                {
+                                    vp_announceChannelSummary(&state.channel,
+                                                              state.channel_index+1,
+                                                              state.bank, vpAllInfo);
+                                }
+                                else
+                                {
+                                    vp_replayLastPrompt();
+                                }
 
-                            f1Handled = true;
+                                f1Handled = true;
+                            }
+                        }
+                        else if(msg.keys & KEY_UP || msg.keys & KNOB_RIGHT)
+                        {
+                            _ui_fsm_loadChannel(state.channel_index + 1, sync_rtx);
+                            vp_announceChannelName(&state.channel,
+                                                   state.channel_index+1,
+                                                   queueFlags);
+                        }
+                        else if(msg.keys & KEY_DOWN || msg.keys & KNOB_LEFT)
+                        {
+                            _ui_fsm_loadChannel(state.channel_index - 1, sync_rtx);
+                            vp_announceChannelName(&state.channel,
+                                                   state.channel_index+1,
+                                                   queueFlags);
                         }
                     }
-                    else if(msg.keys & KEY_UP || msg.keys & KNOB_RIGHT)
-                    {
-                        _ui_fsm_loadChannel(state.channel_index + 1, sync_rtx);
-                        vp_announceChannelName(&state.channel,
-                                               state.channel_index+1,
-                                               queueFlags);
-                    }
-                    else if(msg.keys & KEY_DOWN || msg.keys & KNOB_LEFT)
-                    {
-                        _ui_fsm_loadChannel(state.channel_index - 1, sync_rtx);
-                        vp_announceChannelName(&state.channel,
-                                               state.channel_index+1,
-                                               queueFlags);
-                    }
-                }
                 break;
             // Top menu screen
             case MENU_TOP:
@@ -1900,7 +2019,7 @@ void ui_updateFSM(bool *sync_rtx)
                     _ui_menuBack(MENU_TOP);
                 break;
 #endif
-            // Settings menu screen
+        // Settings menu screen
             case MENU_SETTINGS:
                 if(msg.keys & KEY_UP || msg.keys & KNOB_LEFT)
                     _ui_menuUp(settings_num);
@@ -2041,13 +2160,13 @@ void ui_updateFSM(bool *sync_rtx)
                     ui_state.input_position += 1;
                     ui_state.input_number = input_getPressedNumber(msg);
                     _ui_timedate_add_digit(&ui_state.new_timedate, ui_state.input_position,
-                                            ui_state.input_number);
+                                           ui_state.input_number);
                 }
                 break;
 #endif
             case SETTINGS_DISPLAY:
                 if(msg.keys & KEY_LEFT || (ui_state.edit_mode &&
-                   (msg.keys & KEY_DOWN || msg.keys & KNOB_LEFT)))
+                                            (msg.keys & KEY_DOWN || msg.keys & KNOB_LEFT)))
                 {
                     switch(ui_state.menu_selected)
                     {
@@ -2074,7 +2193,7 @@ void ui_updateFSM(bool *sync_rtx)
                     }
                 }
                 else if(msg.keys & KEY_RIGHT || (ui_state.edit_mode &&
-                        (msg.keys & KEY_UP || msg.keys & KNOB_RIGHT)))
+                                                  (msg.keys & KEY_UP || msg.keys & KNOB_RIGHT)))
                 {
                     switch(ui_state.menu_selected)
                     {
@@ -2112,9 +2231,9 @@ void ui_updateFSM(bool *sync_rtx)
 #ifdef CONFIG_GPS
             case SETTINGS_GPS:
                 if(msg.keys & KEY_LEFT || msg.keys & KEY_RIGHT ||
-                   (ui_state.edit_mode &&
-                   (msg.keys & KEY_DOWN || msg.keys & KNOB_LEFT ||
-                    msg.keys & KEY_UP || msg.keys & KNOB_RIGHT)))
+                    (ui_state.edit_mode &&
+                     (msg.keys & KEY_DOWN || msg.keys & KNOB_LEFT ||
+                      msg.keys & KEY_UP || msg.keys & KNOB_RIGHT)))
                 {
                     switch(ui_state.menu_selected)
                     {
@@ -2135,10 +2254,10 @@ void ui_updateFSM(bool *sync_rtx)
                             break;
                         case G_TIMEZONE:
                             if(msg.keys & KEY_LEFT || msg.keys & KEY_DOWN ||
-                               msg.keys & KNOB_LEFT)
+                                msg.keys & KNOB_LEFT)
                                 state.settings.utc_timezone -= 1;
                             else if(msg.keys & KEY_RIGHT || msg.keys & KEY_UP ||
-                                    msg.keys & KNOB_RIGHT)
+                                     msg.keys & KNOB_RIGHT)
                                 state.settings.utc_timezone += 1;
                             vp_announceTimeZone(state.settings.utc_timezone, queueFlags);
                             break;
@@ -2156,7 +2275,7 @@ void ui_updateFSM(bool *sync_rtx)
                     _ui_menuBack(MENU_SETTINGS);
                 break;
 #endif
-            // Radio Settings
+        // Radio Settings
             case SETTINGS_RADIO:
                 // If the entry is selected with enter we are in edit_mode
                 if (ui_state.edit_mode)
@@ -2164,7 +2283,7 @@ void ui_updateFSM(bool *sync_rtx)
                     switch(ui_state.menu_selected)
                     {
                         case R_OFFSET:
-                            // Handle offset frequency input
+                                        // Handle offset frequency input
 #if defined(CONFIG_UI_NO_KEYBOARD)
                             if(msg.long_press && msg.keys & KEY_ENTER)
                             {
@@ -2174,43 +2293,43 @@ void ui_updateFSM(bool *sync_rtx)
                             if(msg.keys & KEY_ENTER)
                             {
 #endif
-                                // Apply new offset
+        // Apply new offset
                                 state.channel.tx_frequency = state.channel.rx_frequency + ui_state.new_offset;
                                 vp_queueStringTableEntry(&currentLanguage->frequencyOffset);
                                 vp_queueFrequency(ui_state.new_offset);
                                 ui_state.edit_mode = false;
                             }
                             else
-                            if(msg.keys & KEY_ESC)
-                            {
-                                // Announce old frequency offset
-                                vp_queueStringTableEntry(&currentLanguage->frequencyOffset);
-                                vp_queueFrequency((int32_t)state.channel.tx_frequency - (int32_t)state.channel.rx_frequency);
-                            }
-                            else if(msg.keys & KEY_UP || msg.keys & KEY_DOWN ||
-                                    msg.keys & KEY_LEFT || msg.keys & KEY_RIGHT)
-                            {
-                                _ui_numberInputDel(&ui_state.new_offset);
-                            }
+                                if(msg.keys & KEY_ESC)
+                                {
+                                    // Announce old frequency offset
+                                    vp_queueStringTableEntry(&currentLanguage->frequencyOffset);
+                                    vp_queueFrequency((int32_t)state.channel.tx_frequency - (int32_t)state.channel.rx_frequency);
+                                }
+                                else if(msg.keys & KEY_UP || msg.keys & KEY_DOWN ||
+                                         msg.keys & KEY_LEFT || msg.keys & KEY_RIGHT)
+                                {
+                                    _ui_numberInputDel(&ui_state.new_offset);
+                                }
 #if defined(CONFIG_UI_NO_KEYBOARD)
-                            else if(msg.keys & KNOB_LEFT || msg.keys & KNOB_RIGHT || msg.keys & KEY_ENTER)
+                                else if(msg.keys & KNOB_LEFT || msg.keys & KNOB_RIGHT || msg.keys & KEY_ENTER)
 #else
-                            else if(input_isNumberPressed(msg))
+                                else if(input_isNumberPressed(msg))
 #endif
-                            {
-                                _ui_numberInputKeypad(&ui_state.new_offset, msg);
-                                ui_state.input_position += 1;
-                            }
-                            else if (msg.long_press && (msg.keys & KEY_F1) && (state.settings.vpLevel > vpBeep))
-                            {
-                                vp_queueFrequency(ui_state.new_offset);
-                                f1Handled=true;
-                            }
+                                {
+                                    _ui_numberInputKeypad(&ui_state.new_offset, msg);
+                                    ui_state.input_position += 1;
+                                }
+                                else if (msg.long_press && (msg.keys & KEY_F1) && (state.settings.vpLevel > vpBeep))
+                                {
+                                    vp_queueFrequency(ui_state.new_offset);
+                                    f1Handled=true;
+                                }
                             break;
                         case R_DIRECTION:
                             if(msg.keys & KEY_UP || msg.keys & KEY_DOWN ||
-                               msg.keys & KEY_LEFT || msg.keys & KEY_RIGHT ||
-                               msg.keys & KNOB_LEFT || msg.keys & KNOB_RIGHT)
+                                msg.keys & KEY_LEFT || msg.keys & KEY_RIGHT ||
+                                msg.keys & KNOB_LEFT || msg.keys & KNOB_RIGHT)
                             {
                                 // Invert frequency offset direction
                                 if (state.channel.tx_frequency >= state.channel.rx_frequency)
@@ -2296,6 +2415,35 @@ void ui_updateFSM(bool *sync_rtx)
                                 f1Handled=true;
                             }
                             break;
+                        case M17_METATEXT:
+                            // Handle text input for M17 message text
+                            if(msg.keys & KEY_ENTER)
+                            {
+                                _ui_textInputConfirm(ui_state.new_message);
+                                // Save selected callsign and disable input mode
+                                strncpy(state.settings.M17_meta_text, ui_state.new_message, 52);
+                                ui_state.edit_message = false;
+                                ui_state.edit_mode = false;
+                            }
+                            else if(msg.keys & KEY_ESC)
+                            {
+                                // Discard selected message and disable input mode
+                                ui_state.edit_message = false;
+                            }
+                            else if(msg.keys & KEY_UP || msg.keys & KEY_DOWN ||
+                                     msg.keys & KEY_LEFT || msg.keys & KEY_RIGHT)
+                            {
+                                _ui_textInputDel(ui_state.new_message);
+                            }
+                            else if(input_isCharPressed(msg))
+                            {
+                                _ui_textInputKeypad(ui_state.new_message, 52, msg, false);
+                            }
+                            else if (msg.long_press && (msg.keys & KEY_F1) && (state.settings.vpLevel > vpBeep))
+                            {
+                                f1Handled=true;
+                            }
+                            break;
                         case M17_CAN:
                             if(msg.keys & KEY_DOWN || msg.keys & KNOB_LEFT)
                                 _ui_changeM17Can(-1);
@@ -2328,12 +2476,19 @@ void ui_updateFSM(bool *sync_rtx)
                         // Enable edit mode
                         ui_state.edit_mode = true;
 
-                        // If callsign input, reset text input variables
+                                // If callsign input, reset text input variables
                         if(ui_state.menu_selected == M17_CALLSIGN)
                         {
                             _ui_textInputReset(ui_state.new_callsign);
                             vp_announceBuffer(&currentLanguage->callsign,
-                                            true, true, ui_state.new_callsign);
+                                              true, true, ui_state.new_callsign);
+                        }
+                        // If message input, reset text input variables
+                        if(ui_state.menu_selected == M17_METATEXT)
+                        {
+                            //   ui_state.edit_mode = false;
+                            ui_state.edit_message = true;
+                            _ui_textInputReset(ui_state.new_message);
                         }
                     }
                     else if(msg.keys & KEY_UP || msg.keys & KNOB_LEFT)
@@ -2341,9 +2496,9 @@ void ui_updateFSM(bool *sync_rtx)
                     else if(msg.keys & KEY_DOWN || msg.keys & KNOB_RIGHT)
                         _ui_menuDown(settings_m17_num);
                     else if((msg.keys & KEY_RIGHT) && (ui_state.menu_selected == M17_CAN))
-                            _ui_changeM17Can(+1);
+                        _ui_changeM17Can(+1);
                     else if((msg.keys & KEY_LEFT)  && (ui_state.menu_selected == M17_CAN))
-                            _ui_changeM17Can(-1);
+                        _ui_changeM17Can(-1);
                     else if(msg.keys & KEY_ESC)
                     {
                         *sync_rtx = true;
@@ -2354,7 +2509,7 @@ void ui_updateFSM(bool *sync_rtx)
 #endif
             case SETTINGS_ACCESSIBILITY:
                 if(msg.keys & KEY_LEFT || (ui_state.edit_mode &&
-                   (msg.keys & KEY_DOWN || msg.keys & KNOB_LEFT)))
+                                            (msg.keys & KEY_DOWN || msg.keys & KNOB_LEFT)))
                 {
                     switch(ui_state.menu_selected)
                     {
@@ -2372,7 +2527,7 @@ void ui_updateFSM(bool *sync_rtx)
                     }
                 }
                 else if(msg.keys & KEY_RIGHT || (ui_state.edit_mode &&
-                        (msg.keys & KEY_UP || msg.keys & KNOB_RIGHT)))
+                                                  (msg.keys & KEY_UP || msg.keys & KNOB_RIGHT)))
                 {
                     switch(ui_state.menu_selected)
                     {
@@ -2426,7 +2581,7 @@ void ui_updateFSM(bool *sync_rtx)
                 break;
         }
 
-        // Enable Tx only if in MAIN_VFO or MAIN_MEM states
+                // Enable Tx only if in MAIN_VFO or MAIN_MEM states
         bool inMemOrVfo = (state.ui_screen == MAIN_VFO) || (state.ui_screen == MAIN_MEM);
         if ((macro_menu == true) || ((inMemOrVfo == false) && (state.txDisable == false)))
         {
@@ -2594,7 +2749,7 @@ bool ui_updateGUI()
             break;
     }
 
-    // If MACRO menu is active draw it
+            // If MACRO menu is active draw it
     if(macro_menu)
     {
         _ui_drawDarkOverlay();
@@ -2609,10 +2764,10 @@ bool ui_pushEvent(const uint8_t type, const uint32_t data)
 {
     uint8_t newHead = (evQueue_wrPos + 1) % MAX_NUM_EVENTS;
 
-    // Queue is full
+            // Queue is full
     if(newHead == evQueue_rdPos) return false;
 
-    // Preserve atomicity when writing the new element into the queue.
+            // Preserve atomicity when writing the new element into the queue.
     event_t event;
     event.type    = type;
     event.payload = data;

--- a/openrtx/src/ui/default/ui_main.c
+++ b/openrtx/src/ui/default/ui_main.c
@@ -16,16 +16,73 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, see <http://www.gnu.org/licenses/>   *
+ *                                                                         *
+ *   (2025) Modified by KD0OSS for new modes on Module17                   *
  ***************************************************************************/
 
 #include <interfaces/platform.h>
 #include <interfaces/cps_io.h>
+#include <interfaces/delays.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <ui/ui_default.h>
 #include <string.h>
 #include <ui/ui_strings.h>
 #include <utils.h>
+
+
+static char message[66];
+static bool scrollStarted = false;
+
+// shift string to left by one char
+// putting first char to the back
+bool _ui_scrollString(char *string, bool reset)
+{
+    uint8_t stringLen = 0;
+    char *in = NULL;
+
+    if(reset)
+    {
+        // add extra space to allow for gap
+        // between last char and first
+        stringLen = strlen(string)+2;
+        in = malloc(stringLen);
+        if(in == NULL) return false;
+        memset(in, 0, stringLen);
+    }
+    else
+    {
+        stringLen = strlen(string)+1;
+        in = malloc(stringLen);
+    }
+    if(in == NULL) return false;
+    strcpy(in, string);
+    if(reset)
+    {
+        // add space to end
+        in[strlen(string)] = 32;
+    }
+
+    char *data = malloc(stringLen);
+    if(data == NULL)
+    {
+        free(in);
+        return false;
+    }
+    memset(data, 0, stringLen);
+
+    size_t i;
+    for(i=1;i<strlen(in);i++)
+        data[i-1] = in[i];
+    data[i-1] = in[0];
+
+    strcpy(string, data);
+    free(data);
+    free(in);
+
+    return true;
+}
 
 void _ui_drawMainBackground()
 {
@@ -142,6 +199,39 @@ void _ui_drawModeInfo(ui_state_t* ui_state)
                 gfx_print(layout.line1_pos, layout.line2_font, TEXT_ALIGN_CENTER,
                           color_white, "%s", rtxStatus.M17_src);
 
+                // metatext available
+                if((strlen(rtxStatus.M17_Meta_Text) > 13) ||
+                    (rtxStatus.M17_Meta_Text[0] != '\0' && rtxStatus.M17_refl[0] != '\0'))
+                {
+                    if(!scrollStarted)
+                    {
+                        // if reflector info present prepend to message and share line3
+                        if(rtxStatus.M17_refl[0] != '\0')
+                            sprintf(message, "%s--%s", rtxStatus.M17_refl, rtxStatus.M17_Meta_Text);
+                        else
+                            strcpy(message, rtxStatus.M17_Meta_Text);
+                        _ui_scrollString(message, true);
+                        scrollStarted = true;
+                    }
+                    _ui_scrollString(message, false);
+
+                    char msg[14];
+                    strncpy(msg, message, 13);
+                    gfx_print(layout.line3_pos, layout.line2_font, TEXT_ALIGN_CENTER,
+                              color_white, "%s", msg);
+                    sleepFor(0, 100);
+                }
+                else
+                    if(strlen(rtxStatus.M17_Meta_Text) > 0)
+                    {
+                        if(rtxStatus.M17_refl[0] != '\0')
+                            sprintf(message, "%s--%s", rtxStatus.M17_refl, rtxStatus.M17_Meta_Text);
+                        else
+                            strcpy(message, rtxStatus.M17_Meta_Text);
+                        gfx_print(layout.line3_pos, layout.line3_font, TEXT_ALIGN_CENTER,
+                                  color_white, "%s", message);
+                    }
+
                 // RF link (if present)
                 if(rtxStatus.M17_link[0] != '\0')
                 {
@@ -153,7 +243,7 @@ void _ui_drawModeInfo(ui_state_t* ui_state)
                 }
 
                 // Reflector (if present)
-                if(rtxStatus.M17_refl[0] != '\0')
+                if(rtxStatus.M17_refl[0] != '\0' && rtxStatus.M17_Meta_Text[0] == '\0')
                 {
                     gfx_drawSymbol(layout.line3_pos, layout.line4_symbol_size, TEXT_ALIGN_LEFT,
                                    color_white, SYMBOL_NETWORK);
@@ -165,6 +255,7 @@ void _ui_drawModeInfo(ui_state_t* ui_state)
             else
             {
                 const char *dst = NULL;
+                scrollStarted = false;
                 if(ui_state->edit_mode)
                 {
                     dst = ui_state->new_callsign;

--- a/openrtx/src/ui/default/ui_menu.c
+++ b/openrtx/src/ui/default/ui_menu.c
@@ -16,6 +16,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, see <http://www.gnu.org/licenses/>   *
+ *                                                                         *
+ *   (2025) Modified by KD0OSS for new modes on Module17                   *
  ***************************************************************************/
 
 #include <stdio.h>
@@ -216,7 +218,7 @@ void _ui_drawMenuListValue(ui_state_t* ui_state, uint8_t selected,
                 // If we are in edit mode, draw a hollow rectangle
                 text_color = color_black;
                 bool full_rect = true;
-                if(ui_state->edit_mode)
+                if(ui_state->edit_mode || ui_state->edit_message)
                 {
                     text_color = color_white;
                     full_rect = false;
@@ -229,7 +231,7 @@ void _ui_drawMenuListValue(ui_state_t* ui_state, uint8_t selected,
                 // E.g. when pressing Enter on Display Brightness etc.
                 if (editModeChanged)
                     priorSelectedMenuName[0]='\0';
-                if (!ui_state->edit_mode || editModeChanged)
+                if ((!ui_state->edit_mode && !ui_state->edit_message) || editModeChanged)
                 {// If in edit mode, only want to speak the char being entered,,
             //not repeat the entire display.
                     announceMenuItemIfNeeded(entry_buf, value_buf,
@@ -241,6 +243,27 @@ void _ui_drawMenuListValue(ui_state_t* ui_state, uint8_t selected,
             pos.y += layout.menu_h;
         }
     }
+}
+
+bool _ui_viewSubString(char *in_string, char *out_string, uint16_t start_pos, uint16_t num_chars)
+{
+    uint16_t totalLen = strlen(in_string);
+    if(start_pos >= totalLen || (num_chars + start_pos) > totalLen)
+        return false;
+
+    memset(out_string, 0, num_chars+1);
+
+    uint16_t i;
+    for(i=0;i<num_chars;i++)
+    {
+        out_string[i] = in_string[start_pos + i];
+        // replace tab, line feed and carriage return with space
+        if(out_string[i] == 0x09 || out_string[i] == 0x0a || out_string[i] == 0x0d)
+            out_string[i] = 0x20;
+    }
+    out_string[i] = 0;
+
+    return true;
 }
 
 int _ui_getMenuTopEntryName(char *buf, uint8_t max_len, uint8_t index)
@@ -425,6 +448,20 @@ int _ui_getM17ValueName(char *buf, uint8_t max_len, uint8_t index)
         case M17_CALLSIGN:
             sniprintf(buf, max_len, "%s", last_state.settings.callsign);
             break;
+
+        case M17_METATEXT:
+            // limit display to 8 characters
+            if (strlen(last_state.settings.M17_meta_text) > 7)
+            {
+                char tmp[9];
+                memcpy(tmp, last_state.settings.M17_meta_text, 7);
+                tmp[8] = 0;
+                // append asterisk to indicate more characters than displayed
+                sniprintf(buf, max_len, "%s*", tmp);
+            }
+            else
+                sniprintf(buf, max_len, "%s", last_state.settings.M17_meta_text);
+        break;
 
         case M17_CAN:
             sniprintf(buf, max_len, "%d", last_state.settings.m17_can);
@@ -956,10 +993,23 @@ void _ui_drawSettingsM17(ui_state_t* ui_state)
                       TEXT_ALIGN_CENTER, color_white, ui_state->new_callsign);
     }
     else
-    {
-        _ui_drawMenuListValue(ui_state, ui_state->menu_selected, _ui_getM17EntryName,
+        if((ui_state->edit_message) && (ui_state->menu_selected == M17_METATEXT))
+        {
+            uint16_t rect_width = CONFIG_SCREEN_WIDTH - (layout.horizontal_pad * 2);
+            uint16_t rect_height = (CONFIG_SCREEN_HEIGHT - (layout.top_h + layout.bottom_h))/2;
+            point_t rect_origin = {(CONFIG_SCREEN_WIDTH - rect_width) / 2,
+                (CONFIG_SCREEN_HEIGHT - rect_height) / 2};
+                gfx_drawRect(rect_origin, rect_width, rect_height, color_white, false);
+                // Print M17 message being typed
+                gfx_printLine(1, 1, layout.top_h, CONFIG_SCREEN_HEIGHT - layout.bottom_h,
+                              layout.horizontal_pad, layout.message_font,
+                              TEXT_ALIGN_CENTER, color_white, ui_state->new_message);
+        }
+        else
+        {
+            _ui_drawMenuListValue(ui_state, ui_state->menu_selected, _ui_getM17EntryName,
                               _ui_getM17ValueName);
-    }
+        }
 }
 #endif
 

--- a/openrtx/src/ui/module17/ui_main.c
+++ b/openrtx/src/ui/module17/ui_main.c
@@ -16,14 +16,73 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, see <http://www.gnu.org/licenses/>   *
+ *                                                                         *
+ *   (2025) Modified by KD0OSS for new modes on Module17                   *
  ***************************************************************************/
 
 #include <interfaces/platform.h>
 #include <interfaces/cps_io.h>
+#include <interfaces/delays.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <ui/ui_mod17.h>
 #include <string.h>
+
+#include <unistd.h>
+#include <stdlib.h>
+
+
+static char message[54];
+static bool scrollStarted = false;
+
+// shift string to left by one char
+// putting first char to the back
+bool _ui_scrollString(char *string, bool reset)
+{
+    uint8_t stringLen = 0;
+    char *in = NULL;
+
+    if(reset)
+    {
+        // add extra space to allow for gap
+        // between last char and first
+        stringLen = strlen(string)+2;
+        in = malloc(stringLen);
+        if(in == NULL) return false;
+        memset(in, 0, stringLen);
+    }
+    else
+    {
+        stringLen = strlen(string)+1;
+        in = malloc(stringLen);
+    }
+    if(in == NULL) return false;
+    strcpy(in, string);
+    if(reset)
+    {
+        // add space to end
+        in[strlen(string)] = 32;
+    }
+
+    char *data = malloc(stringLen);
+    if(data == NULL)
+    {
+        free(in);
+        return false;
+    }
+    memset(data, 0, stringLen);
+
+    size_t i;
+    for(i=1;i<strlen(in);i++)
+        data[i-1] = in[i];
+    data[i-1] = in[0];
+
+    strcpy(string, data);
+    free(data);
+    free(in);
+
+    return true;
+}
 
 void _ui_drawMainBackground()
 {
@@ -68,26 +127,49 @@ static void _ui_drawModeInfo(ui_state_t* ui_state)
                 gfx_print(layout.line1_pos, layout.line2_font, TEXT_ALIGN_CENTER,
                           color_white, "%s", rtxStatus.M17_src);
 
-                if(rtxStatus.M17_link[0] != '\0')
+                // metatext available
+                if(strlen(rtxStatus.M17_Meta_Text) > 20)
                 {
-                    gfx_drawSymbol(layout.line4_pos, layout.line3_symbol_font, TEXT_ALIGN_LEFT,
-                                color_white, SYMBOL_ACCESS_POINT);
-                    gfx_print(layout.line4_pos, layout.line2_font, TEXT_ALIGN_CENTER,
-                            color_white, "%s", rtxStatus.M17_link);
-                }
+                    if(!scrollStarted)
+                    {
+                        strcpy(message, rtxStatus.M17_Meta_Text);
+                        _ui_scrollString(message, true);
+                        scrollStarted = true;
+                    }
+                    _ui_scrollString(message, false);
 
-                if(rtxStatus.M17_refl[0] != '\0')
-                {
-                    gfx_drawSymbol(layout.line3_pos, layout.line4_symbol_font, TEXT_ALIGN_LEFT,
-                                   color_white, SYMBOL_NETWORK);
-                    gfx_print(layout.line3_pos, layout.line2_font, TEXT_ALIGN_CENTER,
-                              color_white, "%s", rtxStatus.M17_refl);
+                    char msg[21];
+                    strncpy(msg, message, 20);
+                    gfx_print(layout.line5_pos, layout.line2_font, TEXT_ALIGN_CENTER,
+                              color_white, "%s", msg);
+                    sleepFor(0, 100);
                 }
+                else
+                    if(strlen(rtxStatus.M17_Meta_Text) > 0)
+                        gfx_print(layout.line5_pos, layout.line2_font, TEXT_ALIGN_CENTER,
+                                  color_white, "%s", rtxStatus.M17_Meta_Text);
+
+                        if(rtxStatus.M17_link[0] != '\0')
+                        {
+                            gfx_drawSymbol(layout.line4_pos, layout.line4_symbol_font, TEXT_ALIGN_LEFT,
+                                           color_white, SYMBOL_ACCESS_POINT);
+                            gfx_print(layout.line4_pos, layout.line2_font, TEXT_ALIGN_CENTER,
+                                      color_white, "%s", rtxStatus.M17_link);
+                        }
+
+                        if(rtxStatus.M17_refl[0] != '\0')
+                        {
+                            gfx_drawSymbol(layout.line3_pos, layout.line3_symbol_font, TEXT_ALIGN_LEFT,
+                                           color_white, SYMBOL_NETWORK);
+                            gfx_print(layout.line3_pos, layout.line2_font, TEXT_ALIGN_CENTER,
+                                      color_white, "%s", rtxStatus.M17_refl);
+                        }
             }
             else
             {
                 char *dst = NULL;
                 char *last = NULL;
+                scrollStarted = false;
 
                 if(ui_state->edit_mode)
                 {

--- a/openrtx/src/ui/module17/ui_menu.c
+++ b/openrtx/src/ui/module17/ui_menu.c
@@ -16,6 +16,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, see <http://www.gnu.org/licenses/>   *
+ *                                                                         *
+ *   (2025) Modified by KD0OSS for new modes on Module17                   *
  ***************************************************************************/
 
 #include <stdio.h>
@@ -195,6 +197,19 @@ int _ui_getM17ValueName(char *buf, uint8_t max_len, uint8_t index)
     {
         case M_CALLSIGN:
             snprintf(buf, max_len, "%s", last_state.settings.callsign);
+            return 0;
+        case M_METATEXT:
+            // limit display to 8 characters
+            if (strlen(last_state.settings.M17_meta_text) > 8)
+            {
+                char tmp[9];
+                memcpy(tmp, last_state.settings.M17_meta_text, 8);
+                tmp[8] = 0;
+                // append asterisk to indicate more characters than displayed
+                snprintf(buf, max_len, "%s*", tmp);
+            }
+            else
+                snprintf(buf, max_len, "%s", last_state.settings.M17_meta_text);
             return 0;
         case M_CAN:
             snprintf(buf, max_len, "%d", last_state.settings.m17_can);
@@ -572,6 +587,21 @@ void _ui_drawSettingsM17(ui_state_t* ui_state)
         gfx_printLine(1, 1, layout.top_h, CONFIG_SCREEN_HEIGHT - layout.bottom_h,
                       layout.horizontal_pad, layout.input_font,
                       TEXT_ALIGN_CENTER, color_white, ui_state->new_callsign);
+        // Print Button Info
+        gfx_print(layout.line5_pos, layout.line5_font, TEXT_ALIGN_LEFT,
+                  color_white, "Cancel");
+        gfx_print(layout.line5_pos, layout.line5_font, TEXT_ALIGN_RIGHT,
+                  color_white, "Accept");
+    }
+    else if(ui_state->edit_message)
+    {
+        gfx_printLine(1, 4, layout.top_h, CONFIG_SCREEN_HEIGHT - layout.bottom_h,
+                      layout.horizontal_pad, layout.menu_font,
+                      TEXT_ALIGN_LEFT, color_white, "Message:");
+
+        gfx_printLine(1, 1, layout.top_h, CONFIG_SCREEN_HEIGHT - layout.bottom_h,
+                      layout.horizontal_pad, layout.message_font,
+                      TEXT_ALIGN_CENTER, color_white, ui_state->new_message);
         // Print Button Info
         gfx_print(layout.line5_pos, layout.line5_font, TEXT_ALIGN_LEFT,
                   color_white, "Cancel");


### PR DESCRIPTION
m17 meta: send and receive text metadata, send gnss metadata for m17 mode

This commit contains the original work on supporting sending and receiving metadata, both text and gnss, for the M17 mode. This was included as part of a larger PR https://github.com/OpenRTX/OpenRTX/pull/314 which the lead requested be split up, with the first PR focusing on this feature alone.

This change was created by taking https://github.com/turnrye/OpenRTX/commit/23d8034c907a25e1f096eb977448ca35c8e0ac3a and picking over only files, and in some case sections of files, in order for the metadata features to function. It has generally been tested to ensure that the picking was done properly, but further verification of the intended functionality has not taken place as part of this commit.

Compared to Rick's original work, the only changes that I've intentionally made here are to permit builds, as there was a mistaken import left behind in the original branch.