### PR TITLE
ci: fix build failure by skipping catch2

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -121,6 +121,8 @@ endif
 # Catch2, C++ testing framework (only for native/linux builds)
 if not meson.is_cross_build()
   catch2_dep = dependency('catch2-with-main', fallback: ['catch2', 'catch2_with_main_dep'])
+else
+  catch2_dep = disabler()
 endif
 
 # XPowersLib, library for x-powers power management series


### PR DESCRIPTION
Use meson's disabler() feature to skip any executable (or test) that depends on catch2 but the build is a cross build (and therefore unit tests aren't expected).