### PR TITLE
Cache devcontainer for builds

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:24.04
 
+LABEL org.opencontainers.image.source=https://github.com/OpenRTX/OpenRTX
+
 # Install dependencies
 RUN apt-get update -y && apt-get install -y --no-install-recommends \
   git \

--- a/.github/workflows/build-devcontainer.yml
+++ b/.github/workflows/build-devcontainer.yml
@@ -1,0 +1,43 @@
+name: "Build devcontainer"
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'requirements.txt'
+      - '.github/workflows/build-devcontainer.yml'
+      - '.devcontainer/Dockerfile'
+      - '.devcontainer/devcontainer.json'
+  pull_request:
+    paths:
+      - 'requirements.txt'
+      - '.github/workflows/build-devcontainer.yml'
+      - '.devcontainer/Dockerfile'
+      - '.devcontainer/devcontainer.json'
+
+env:
+  RADIO_TOOL_VERSION: 0.2.2
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+  DEVCONTAINER_NAME: ghcr.io/openrtx/openrtx-devcontainer
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Pre-build dev container image
+        uses: devcontainers/ci@v0.3
+        with:
+            imageName: ${{ env.DEVCONTAINER_NAME }}
+            cacheFrom: ${{ env.DEVCONTAINER_NAME }}
+            push: always

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
 env:
   RADIO_TOOL_VERSION: 0.2.2
   BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
+  DEVCONTAINER_NAME: ghcr.io/openrtx/openrtx-devcontainer
 jobs:
   build:
     runs-on: ubuntu-24.04
@@ -18,6 +19,8 @@ jobs:
       - name: Compile using devcontainer
         uses: devcontainers/ci@v0.3
         with:
+          cacheFrom: ${{ env.DEVCONTAINER_NAME }}
+          push: never
           runCmd: |
             meson setup build_linux &&
             meson setup --cross-file cross_cm4.txt build_cm4 &&

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 # This file is part of OpenRTX.
 
 #Build dirs
-build*
+/build*
 
 # Prerequisites
 *.d


### PR DESCRIPTION
This change updates the CI to publish the devcontainer. This is to simplify the build process so that the `build` stage doesnt have to configure the entire build environment each time. This also addresses some build instability that @mdiepart was running into where network flakiness was leading to build failures.

[Here's an example build](https://github.com/turnrye/OpenRTX/actions/runs/22604554084/job/65493673952) on my fork where the build step took 3min 21sec.

Note that this change will result in a package being published with the name `openrtx-devcontainer`, with the only tag being `latest` always.

The first build after merge will need to be fired off manually, and it will only be updated in the future when a python requirement, the dockerfile, or the devcontainer config file change (as opposed to today where it's re-built each time).