### PR TITLE
M17 packet: add net-new protocol definitions for packet support

### DIFF
--- a/openrtx/include/protocols/M17/M17CodePuncturing.hpp
+++ b/openrtx/include/protocols/M17/M17CodePuncturing.hpp
@@ -52,6 +52,14 @@ static constexpr std::array< uint8_t, 12 > DATA_PUNCTURE =
     1, 1, 1, 1, 1, 0
 };
 
+/**
+ *  Puncture matrix for packet frames.
+ */
+static constexpr std::array< uint8_t, 8 > PACKET_PUNCTURE =
+{
+    1, 1, 1, 1,
+    1, 1, 1, 0
+};
 
 /**
  * Apply a given puncturing scheme to a byte array.

--- a/openrtx/include/protocols/M17/M17Datatypes.hpp
+++ b/openrtx/include/protocols/M17/M17Datatypes.hpp
@@ -36,6 +36,7 @@ using payload_t = std::array< uint8_t, 16 >;   // Data type for frame payload fi
 using lich_t    = std::array< uint8_t, 12 >;   // Data type for Golay(24,12) encoded LICH data
 using frame_t   = std::array< uint8_t, 48 >;   // Data type for a full M17 data frame, including sync word
 using syncw_t   = std::array< uint8_t, 2  >;   // Data type for a sync word
+using pktPayload_t = std::array< uint8_t, 26 >;// Data type for packet frame payload field
 
 enum M17DataMode
 {

--- a/openrtx/include/protocols/M17/M17Demodulator.hpp
+++ b/openrtx/include/protocols/M17/M17Demodulator.hpp
@@ -165,7 +165,10 @@ private:
     struct dcBlock                 dcBlock;         ///< State of the DC removal filter
 
     Correlator   < M17_SYNCWORD_SYMBOLS, SAMPLES_PER_SYMBOL > correlator;
+    Synchronizer < M17_SYNCWORD_SYMBOLS, SAMPLES_PER_SYMBOL > lsfSync   {{ +3, +3, +3, +3, -3, -3, +3, -3 }};
     Synchronizer < M17_SYNCWORD_SYMBOLS, SAMPLES_PER_SYMBOL > streamSync{{ -3, -3, -3, -3, +3, +3, -3, +3 }};
+    Synchronizer < M17_SYNCWORD_SYMBOLS, SAMPLES_PER_SYMBOL > packetSync{{ +3, -3, +3, +3, -3, -3, -3, -3 }};
+    Synchronizer < M17_SYNCWORD_SYMBOLS, SAMPLES_PER_SYMBOL >    eotSync{{ +3, +3, +3, +3, +3, +3, -3, +3 }};
     Iir          < 3 >                                        sampleFilter{sfNum, sfDen};
 };
 

--- a/openrtx/include/protocols/M17/PacketFrame.hpp
+++ b/openrtx/include/protocols/M17/PacketFrame.hpp
@@ -1,0 +1,97 @@
+/***************************************************************************
+ *   Copyright (C) 2021 - 2023 by Federico Amedeo Izzo IU2NUO,             *
+ *                                Niccolò Izzo IU2KIN                      *
+ *                                Frederik Saraci IU2NRO                   *
+ *                                Silvano Seva IU2KWO                      *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 3 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, see <http://www.gnu.org/licenses/>   *
+ ***************************************************************************/
+
+#ifndef M17_PACKET_FRAME_H
+#define M17_PACKET_FRAME_H
+
+#ifndef __cplusplus
+#error This header is C++ only!
+#endif
+
+#include <cstring>
+#include <string>
+#include "M17Datatypes.hpp"
+
+namespace M17
+{
+
+class M17FrameDecoder;
+
+/**
+ * This class describes and handles a generic M17 packet frame.
+ */
+class PacketFrame {
+public:
+    /**
+     * Constructor.
+     */
+    PacketFrame()
+    {
+        clear();
+    }
+
+    /**
+     * Destructor.
+     */
+    ~PacketFrame()
+    {
+    }
+
+    /**
+     * Clear the frame content, filling it with zeroes.
+     */
+    void clear()
+    {
+        memset(&data, 0x00, sizeof(data));
+    }
+
+    /**
+     * Access frame payload.
+     *
+     * @return a reference to frame's payload field, allowing for both read and
+     * write access.
+     */
+    pktPayload_t &payload()
+    {
+        return data.payload;
+    }
+
+    /**
+     * Get underlying data.
+     *
+     * @return a pointer to const uint8_t allowing direct access to frame data.
+     */
+    const uint8_t *getData()
+    {
+        return reinterpret_cast<const uint8_t *>(&data);
+    }
+
+private:
+    struct __attribute__((packed)) {
+        pktPayload_t payload; // Payload data
+    } data;
+    ///< Frame data.
+    // Frame decoder class needs to access raw frame data
+    friend class M17FrameDecoder;
+};
+
+} // namespace M17
+
+#endif // M17_PACKET_FRAME_H

--- a/scripts/clang_format.sh
+++ b/scripts/clang_format.sh
@@ -69,6 +69,7 @@ openrtx/include/interfaces/radio.h
 openrtx/include/peripherals/gps.h
 openrtx/include/peripherals/rng.h
 openrtx/include/peripherals/rtc.h
+openrtx/include/protocols/M17/PacketFrame.hpp
 openrtx/src/core/dsp.cpp
 openrtx/src/core/memory_profiling.cpp
 platform/drivers/ADC/ADC0_GDx.h


### PR DESCRIPTION
This commit adds the various M17 protocol definitions that are unique to packet mode. Subsequent commits will implement the updates to the protocol mechanisms to utilize these.

Ref https://tasks.openrtx.org/project/openrtx/task/756