### PR TITLE
README: add section mentioning weblate

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,3 +107,9 @@ Also, a thank you for donating hardware to this project goes to:
 * smeegle5000
 
 And thanks to everyone who donated via [LiberaPay](https://liberapay.com/OpenRTX/donate).
+
+## Translation
+
+Contribute to the crowdsourced effort to make OpenRTX more accessible by helping [translate it](https://hosted.weblate.org/projects/openrtx/). Weblate proudly supports libre projects like OpenRTX with their tools to help this.
+
+[![Translation status](https://hosted.weblate.org/widget/openrtx/287x66-grey.png)](https://hosted.weblate.org/engage/openrtx/)


### PR DESCRIPTION
As we adopt Weblate as the tool for providing translations, one of their hosting terms is that the project's README references their support. This change adds that as part of a section referencing the translation effort and sharing a graphic with translation stats.

Ref https://tasks.openrtx.org/project/openrtx/task/743