### PR TITLE
ci: rename build artifacts to align with naming convention

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   RADIO_TOOL_VERSION: 0.2.2
-
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
 jobs:
   build:
     runs-on: ubuntu-24.04
@@ -36,23 +36,36 @@ jobs:
             meson compile -C build_arm openrtx_gd77_wrap &&
             meson compile -C build_cm7 openrtx_cs7000p_wrap &&
             meson compile -C build_cm7 openrtx_cs7000p_dfu &&
-            chmod -R 777 *
+            chmod -R 777 * &&
+            ls build_cm7/ &&
+            ls build_arm/ &&
+            ls build_linux/ &&
+            mv build_cm7/openrtx_cs7000p_wrap openrtx_cs7000p_${{ env.BRANCH_NAME }}.bin &&
+            mv build_cm7/openrtx_cs7000p_dfu openrtx_cs7000p_${{ env.BRANCH_NAME }}.dfu &&
+            mv build_arm/openrtx_cs7000_bin openrtx_cs7000_${{ env.BRANCH_NAME }}.bin &&
+            mv build_arm/openrtx_cs7000_dfu openrtx_cs7000_${{ env.BRANCH_NAME }}.dfu &&
+            mv build_arm/openrtx_dm1701_wrap openrtx_dm1701_${{ env.BRANCH_NAME }}.bin &&
+            mv build_arm/openrtx_dm1801_bin.sgl openrtx_dm1801_${{ env.BRANCH_NAME }}.sgl &&
+            mv build_arm/openrtx_gd77_bin.sgl openrtx_gd77_${{ env.BRANCH_NAME }}.sgl &&
+            mv build_linux/openrtx_linux openrtx_linux_${{ env.BRANCH_NAME }} &&
+            mv build_arm/openrtx_md3x0_wrap openrtx_md3x0_${{ env.BRANCH_NAME }}.bin &&
+            mv build_arm/openrtx_mduv3x0_wrap openrtx_mduv3x0_${{ env.BRANCH_NAME }}.bin &&
+            mv build_arm/openrtx_mod17_bin openrtx_mod17_${{ env.BRANCH_NAME }}.bin
       - uses: actions/upload-artifact@v4
         with:
           name: release-bins
           path: |
-            ${{github.workspace}}/build_cm7/openrtx_cs7000p_wrap
-            ${{github.workspace}}/build_cm7/openrtx_cs7000p_dfu
-            ${{github.workspace}}/build_arm/openrtx_cs7000_bin
-            ${{github.workspace}}/build_arm/openrtx_cs7000_dfu
-            ${{github.workspace}}/build_arm/openrtx_dm1701_wrap
-            ${{github.workspace}}/build_arm/openrtx_dm1801_wrap.sgl
-            ${{github.workspace}}/build_arm/openrtx_gd77_wrap.sgl
-            ${{github.workspace}}/build_linux/openrtx_linux
-            ${{github.workspace}}/build_arm/openrtx_md3x0_wrap
-            ${{github.workspace}}/build_arm/openrtx_md9600_wrap
-            ${{github.workspace}}/build_arm/openrtx_mduv3x0_wrap
-            ${{github.workspace}}/build_arm/openrtx_mod17_bin
+            ${{github.workspace}}/openrtx_cs7000p_${{ env.BRANCH_NAME }}.bin
+            ${{github.workspace}}/openrtx_cs7000p_${{ env.BRANCH_NAME }}.dfu
+            ${{github.workspace}}/openrtx_cs7000_${{ env.BRANCH_NAME }}.bin
+            ${{github.workspace}}/openrtx_cs7000_${{ env.BRANCH_NAME }}.dfu
+            ${{github.workspace}}/openrtx_dm1701_${{ env.BRANCH_NAME }}.bin
+            ${{github.workspace}}/openrtx_dm1801_${{ env.BRANCH_NAME }}.sgl
+            ${{github.workspace}}/openrtx_gd77_${{ env.BRANCH_NAME }}.sgl
+            ${{github.workspace}}/openrtx_linux_${{ env.BRANCH_NAME }}
+            ${{github.workspace}}/openrtx_md3x0_${{ env.BRANCH_NAME }}.bin
+            ${{github.workspace}}/openrtx_mduv3x0_${{ env.BRANCH_NAME }}.bin
+            ${{github.workspace}}/openrtx_mod17_${{ env.BRANCH_NAME }}.bin
           if-no-files-found: error
   build-zephyr:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
OpenRTX releases have had their artifacts follow a historical pattern, which has both set users expectations and had documentation (both official and unofficial) built. The CI builds don't follow those conventions though, which causes confusion with users who don't have experience doing local builds.

This change moves the build artifacts to match the file naming convention users are accustomed to, and it uses the branch name as the name of the build name that is listed.

Other notable fixes:
- Add missing dm1801 and gd77 artifacts (they were previously looking for "_wrap" which for these platforms doesn't create a file with "wrap" in the name)

Fixes: https://tasks.openrtx.org/project/openrtx/task/779

# But does it work?

This branch has a build on it with successful results. The artifacts contained in the zip are:
```
openrtx_cs7000_ci-artifact-renaming.bin
openrtx_cs7000_ci-artifact-renaming.dfu
openrtx_cs7000p_ci-artifact-renaming.bin
openrtx_cs7000p_ci-artifact-renaming.dfu
openrtx_dm1701_ci-artifact-renaming.bin
openrtx_dm1801_ci-artifact-renaming.sgl
openrtx_gd77_ci-artifact-renaming.sgl
openrtx_linux_ci-artifact-renaming
openrtx_md3x0_ci-artifact-renaming.bin
openrtx_mduv3x0_ci-artifact-renaming.bin
openrtx_mod17_ci-artifact-renaming.bin
```
