### PR TITLE
Added support for M17 packet mode

### DIFF
--- a/openrtx/include/core/state.h
+++ b/openrtx/include/core/state.h
@@ -62,6 +62,9 @@ typedef struct
     bool       restore_eflash;
     bool       txDisable;
     uint8_t    step_index;
+    #ifdef CONFIG_M17
+    bool       havePacketData;
+    #endif
 }
 state_t;
 

--- a/openrtx/include/protocols/M17/M17CodePuncturing.hpp
+++ b/openrtx/include/protocols/M17/M17CodePuncturing.hpp
@@ -52,6 +52,14 @@ static constexpr std::array< uint8_t, 12 > DATA_PUNCTURE =
     1, 1, 1, 1, 1, 0
 };
 
+/**
+ *  Puncture matrix for packet frames.
+ */
+static constexpr std::array< uint8_t, 8 > PACKET_PUNCTURE =
+{
+    1, 1, 1, 1,
+    1, 1, 1, 0
+};
 
 /**
  * Apply a given puncturing scheme to a byte array.

--- a/openrtx/include/protocols/M17/M17Datatypes.hpp
+++ b/openrtx/include/protocols/M17/M17Datatypes.hpp
@@ -31,11 +31,12 @@
 namespace M17
 {
 
-using call_t    = std::array< uint8_t, 6 >;    // Data type for encoded callsign
-using payload_t = std::array< uint8_t, 16 >;   // Data type for frame payload field
-using lich_t    = std::array< uint8_t, 12 >;   // Data type for Golay(24,12) encoded LICH data
-using frame_t   = std::array< uint8_t, 48 >;   // Data type for a full M17 data frame, including sync word
-using syncw_t   = std::array< uint8_t, 2  >;   // Data type for a sync word
+using call_t       = std::array< uint8_t, 6 >;    // Data type for encoded callsign
+using payload_t    = std::array< uint8_t, 16 >;   // Data type for frame payload field
+using pktPayload_t = std::array< uint8_t, 26 >;   // Data type for packet frame payload field
+using lich_t       = std::array< uint8_t, 12 >;   // Data type for Golay(24,12) encoded LICH data
+using frame_t      = std::array< uint8_t, 48 >;   // Data type for a full M17 data frame, including sync word
+using syncw_t      = std::array< uint8_t, 2  >;   // Data type for a sync word
 
 enum M17DataMode
 {
@@ -78,20 +79,16 @@ enum M17ScramblingType
  */
 typedef struct __attribute__((packed))
 {
-    uint8_t  data_src;          //< Data source
-    uint8_t  station_type;      //< Station type
-    uint8_t  lat_deg;           //< Latitude, whole number
-    uint16_t lat_dec;           //< Latitude, decimal part multiplied by 65535
-    uint8_t  lon_deg;           //< Longitude, whole number
-    uint16_t lon_dec;           //< Longitude, decimal part multiplied by 65535
-    uint8_t  lat_sign  : 1;     //< Latitude N/S: 0 = north, 1 = south
-    uint8_t  lon_sign  : 1;     //< Longitude E/W: 0 = east, 1 = west
-    uint8_t  alt_valid : 1;     //< Altitude data valid
-    uint8_t  spd_valid : 1;     //< Speed data valid
-    uint8_t  _unused   : 4;
-    uint16_t altitude;          //< Altitude above sea level in feet + 1500
-    uint16_t bearing;           //< Bearing in degrees, whole number
-    uint8_t  speed;             //< Speed in mph, whole number
+    uint8_t  data_src : 4;      //< Data source
+    uint8_t  station_type : 4;  //< Station type
+    uint8_t  validity : 4;      //< Data validity
+    uint8_t  radius : 3;        //< Radius
+    uint16_t bearing : 9;       //< Bearing
+    uint8_t  lat[3];            //< Latitude
+    uint8_t  lon[3];            //< Longitude
+    uint16_t altitude;          //< Altitude MSL, 0.5m steps, 500m offset
+    uint16_t  speed : 12;       //< Speed, 0.5km/h steps
+    uint16_t  _unused : 12;
 }
 gnssData_t;
 

--- a/openrtx/include/protocols/M17/M17Demodulator.hpp
+++ b/openrtx/include/protocols/M17/M17Demodulator.hpp
@@ -165,7 +165,10 @@ private:
     struct dcBlock                 dcBlock;         ///< State of the DC removal filter
 
     Correlator   < M17_SYNCWORD_SYMBOLS, SAMPLES_PER_SYMBOL > correlator;
+    Synchronizer < M17_SYNCWORD_SYMBOLS, SAMPLES_PER_SYMBOL > lsfSync   {{ +3, +3, +3, +3, -3, -3, +3, -3 }};
     Synchronizer < M17_SYNCWORD_SYMBOLS, SAMPLES_PER_SYMBOL > streamSync{{ -3, -3, -3, -3, +3, +3, -3, +3 }};
+    Synchronizer < M17_SYNCWORD_SYMBOLS, SAMPLES_PER_SYMBOL > packetSync{{ +3, -3, +3, +3, -3, -3, -3, -3 }};
+    Synchronizer < M17_SYNCWORD_SYMBOLS, SAMPLES_PER_SYMBOL >    eotSync{{ +3, +3, +3, +3, +3, +3, -3, +3 }};
     Iir          < 3 >                                        sampleFilter{sfNum, sfDen};
 };
 

--- a/openrtx/include/protocols/M17/M17FrameDecoder.hpp
+++ b/openrtx/include/protocols/M17/M17FrameDecoder.hpp
@@ -31,6 +31,7 @@
 #include "M17LinkSetupFrame.hpp"
 #include "M17Viterbi.hpp"
 #include "M17StreamFrame.hpp"
+#include "M17PacketFrame.hpp"
 
 namespace M17
 {
@@ -41,7 +42,8 @@ enum class M17FrameType : uint8_t
     LINK_SETUP = 1,    ///< Frame is a Link Setup Frame.
     STREAM     = 2,    ///< Frame is a stream data frame.
     PACKET     = 3,    ///< Frame is a packet data frame.
-    UNKNOWN    = 4     ///< Frame is unknown.
+    EOT        = 4,    ///< Frame is a EOT frame.
+    UNKNOWN    = 5     ///< Frame is unknown.
 };
 
 /**
@@ -87,6 +89,16 @@ public:
     }
 
     /**
+     * Get the latest packet data frame decoded.
+     *
+     * @return a reference to the latest packet data frame decoded.
+     */
+    const M17PacketFrame& getPacketFrame()
+    {
+        return packetFrame;
+    }
+
+    /**
      * Get the latest stream data frame decoded.
      *
      * @return a reference to the latest stream data frame decoded.
@@ -126,6 +138,14 @@ private:
     void decodeStream(const std::array< uint8_t, 46 >& data);
 
     /**
+     * Decode packet data and update the internal LSF field with the new
+     * frame data.
+     *
+     * @param data: byte array containg frame data, without sync word.
+     */
+    void decodePacket(const std::array< uint8_t, 46 >& data);
+
+    /**
      * Decode a LICH block.
      *
      * @param segment: byte array where to store the decoded Link Setup Frame
@@ -140,6 +160,7 @@ private:
     M17LinkSetupFrame lsf;              ///< Latest LSF received.
     M17LinkSetupFrame lsfFromLich;      ///< LSF assembled from LICH segments.
     M17StreamFrame    streamFrame;      ///< Latest stream dat frame received.
+    M17PacketFrame    packetFrame;      ///< Latest packet dat frame received.
     M17HardViterbi    viterbi;          ///< Viterbi decoder.
 
     ///< Maximum allowed hamming distance when determining the frame type.

--- a/openrtx/include/protocols/M17/M17FrameEncoder.hpp
+++ b/openrtx/include/protocols/M17/M17FrameEncoder.hpp
@@ -30,6 +30,7 @@
 #include "M17ConvolutionalEncoder.hpp"
 #include "M17LinkSetupFrame.hpp"
 #include "M17StreamFrame.hpp"
+#include "M17PacketFrame.hpp"
 
 namespace M17
 {
@@ -91,6 +92,8 @@ public:
      * @param output: destination buffer for the encoded data.
      */
     void encodeEotFrame(frame_t& output);
+
+    void encodePacketFrame(const pktPayload_t& payload, frame_t& output);
 
 private:
 

--- a/openrtx/include/protocols/M17/M17LinkSetupFrame.hpp
+++ b/openrtx/include/protocols/M17/M17LinkSetupFrame.hpp
@@ -116,6 +116,12 @@ public:
     void updateCrc();
 
     /**
+     * Compute a new CRC over the content and update the corresponding
+     * field.
+     */
+    uint16_t m17Crc(const void *data, const size_t len);
+
+    /**
      * Check if frame data is valid that is, if the CRC computed over the LSF
      * fields matches the one carried by the LSF itself.
      *

--- a/openrtx/include/protocols/M17/M17PacketFrame.hpp
+++ b/openrtx/include/protocols/M17/M17PacketFrame.hpp
@@ -1,0 +1,100 @@
+/***************************************************************************
+ *   Copyright (C) 2021 - 2023 by Federico Amedeo Izzo IU2NUO,             *
+ *                                Niccolò Izzo IU2KIN                      *
+ *                                Frederik Saraci IU2NRO                   *
+ *                                Silvano Seva IU2KWO                      *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, see <http://www.gnu.org/licenses/>   *
+ ***************************************************************************/
+
+#ifndef M17_PACKET_FRAME_H
+#define M17_PACKET_FRAME_H
+
+#ifndef __cplusplus
+#error This header is C++ only!
+#endif
+
+#include <cstring>
+#include <string>
+#include "M17Datatypes.hpp"
+
+namespace M17
+{
+
+class M17FrameDecoder;
+
+/**
+ * This class describes and handles a generic M17 packet frame.
+ */
+class M17PacketFrame
+{
+public:
+
+    /**
+     * Constructor.
+     */
+    M17PacketFrame()
+    {
+        clear();
+    }
+
+    /**
+     * Destructor.
+     */
+    ~M17PacketFrame(){ }
+
+    /**
+     * Clear the frame content, filling it with zeroes.
+     */
+    void clear()
+    {
+        memset(&data, 0x00, sizeof(data));
+    }
+
+    /**
+     * Access frame payload.
+     *
+     * @return a reference to frame's payload field, allowing for both read and
+     * write access.
+     */
+    pktPayload_t& payload()
+    {
+        return data.payload;
+    }
+
+    /**
+     * Get underlying data.
+     *
+     * @return a pointer to const uint8_t allowing direct access to frame data.
+     */
+    const uint8_t *getData()
+    {
+        return reinterpret_cast < const uint8_t * > (&data);
+    }
+
+private:
+
+    struct __attribute__((packed))
+    {
+        pktPayload_t payload;   // Payload data
+    }
+    data;
+                                                   ///< Frame data.
+    // Frame decoder class needs to access raw frame data
+    friend class M17FrameDecoder;
+};
+
+}      // namespace M17
+
+#endif // M17_PACKET_FRAME_H

--- a/openrtx/include/rtx/OpMode_M17.hpp
+++ b/openrtx/include/rtx/OpMode_M17.hpp
@@ -16,6 +16,8 @@
  *                                                                         *
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program; if not, see <http://www.gnu.org/licenses/>   *
+ *                                                                         *
+ *   (2025) Modified by KD0OSS for new modes on Module17                   *
  ***************************************************************************/
 
 #ifndef OPMODE_M17_H
@@ -26,7 +28,14 @@
 #include "protocols/M17/M17Demodulator.hpp"
 #include "protocols/M17/M17Modulator.hpp"
 #include "core/audio_path.h"
+#include <vector>
 #include "OpMode.hpp"
+
+#define M17_GNSS_SOURCE_M17CLIENT        ((uint8_t)0)
+#define M17_GNSS_SOURCE_OPENRTX          ((uint8_t)1)
+#define M17_GNSS_STATION_FIXED           ((uint8_t)0)
+#define M17_GNSS_STATION_MOBILE          ((uint8_t)1)
+#define M17_GNSS_STATION_HANDHELD        ((uint8_t)2)
 
 /**
  * Specialisation of the OpMode class for the management of M17 operating mode.
@@ -85,6 +94,7 @@ public:
         return OPMODE_M17;
     }
 
+#if !defined(REPEATER) && !defined(HOTSPOT)
     /**
      * Check if RX squelch is open.
      *
@@ -94,6 +104,8 @@ public:
     {
         return dataValid;
     }
+
+#endif
 
 private:
 
@@ -122,6 +134,14 @@ private:
     void txState(rtxStatus_t *const status);
 
     /**
+     * Function handling the Packet Data TX operating state.
+     *
+     * @param status: pointer to the rtxStatus_t structure containing the
+     * current RTX status.
+     */
+    void txPacketState(rtxStatus_t *const status);
+
+    /**
      * Compare two callsigns in plain text form.
      * The comparison does not take into account the country prefixes (strips
      * the '/' and whatever is in front from all callsigns). It does take into
@@ -135,19 +155,34 @@ private:
     bool compareCallsigns(const std::string& localCs, const std::string& incomingCs);
 
 
-    bool startRx;                      ///< Flag for RX management.
-    bool startTx;                      ///< Flag for TX management.
-    bool locked;                       ///< Demodulator locked on data stream.
-    bool dataValid;                    ///< Demodulated data is valid
-    bool extendedCall;                 ///< Extended callsign data received
-    bool invertTxPhase;                ///< TX signal phase inversion setting.
-    bool invertRxPhase;                ///< RX signal phase inversion setting.
-    pathId rxAudioPath;                ///< Audio path ID for RX
-    pathId txAudioPath;                ///< Audio path ID for TX
-    M17::M17Modulator    modulator;    ///< M17 modulator.
-    M17::M17Demodulator  demodulator;  ///< M17 demodulator.
-    M17::M17FrameDecoder decoder;      ///< M17 frame decoder
-    M17::M17FrameEncoder encoder;      ///< M17 frame encoder
+    uint16_t numPacketbytes = 0;          ///< Number of packet bytes remaining
+    uint16_t lastCRC = 0;                 ///< CRC for last valid SMS message
+    int16_t  gpsTimer = -1;               ///< GPS timer to prevent sending more than once every 5 seconds
+    bool     smsEnabled = false;          ///< SMS enabled
+    bool     smsStarted = false;          ///< SMS message started flag
+    int8_t   smsLastFrame = 0;            ///< SMS frame counter
+    char     smsBuffer[822];              ///< SMS temporary buffer
+    uint16_t totalSMSLength;              ///< Total characters in SMS recall buffer
+    std::vector<char*> smsSender = {};    ///< SMS Sender Id buffer
+    std::vector<char*> smsMessage = {};   ///< SMS message buffer
+
+    pathId rxAudioPath;                  ///< Audio path ID for RX
+    pathId txAudioPath;                  ///< Audio path ID for TX
+    bool extendedCall;                   ///< Extended callsign data received
+
+#if !defined(REPEATER) && !defined(HOTSPOT)
+    bool startRx;                        ///< Flag for RX management.
+    bool startTx;                        ///< Flag for TX management.
+    bool locked;                         ///< Demodulator locked on data stream.
+    bool dataValid;                      ///< Demodulated data is valid
+    bool invertTxPhase;                  ///< TX signal phase inversion setting.
+    bool invertRxPhase;                  ///< RX signal phase inversion setting.
+    M17::M17Modulator      modulator;    ///< M17 modulator.
+    M17::M17Demodulator    demodulator;  ///< M17 demodulator.
+    M17::M17FrameDecoder   decoder;      ///< M17 frame decoder
+    M17::M17FrameEncoder   encoder;      ///< M17 frame encoder
+    M17::M17LinkSetupFrame lsf;          ///< M17 link setup frame
+#endif
 };
 
 #endif /* OPMODE_M17_H */

--- a/openrtx/src/core/state.c
+++ b/openrtx/src/core/state.c
@@ -80,6 +80,9 @@ void state_init()
     state.emergency     = false;
     state.txDisable     = false;
     state.step_index    = 4; // Default frequency step 12.5kHz
+#ifdef CONFIG_M17
+    state.havePacketData    = false;
+#endif
 
     // Force brightness field to be in range 0 - 100
     if(state.settings.brightness > 100)

--- a/openrtx/src/protocols/M17/M17Callsign.cpp
+++ b/openrtx/src/protocols/M17/M17Callsign.cpp
@@ -32,6 +32,15 @@ bool M17::encode_callsign(const std::string& callsign, call_t& encodedCall,
     // Encode the characters to base-40 digits.
     uint64_t encoded = 0;
 
+    // if callsign empty or ALL set to broadcast address
+    if(callsign.empty() || callsign == "ALL")
+    {
+        encoded = 0xffffffffffff;
+        auto *ptr = reinterpret_cast< uint8_t *>(&encoded);
+        std::copy(ptr, ptr + 6, encodedCall.rbegin());
+        return true;
+    }
+
     for(auto it = callsign.rbegin(); it != callsign.rend(); ++it)
     {
         encoded *= 40;

--- a/openrtx/src/protocols/M17/M17Demodulator.cpp
+++ b/openrtx/src/protocols/M17/M17Demodulator.cpp
@@ -265,17 +265,24 @@ bool M17Demodulator::update(const bool invertPhase)
                 case DemodState::UNLOCKED:
                 {
                     int32_t syncThresh = static_cast< int32_t >(corrThreshold * 33.0f);
-                    int8_t  syncStatus = streamSync.update(correlator, syncThresh, -syncThresh);
+                    int8_t  syncStatus = lsfSync.update(correlator, syncThresh, -syncThresh);
 
                     if(syncStatus != 0)
                         demodState = DemodState::SYNCED;
+                    else
+                    {   // if no LSF try Stream
+                        syncStatus = streamSync.update(correlator, syncThresh, -syncThresh);
+
+                        if(syncStatus != 0)
+                            demodState = DemodState::SYNCED;
+                    }
                 }
                     break;
 
                 case DemodState::SYNCED:
                 {
                     // Set sampling point and deviation, zero frame symbol count
-                    samplingPoint  = streamSync.samplingIndex();
+                    samplingPoint  = lsfSync.samplingIndex();
                     outerDeviation = correlator.maxDeviation(samplingPoint);
                     frameIndex     = 0;
 
@@ -290,8 +297,8 @@ bool M17Demodulator::update(const bool invertPhase)
                             updateFrame(val);
                     }
 
-                    uint8_t hd  = hammingDistance((*demodFrame)[0], STREAM_SYNC_WORD[0]);
-                            hd += hammingDistance((*demodFrame)[1], STREAM_SYNC_WORD[1]);
+                    uint8_t hd  = hammingDistance((*demodFrame)[0], LSF_SYNC_WORD[0]);
+                            hd += hammingDistance((*demodFrame)[1], LSF_SYNC_WORD[1]);
 
                     if(hd == 0)
                     {
@@ -300,7 +307,34 @@ bool M17Demodulator::update(const bool invertPhase)
                     }
                     else
                     {
-                        demodState = DemodState::UNLOCKED;
+                        // Set sampling point and deviation, zero frame symbol count
+                        samplingPoint  = streamSync.samplingIndex();
+                        outerDeviation = correlator.maxDeviation(samplingPoint);
+                        frameIndex     = 0;
+
+                        // Quantize the syncword taking data from the correlator
+                        // memory.
+                        for(size_t i = 0; i < SYNCWORD_SAMPLES; i++)
+                        {
+                            size_t  pos = (correlator.index() + i) % SYNCWORD_SAMPLES;
+                            int16_t val = correlator.data()[pos];
+
+                            if((pos % SAMPLES_PER_SYMBOL) == samplingPoint)
+                                updateFrame(val);
+                        }
+
+                        hd  = hammingDistance((*demodFrame)[0], STREAM_SYNC_WORD[0]);
+                        hd += hammingDistance((*demodFrame)[1], STREAM_SYNC_WORD[1]);
+
+                        if(hd == 0)
+                        {
+                            locked     = true;
+                            demodState = DemodState::LOCKED;
+                        }
+                        else
+                        {
+                            demodState = DemodState::UNLOCKED;
+                        }
                     }
                 }
                     break;
@@ -331,7 +365,33 @@ bool M17Demodulator::update(const bool invertPhase)
 
                     // Find the new correlation peak
                     int32_t syncThresh = static_cast< int32_t >(corrThreshold * 33.0f);
-                    int8_t  syncStatus = streamSync.update(correlator, syncThresh, -syncThresh);
+
+                    // Look for packet frame
+                    int8_t  syncStatus = packetSync.update(correlator, syncThresh, -syncThresh);
+
+                    if(syncStatus != 0)
+                    {
+                        // Correlation has to coincide with a syncword!
+                        if(frameIndex == M17_SYNCWORD_SYMBOLS)
+                        {
+                            uint8_t hd  = hammingDistance((*demodFrame)[0], PACKET_SYNC_WORD[0]);
+                                    hd += hammingDistance((*demodFrame)[1], PACKET_SYNC_WORD[1]);
+
+                            // Valid sync found: update deviation and sample
+                            // point, then go back to locked state
+                            if(hd <= 1)
+                            {
+                                outerDeviation = correlator.maxDeviation(samplingPoint);
+                                samplingPoint  = packetSync.samplingIndex();
+                                missedSyncs    = 0;
+                                demodState     = DemodState::LOCKED;
+                                break;
+                            }
+                        }
+                    }
+
+                    // Look for stream frame
+                    syncStatus = streamSync.update(correlator, syncThresh, -syncThresh);
 
                     if(syncStatus != 0)
                     {
@@ -347,6 +407,29 @@ bool M17Demodulator::update(const bool invertPhase)
                             {
                                 outerDeviation = correlator.maxDeviation(samplingPoint);
                                 samplingPoint  = streamSync.samplingIndex();
+                                missedSyncs    = 0;
+                                demodState     = DemodState::LOCKED;
+                                break;
+                            }
+                        }
+                    }
+
+                    // Look for EOT
+                    syncStatus = eotSync.update(correlator, syncThresh, -syncThresh);
+
+                    if(syncStatus != 0)
+                    {
+                        // Correlation has to coincide with a syncword!
+                        if(frameIndex == M17_SYNCWORD_SYMBOLS)
+                        {
+                            uint8_t hd  = hammingDistance((*demodFrame)[0], EOT_SYNC_WORD[0]);
+                                    hd += hammingDistance((*demodFrame)[1], EOT_SYNC_WORD[1]);
+
+                            // Valid sync found: update deviation and sample
+                            // point, then go back to locked state
+                            if(hd <= 1)
+                            {
+                                outerDeviation = correlator.maxDeviation(samplingPoint);
                                 missedSyncs    = 0;
                                 demodState     = DemodState::LOCKED;
                                 break;

--- a/openrtx/src/protocols/M17/M17LinkSetupFrame.cpp
+++ b/openrtx/src/protocols/M17/M17LinkSetupFrame.cpp
@@ -88,6 +88,13 @@ void M17LinkSetupFrame::updateCrc()
     data.crc     = __builtin_bswap16(crc);
 }
 
+uint16_t M17LinkSetupFrame::m17Crc(const void *data, const size_t len)
+{
+    // Compute CRC over len bytes, then store it in big endian format.
+    uint16_t crc = crc16(data, len);
+    return __builtin_bswap16(crc);
+}
+
 bool M17LinkSetupFrame::valid() const
 {
     uint16_t crc = crc16(&data, 28);


### PR DESCRIPTION
# What

This change adds support for M17's packet mode. It does not offer any user-facing functionality yet, but rather lays the foundation for sending and receiving of SMS messages as the first packet features.

# How

This change is based on the work originally done in https://github.com/OpenRTX/OpenRTX/pull/314, current as of https://github.com/OpenRTX/OpenRTX/pull/314/commits/e8c3ea54b93fe894b86d69c29448fdcdb236bb7d. The changes there had whitespace changes removed, then were squash merged onto a new branch. From there, changes that were unrelated to the packet mode feature were removed. Then, changes consistent with feedback from previous commits were made to try to simplify code review.

The work in this PR was done by @kd0oss Rick. I am helping pick, address feedback, and land these changes.

# Potentially controversial decisions

- Packet block reassembly is not included; it's tightly coupled to the SMS feature, so that's in a subsequent PR; based on past feedback, I anticipate @silseva will want to see this refactored now however to have reassembly take place in a dedicated protocol class
- Packet block fragmentation is present in this PR in a quasi-generalized way; I'm fairly certain though that the packet protocol byte needs to be parameterized for it to truly be agnostic
- Packet block fragmentation is taking place in the OpMode code, but based on past feedback, I anticipate @silseva will want to see this refactored and moved into a the protocol class referenced in the first bullet point