### PR TITLE
FM Menu

### DIFF
--- a/openrtx/include/ui/EnglishStrings.h
+++ b/openrtx/include/ui/EnglishStrings.h
@@ -98,6 +98,11 @@ const stringsTable_t englishStrings =
     .noGps             = "No GPS",
     .batteryIcon       = "Battery Icon",
     .fmSettings        = "FM Settings",
-    .CTCSSTone         = "CTCSS Frequency"
+    .CTCSSTone         = "CTCSS Frequency",
+    .CTCSSEnabled      = "CTCSS En.",
+    .CTCSSEnabledEncode = "Encode",
+    .CTCSSEnabledDecode = "Decode",
+    .CTCSSEnabledBoth  = "Both",
+    .CTCSSEnabledNone  = "None"
 };
 #endif  // ENGLISHSTRINGS_H

--- a/openrtx/include/ui/SpanishStrings.h
+++ b/openrtx/include/ui/SpanishStrings.h
@@ -99,6 +99,12 @@ const stringsTable_t spanishStrings =
     .noGps             = "Ningún GPS",
     .batteryIcon       = "Icon de batteria",
     .fmSettings        = "Ajustes de FM",
-    .CTCSSTone         = "CTCSS Frequency"
+    .CTCSSTone         = "CTCSS Frequency",
+    .CTCSSEnabled      = "CTCSS En.",
+    .CTCSSEnabledEncode = "Codificar",
+    .CTCSSEnabledDecode = "Decodificar",
+    .CTCSSEnabledBoth  = "Ambos",
+    .CTCSSEnabledNone  = "Ni"
+
 };
 #endif  // SPANISHSTRINGS_H

--- a/openrtx/include/ui/ui_default.h
+++ b/openrtx/include/ui/ui_default.h
@@ -157,7 +157,8 @@ enum settingsM17Items
 
 enum settingsFMItems
 {
-    CTCSS_Tone
+    CTCSS_Tone,
+    CTCSS_Enabled
 };
 
 /**

--- a/openrtx/include/ui/ui_strings.h
+++ b/openrtx/include/ui/ui_strings.h
@@ -103,6 +103,11 @@ typedef struct
     const char* batteryIcon;
     const char* fmSettings;
     const char* CTCSSTone;
+    const char* CTCSSEnabled;
+    const char* CTCSSEnabledEncode;
+    const char* CTCSSEnabledDecode;
+    const char* CTCSSEnabledBoth;
+    const char* CTCSSEnabledNone;
 }
 stringsTable_t;
 

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -119,7 +119,7 @@ extern void _ui_drawSettingsReset2Defaults(ui_state_t* ui_state);
 extern void _ui_drawSettingsRadio(ui_state_t* ui_state);
 extern bool _ui_drawMacroMenu(ui_state_t* ui_state);
 extern void _ui_reset_menu_anouncement_tracking();
-
+// TODO: get these from ui strings / currentLanguage
 const char *menu_items[] =
 {
     "Banks",
@@ -188,7 +188,8 @@ const char * settings_m17_items[] =
 
 const char* settings_fm_items[] =
 {
-    "CTCSS Tone"
+    "CTCSS Tone",
+    "CTCSS On"
 };
 
 const char * settings_accessibility_items[] =
@@ -890,6 +891,26 @@ static bool _ui_exitStandby(long long now)
     return true;
 }
 
+// TODO: find a better home for this function
+/**
+ * Handle tone selection scrolling. This makes it easy for the UX to scroll through the various states that these two bool states can be.
+ */
+int _ui_handleToneSelectScroll(bool direction_up) {
+    bool tone_tx_enable = state.channel.fm.txToneEn;
+    bool tone_rx_enable = state.channel.fm.rxToneEn;
+    uint8_t tone_flags = tone_tx_enable << 1 | tone_rx_enable;
+    if(direction_up) 
+        tone_flags++;
+    else
+        tone_flags--;
+    tone_flags %= 4;
+    tone_tx_enable            = tone_flags >> 1;
+    tone_rx_enable            = tone_flags & 1;
+    state.channel.fm.txToneEn = tone_tx_enable;
+    state.channel.fm.rxToneEn = tone_rx_enable;
+    return 1;
+}
+
 static void _ui_fsm_menuMacro(kbd_msg_t msg, bool *sync_rtx)
 {
     // If there is no keyboard left and right select the menu entry to edit
@@ -913,9 +934,6 @@ static void _ui_fsm_menuMacro(kbd_msg_t msg, bool *sync_rtx)
     ui_state.input_number = input_getPressedNumber(msg);
 #endif // CONFIG_UI_NO_KEYBOARD
     // CTCSS Encode/Decode Selection
-    bool tone_tx_enable = state.channel.fm.txToneEn;
-    bool tone_rx_enable = state.channel.fm.rxToneEn;
-    uint8_t tone_flags = tone_tx_enable << 1 | tone_rx_enable;
     vpQueueFlags_t queueFlags = vp_getVoiceLevelQueueFlags();
 
     switch(ui_state.input_number)
@@ -923,12 +941,7 @@ static void _ui_fsm_menuMacro(kbd_msg_t msg, bool *sync_rtx)
         case 1:
             if(state.channel.mode == OPMODE_FM)
             {
-                tone_flags++;
-                tone_flags %= 4;
-                tone_tx_enable            = tone_flags >> 1;
-                tone_rx_enable            = tone_flags & 1;
-                state.channel.fm.txToneEn = tone_tx_enable;
-                state.channel.fm.rxToneEn = tone_rx_enable;
+                _ui_handleToneSelectScroll(true);
                 *sync_rtx                 = true;
                 vp_announceCTCSS(
                     state.channel.fm.rxToneEn, state.channel.fm.rxTone,
@@ -2386,6 +2399,12 @@ void ui_updateFSM(bool *sync_rtx)
                                     state.channel.fm.txTone--;
                                 }
                             }
+                            else if (msg.keys & KEY_UP || msg.keys & KNOB_RIGHT)
+                            {
+                                state.channel.fm.txTone++;
+                            } else if (msg.keys & KEY_ENTER) {
+                                ui_state.edit_mode = false;
+                            }
                             state.channel.fm.txTone %= CTCSS_FREQ_NUM;
                             state.channel.fm.rxTone = state.channel.fm.txTone;
                             *sync_rtx               = true;
@@ -2394,19 +2413,25 @@ void ui_updateFSM(bool *sync_rtx)
                                              state.channel.fm.txToneEn,
                                              state.channel.fm.txTone,
                                              queueFlags);
-                            if (msg.keys & KEY_UP || msg.keys & KNOB_RIGHT)
+                            break;
+                        case CTCSS_Enabled:
+                            if (msg.keys & KEY_DOWN || msg.keys & KNOB_LEFT)
                             {
-                                state.channel.fm.txTone++;
-                                state.channel.fm.txTone %= CTCSS_FREQ_NUM;
-                                state.channel.fm.rxTone =
-                                    state.channel.fm.txTone;
-                                *sync_rtx = true;
-                                vp_announceCTCSS(state.channel.fm.rxToneEn,
-                                                 state.channel.fm.rxTone,
-                                                 state.channel.fm.txToneEn,
-                                                 state.channel.fm.txTone,
-                                                 queueFlags);
+                                _ui_handleToneSelectScroll(true);
+                            } else if (msg.keys & KEY_UP || msg.keys & KNOB_RIGHT)
+                            {
+                                _ui_handleToneSelectScroll(false);
+                            } else if (msg.keys & KEY_ENTER) {
+                                ui_state.edit_mode = false;
                             }
+
+                            *sync_rtx = true;
+                            vp_announceCTCSS(state.channel.fm.rxToneEn,
+                                             state.channel.fm.rxTone,
+                                             state.channel.fm.txToneEn,
+                                             state.channel.fm.txTone,
+                                             queueFlags | vpqIncludeDescriptions);
+                            break;
                     }
                 }
                 else if (msg.keys & KEY_UP || msg.keys & KNOB_LEFT)

--- a/openrtx/src/ui/default/ui_main.c
+++ b/openrtx/src/ui/default/ui_main.c
@@ -78,10 +78,33 @@ void _ui_drawBankChannel()
               b, last_state.channel_index + 1, last_state.channel.name);
 }
 
+char* _ui_getToneEnabledString(bool tone_tx_enable, bool tone_rx_enable, bool use_abbreviation) {
+    if(use_abbreviation) {
+        static char *strings[] = {
+            "N",
+            "T",
+            "R",
+            "B"
+        };
+
+        uint8_t index = (tone_rx_enable << 1) | (tone_tx_enable);
+        return strings[index];
+    } else {
+        char *strings[] = {
+            currentLanguage->CTCSSEnabledNone,
+            currentLanguage->CTCSSEnabledEncode,
+            currentLanguage->CTCSSEnabledDecode,
+            currentLanguage->CTCSSEnabledBoth,
+        };
+
+        uint8_t index = (tone_rx_enable << 1) | (tone_tx_enable);
+        return strings[index];
+    }
+}
+
 void _ui_drawModeInfo(ui_state_t* ui_state)
 {
     char bw_str[8] = { 0 };
-    char encdec_str[9] = { 0 };
 
     switch(last_state.channel.mode)
     {
@@ -96,23 +119,13 @@ void _ui_drawModeInfo(ui_state_t* ui_state)
             // Get encdec string
             bool tone_tx_enable = last_state.channel.fm.txToneEn;
             bool tone_rx_enable = last_state.channel.fm.rxToneEn;
-
-            if (tone_tx_enable && tone_rx_enable)
-                sniprintf(encdec_str, 9, "ED");
-            else if (tone_tx_enable && !tone_rx_enable)
-                sniprintf(encdec_str, 9, " E");
-            else if (!tone_tx_enable && tone_rx_enable)
-                sniprintf(encdec_str, 9, " D");
-            else
-                sniprintf(encdec_str, 9, "  ");
-
             // Print Bandwidth, Tone and encdec info
             if (tone_tx_enable || tone_rx_enable)
             {
                 uint16_t tone = ctcss_tone[last_state.channel.fm.txTone];
                 gfx_print(layout.line2_pos, layout.line2_font, TEXT_ALIGN_CENTER,
                           color_white, "%s %d.%d %s", bw_str, (tone / 10),
-                          (tone % 10), encdec_str);
+                          (tone % 10), _ui_getToneEnabledString(tone_tx_enable, tone_rx_enable, true));
             }
             else
             {

--- a/openrtx/src/ui/default/ui_menu.c
+++ b/openrtx/src/ui/default/ui_menu.c
@@ -38,6 +38,7 @@
 
 /* UI main screen helper functions, their implementation is in "ui_main.c" */
 extern void _ui_drawMainBottom();
+extern char* _ui_getToneEnabledString(bool tone_tx_enable, bool tone_rx_enable, bool use_abbreviation);
 
 static char priorSelectedMenuName[MAX_ENTRY_LEN] = "\0";
 static char priorSelectedMenuValue[MAX_ENTRY_LEN] = "\0";
@@ -462,6 +463,11 @@ int _ui_getFMValueName(char* buf, uint8_t max_len, uint8_t index)
         {
             uint16_t tone = ctcss_tone[last_state.channel.fm.txTone];
             sniprintf(buf, max_len, "%d.%d", (tone / 10), (tone % 10));
+            break;
+        }
+        case CTCSS_Enabled:
+        {
+            sniprintf(buf, max_len, "%s", _ui_getToneEnabledString(last_state.channel.fm.txToneEn, last_state.channel.fm.rxToneEn, false));
             break;
         }
     }
@@ -1136,16 +1142,7 @@ bool _ui_drawMacroMenu(ui_state_t* ui_state)
         if (last_state.channel.mode == OPMODE_FM)
         {
             char encdec_str[9]  = {0};
-            bool tone_tx_enable = last_state.channel.fm.txToneEn;
-            bool tone_rx_enable = last_state.channel.fm.rxToneEn;
-            if (tone_tx_enable && tone_rx_enable)
-                sniprintf(encdec_str, 9, "  B ");
-            else if (tone_tx_enable && !tone_rx_enable)
-                sniprintf(encdec_str, 9, "  E ");
-            else if (!tone_tx_enable && tone_rx_enable)
-                sniprintf(encdec_str, 9, "  D ");
-            else
-                sniprintf(encdec_str, 9, "  N ");
+            sniprintf(encdec_str, 9, "  %s", _ui_getToneEnabledString(last_state.channel.fm.txToneEn, last_state.channel.fm.rxToneEn, true));
             gfx_print(layout.line1_pos, layout.top_font, TEXT_ALIGN_LEFT,
                       color_white, encdec_str);
             uint16_t tone = ctcss_tone[last_state.channel.fm.txTone];


### PR DESCRIPTION
This PR is my attempt at helping to land https://github.com/OpenRTX/OpenRTX/pull/261. 

From the original changes, I've:

- Rebased to get latest master and addressed conflicts
- Rewritten the commit history to have feature-oriented commits (but kept the author for credit)
- Added to the FM Settings menu the ability to manage encode/decode setting
- Refactored the setting and display of the CTCSS enabled option to have code sharing

## Verification
There are no automated tests covering this feature, so you must manually test. This feature does not apply to module17, and the UI code is shared across all targets, so a single platform is sufficient to test with.

1. Open meta menu pressing M
2. While holding M, Repeatedly press 1 to toggle through the encode/decode ctcss options
3. Periodically unpress to verify that the main VFO screen reflects the proper CTCSS option as specified in the meta menu
4. Ensure that when the meta menu selects "N" for "None", the entire CTCSS entry is hidden from the VFO screen
5. Press enter to open the menu and navigate to Settings -> FM Settings
6. Ensure that the options shown in the menu as selected are the same as in the meta menu and in the VFO screen
7. Change the CTCSS tone frequency and enablement setting, again confirming that the changes are reflected in the VFO screen

![optimized_output_10](https://github.com/user-attachments/assets/87056d21-ca77-4e6b-b13d-0c592d126384)
