### PR TITLE
hr-c6000 driver: add method to read an spi 16 bit register

### DIFF
--- a/platform/drivers/baseband/HR_C6000.h
+++ b/platform/drivers/baseband/HR_C6000.h
@@ -92,9 +92,6 @@ public:
 
 private:
 
-    static const uint8_t SPI_IS_READ_FLAG = 0x80;
-    static const uint8_t SPI_EXPAND_FLAG = 0x40;
-
     /**
      * Write a register with 16-bit address.
      *
@@ -106,7 +103,7 @@ private:
     {
         uint8_t data[4];
 
-        data[0] =  static_cast< uint8_t >(opMode) | SPI_EXPAND_FLAG;
+        data[0] =  static_cast< uint8_t >(opMode) | static_cast< uint8_t >(SpiFlags::EXPAND);
         data[2] = (addr >> 8) & 0x07;
         data[1] = addr & 0xFF;
         data[3] = value;
@@ -127,15 +124,12 @@ private:
         uint8_t data[3];
         uint8_t value[1];
 
-        const uint8_t READ_FLAG = 0x80;
-        const uint8_t EXPAND_FLAG = 0x40;
-
-        data[0] =  static_cast< uint8_t >(opMode) | SPI_EXPAND_FLAG | SPI_IS_READ_FLAG;
+        data[0] =  static_cast< uint8_t >(opMode) | static_cast< uint8_t >(SpiFlags::EXPAND) | static_cast< uint8_t >(SpiFlags::IS_READ);
         data[2] = (addr >> 8) & 0x07;
         data[1] = addr & 0xFF;
 
         ScopedChipSelect cs(uSpi, uCs);
-        spi_send(uSpi, data, 4);
+        spi_send(uSpi, data, sizeof(data));
         spi_receive(uSpi, value, 1);
         return value[0];
     }

--- a/platform/drivers/baseband/HR_C6000.h
+++ b/platform/drivers/baseband/HR_C6000.h
@@ -92,6 +92,9 @@ public:
 
 private:
 
+    static const uint8_t SPI_IS_READ_FLAG = 0x80;
+    static const uint8_t SPI_EXPAND_FLAG = 0x40;
+
     /**
      * Write a register with 16-bit address.
      *
@@ -103,13 +106,38 @@ private:
     {
         uint8_t data[4];
 
-        data[0] =  static_cast< uint8_t >(opMode) | 0x40;
+        data[0] =  static_cast< uint8_t >(opMode) | SPI_EXPAND_FLAG;
         data[2] = (addr >> 8) & 0x07;
         data[1] = addr & 0xFF;
         data[3] = value;
 
         ScopedChipSelect cs(uSpi, uCs);
         spi_send(uSpi, data, 4);
+    }
+
+    /**
+     * Read a register with 16-bit address.
+     *
+     * @param opMode: "operating mode" specifier, see datasheet for details.
+     * @param addr: register address.
+     * @return: value read from the register.
+     */
+    uint8_t readReg16(const C6000_SpiOpModes opMode, const uint16_t addr)
+    {
+        uint8_t data[3];
+        uint8_t value[1];
+
+        const uint8_t READ_FLAG = 0x80;
+        const uint8_t EXPAND_FLAG = 0x40;
+
+        data[0] =  static_cast< uint8_t >(opMode) | SPI_EXPAND_FLAG | SPI_IS_READ_FLAG;
+        data[2] = (addr >> 8) & 0x07;
+        data[1] = addr & 0xFF;
+
+        ScopedChipSelect cs(uSpi, uCs);
+        spi_send(uSpi, data, 4);
+        spi_receive(uSpi, value, 1);
+        return value[0];
     }
 };
 

--- a/platform/drivers/baseband/HR_Cx000.h
+++ b/platform/drivers/baseband/HR_Cx000.h
@@ -49,6 +49,14 @@ enum class TxAudioSource
     LINE_IN     ///< Audio source is "line in", e.g. tone generator.
 };
 
+/**
+ * Flags to use in SPI communication for 16 bit register reads and writes.
+ */
+enum class SpiFlags : uint8_t
+{
+    IS_READ = 0x80,
+    EXPAND = 0x40
+};
 class ScopedChipSelect;
 
 /**


### PR DESCRIPTION
Implement the helper method for reading 16 bit registers from the HR-c6000. This is based on the datasheet's instructions about how to read. I've done some light testing of this, showing that when I write to a register and then read it back, it has the expected value.

This may be helpful to developers implementing more features on this baseband chip. I'm using this to debug my DTMF code.