### PR TITLE
ci: close stale issues and PRs

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -1,0 +1,20 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v10
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 30 days with no activity. Please comment within 5 days if this in fact is not stale, otherwise this will be closed.'
+          stale-pr-message: 'This PR is stale because it has been open 30 days with no activity. Please comment within 5 days if this in fact is not stale, otherwise this will be closed.'
+          close-issue-message: 'This issue was closed due to continued inactivity.'
+          close-pr-message: 'This PR was closed due to continued inactivity.'
+          close-issue-label: Stale-Closed
+          close-pr-label: Stale-Closed
+          exempt-issue-labels: bug,issue
+          days-before-stale: 30
+          days-before-close: 15


### PR DESCRIPTION
This change adds a github action in order to warn users after 30 days of inactivity that their PRs and issues are subject to being closed if they are not updated within the next 5 days. Labels are added to auto-closed issues so that analysis is easier, and issues with the labels bug or issue are skipped from this.

I chose not to do this for the enhancement type issues, as the longer term product backlog is being tracked in Tiaga, not GitHub Issues. Users are still welcome to log issues for enhancements, but this will encourage them to keep these discussions alive and work to a conclusion rather than having the longer-term roadmap split across two places.