### PR TITLE
M17 tx gain

### DIFF
--- a/openrtx/include/core/settings.h
+++ b/openrtx/include/core/settings.h
@@ -64,6 +64,7 @@ typedef struct
     char    m17_dest[10];         // M17 destination
     bool    showBatteryIcon;      // Battery display true: icon, false: percentage
     bool    gpsSetTime;           // Use GPS to ajust RTC time
+    uint8_t m17_tx_level;          // M17 TX level
 }
 __attribute__((packed)) settings_t;
 
@@ -91,6 +92,11 @@ static const settings_t default_settings =
     "",                           // Empty M17 destination
     false,                        // Display battery icon
     false,                        // Update RTC with GPS
+#ifdef PLATFORM_MOD17
+    12,                           // M17 TX level 
+#else
+    32,                           // M17 TX level 
+#endif
 };
 
 #endif /* SETTINGS_H */

--- a/openrtx/include/ui/ui_default.h
+++ b/openrtx/include/ui/ui_default.h
@@ -154,7 +154,8 @@ enum settingsM17Items
 {
     M17_CALLSIGN = 0,
     M17_CAN,
-    M17_CAN_RX
+    M17_CAN_RX,
+    M17_TX_LEVEL
 };
 
 enum settingsFMItems

--- a/openrtx/include/ui/ui_mod17.h
+++ b/openrtx/include/ui/ui_mod17.h
@@ -124,7 +124,8 @@ enum m17Items
 {
     M_CALLSIGN = 0,
     M_CAN,
-    M_CAN_RX
+    M_CAN_RX,
+    M_TX_LEVEL
 };
 
 enum module17Items

--- a/openrtx/src/core/audio_codec.c
+++ b/openrtx/src/core/audio_codec.c
@@ -33,6 +33,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include "core/dsp.h"
+#include "core/state.h"
 
 #define BUF_SIZE 4
 
@@ -52,14 +53,6 @@ static uint8_t          readPos;
 static uint8_t          writePos;
 static uint8_t          numElements;
 static uint64_t         dataBuffer[BUF_SIZE];
-
-#ifdef PLATFORM_MOD17
-static const uint8_t micGain = 12;
-#else
-#ifndef PLATFORM_LINUX
-static const uint8_t micGain = 32;
-#endif
-#endif
 
 static void *encodeFunc(void *arg);
 static void *decodeFunc(void *arg);
@@ -221,7 +214,7 @@ static void *encodeFunc(void *arg)
             int16_t sample;
 
             sample = dsp_dcBlockFilter(&dcBlock, audio.data[i]);
-            audio.data[i] = sample * micGain;
+            audio.data[i] = sample * state.settings.m17_tx_level;
         }
         #endif
 

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -185,7 +185,8 @@ const char * settings_m17_items[] =
 {
     "Callsign",
     "CAN",
-    "CAN RX Check"
+    "CAN RX Check",
+    "TX Level"
 };
 
 const char* settings_fm_items[] =
@@ -796,6 +797,11 @@ static inline void _ui_changeM17Can(int variation)
 {
     uint8_t can = state.settings.m17_can;
     state.settings.m17_can = (can + variation) % 16;
+}
+static inline void _ui_changeM17TxLevel(int variation)
+{
+    uint8_t gain = state.settings.m17_tx_level;
+    state.settings.m17_tx_level = (gain + variation) % 255;
 }
 #endif
 
@@ -2333,6 +2339,16 @@ void ui_updateFSM(bool *sync_rtx)
                                 _ui_changeM17Can(-1);
                             else if(msg.keys & KEY_UP || msg.keys & KNOB_RIGHT)
                                 _ui_changeM17Can(+1);
+                            else if(msg.keys & KEY_ENTER)
+                                ui_state.edit_mode = !ui_state.edit_mode;
+                            else if(msg.keys & KEY_ESC)
+                                ui_state.edit_mode = false;
+                            break;
+                        case M17_TX_LEVEL:
+                            if(msg.keys & KEY_DOWN || msg.keys & KNOB_LEFT)
+                                _ui_changeM17TxLevel(-1);
+                            else if(msg.keys & KEY_UP || msg.keys & KNOB_RIGHT)
+                                _ui_changeM17TxLevel(+1);
                             else if(msg.keys & KEY_ENTER)
                                 ui_state.edit_mode = !ui_state.edit_mode;
                             else if(msg.keys & KEY_ESC)

--- a/openrtx/src/ui/default/ui_menu.c
+++ b/openrtx/src/ui/default/ui_menu.c
@@ -444,6 +444,9 @@ int _ui_getM17ValueName(char *buf, uint8_t max_len, uint8_t index)
                                                            currentLanguage->on :
                                                            currentLanguage->off);
             break;
+        case M17_TX_LEVEL:
+            sniprintf(buf, max_len, "%d", last_state.settings.m17_tx_level);
+            break;
     }
 
     return 0;

--- a/openrtx/src/ui/module17/ui.c
+++ b/openrtx/src/ui/module17/ui.c
@@ -95,7 +95,8 @@ const char *m17_items[] =
 {
     "Callsign",
     "CAN",
-    "CAN RX Check"
+    "CAN RX Check",
+    "TX Level"
 };
 
 const char *module17_items[] =
@@ -343,6 +344,12 @@ static void _ui_changeBrightness(int variation)
 
     state.settings.brightness += variation;
     display_setBacklightLevel(state.settings.brightness);
+}
+
+static inline void _ui_changeM17TxLevel(int variation)
+{
+    uint8_t gain = state.settings.m17_tx_level;
+    state.settings.m17_tx_level = (gain + variation) % 255;
 }
 
 static void _ui_changeCAN(int variation)
@@ -695,6 +702,9 @@ void ui_updateFSM(bool *sync_rtx)
                             case M_CAN_RX:
                                 state.settings.m17_can_rx = !state.settings.m17_can_rx;
                                 break;
+                            case M_TX_LEVEL:
+                                _ui_changeM17TxLevel(-1);
+                                break;
                             default:
                                 state.ui_screen = SETTINGS_M17;
                         }
@@ -708,6 +718,9 @@ void ui_updateFSM(bool *sync_rtx)
                                 break;
                             case M_CAN_RX:
                                 state.settings.m17_can_rx = !state.settings.m17_can_rx;
+                                break;
+                            case M_TX_LEVEL:
+                                _ui_changeM17TxLevel(+1);
                                 break;
                             default:
                                 state.ui_screen = SETTINGS_M17;

--- a/openrtx/src/ui/module17/ui_menu.c
+++ b/openrtx/src/ui/module17/ui_menu.c
@@ -202,6 +202,9 @@ int _ui_getM17ValueName(char *buf, uint8_t max_len, uint8_t index)
         case M_CAN_RX:
             snprintf(buf, max_len, "%s", (last_state.settings.m17_can_rx) ? "on" : "off");
             break;
+        case M_TX_LEVEL:
+            sniprintf(buf, max_len, "%d", last_state.settings.m17_tx_level);
+            break;
     }
 
     return 0;


### PR DESCRIPTION
# What

- Move audio_codec's tx multiplier values to setting
- Add settings UI entries to allow it to be configured

# Why

So that users who experience low level issues on M17 TX can address them

# How

This is a pretty straight-forward change.

# TODO

- [ ] Add "migration" concept to ensure a sensible default is set
- [ ] The menu says "gain" because that's what users expect, but this is actually a multiplier instead; 0 = dead silence, not "no gain"; find a better name for this, and consider if that changes what the scale should be
- [ ] Consider if the entire approach is wrong from a UX perspective -- for example "TX Gain" as built here is a range from 0-255 which is a lot of (too much?) granularity; also having defaults like "32" are unintuitive; maybe the fix for both is to change this to a log scale?