### PR TITLE
ci: fix artifact path for cs7000p build target

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           name: release-bins
           path: |
-            ${{github.workspace}}/build_cm7/openrtx_cs7000p_wrap.bin
+            ${{github.workspace}}/build_cm7/openrtx_cs7000p_wrap
             ${{github.workspace}}/build_cm7/openrtx_cs7000p_dfu
             ${{github.workspace}}/build_arm/openrtx_cs7000_bin
             ${{github.workspace}}/build_arm/openrtx_cs7000_dfu


### PR DESCRIPTION
The build artifacts were looking for a file ending with , and so it was never picked up. This fixes that problem.

Draft till I confirm that this build includes the missing file.

https://tasks.openrtx.org/project/openrtx/task/778