### PR TITLE
core: crc: improve M17 CRC and move to core

### DIFF
--- a/openrtx/include/core/crc.h
+++ b/openrtx/include/core/crc.h
@@ -15,6 +15,24 @@ extern "C" {
 #endif
 
 /**
+ * @brief Compute the M17 16-bit CRC over a given block of data.
+ *
+ * Created using pycrc https://pycrc.org with the configuration:
+ *  - Width         = 16
+ *  - Poly          = 0x5935
+ *  - XorIn         = 0xffff
+ *  - ReflectIn     = False
+ *  - XorOut        = 0x0000
+ *  - ReflectOut    = False
+ *  - Algorithm     = table-driven
+ *
+ * @param data: input data.
+ * @param len: data length, in bytes.
+ * @return A uint16_t M17 CRC.
+ */
+uint16_t crc_m17(const void *data, const size_t len);
+
+/**
  * Compute the CCITT 16-bit CRC over a given block of data.
  *
  * @param data: input data.

--- a/openrtx/include/protocols/M17/M17LinkSetupFrame.hpp
+++ b/openrtx/include/protocols/M17/M17LinkSetupFrame.hpp
@@ -140,17 +140,6 @@ public:
 
 private:
 
-    /**
-     * Compute the CRC16 of a given chunk of data using the polynomial 0x5935
-     * with an initial value set to 0xFFFF, as per M17 specification.
-     *
-     * \param data: pointer to the data block.
-     * \param len: lenght of the data block, in bytes.
-     * \return computed CRC16 over the data block.
-     */
-    uint16_t crc16(const void *data, const size_t len) const;
-
-
     struct __attribute__((packed))
     {
         call_t       dst;    ///< Destination callsign

--- a/openrtx/src/core/crc.c
+++ b/openrtx/src/core/crc.c
@@ -6,16 +6,33 @@
 
 #include "core/crc.h"
 
+uint16_t crc_m17(const void *data, const size_t len)
+{
+    static const uint16_t CRC_M17_TABLE[] = { 0x0000, 0x5935, 0xb26a, 0xeb5f,
+                                              0x3de1, 0x64d4, 0x8f8b, 0xd6be,
+                                              0x7bc2, 0x22f7, 0xc9a8, 0x909d,
+                                              0x4623, 0x1f16, 0xf449, 0xad7c };
+    uint16_t crc = 0xFFFF;
+    const uint8_t *d = (const uint8_t *)data;
+
+    for (size_t i = 0; i < len; i++) {
+        uint8_t tbl_idx = (crc >> 12) ^ (d[i] >> 4);
+        crc = CRC_M17_TABLE[tbl_idx & 0x0f] ^ (crc << 4);
+        tbl_idx = (crc >> 12) ^ d[i];
+        crc = CRC_M17_TABLE[tbl_idx & 0x0f] ^ (crc << 4);
+    }
+    return crc;
+}
+
 uint16_t crc_ccitt(const void *data, const size_t len)
 {
-    uint16_t x   = 0;
+    uint16_t x = 0;
     uint16_t crc = 0;
-    const uint8_t *buf = ((const uint8_t *) data);
+    const uint8_t *buf = ((const uint8_t *)data);
 
-    for(size_t i = 0; i < len; i++)
-    {
-        x   = (crc >> 8) ^ buf[i];
-        x  ^= x >> 4;
+    for (size_t i = 0; i < len; i++) {
+        x = (crc >> 8) ^ buf[i];
+        x ^= x >> 4;
         crc = (crc << 8) ^ (x << 12) ^ (x << 5) ^ x;
     }
 

--- a/openrtx/src/protocols/M17/M17LinkSetupFrame.cpp
+++ b/openrtx/src/protocols/M17/M17LinkSetupFrame.cpp
@@ -9,6 +9,7 @@
 #include "protocols/M17/M17Callsign.hpp"
 #include "protocols/M17/M17LinkSetupFrame.hpp"
 #include "core/utils.h"
+#include "core/crc.h"
 
 using namespace M17;
 
@@ -71,13 +72,13 @@ meta_t& M17LinkSetupFrame::metadata()
 void M17LinkSetupFrame::updateCrc()
 {
     // Compute CRC over the first 28 bytes, then store it in big endian format.
-    uint16_t crc = crc16(&data, 28);
+    uint16_t crc = crc_m17(&data, 28);
     data.crc     = __builtin_bswap16(crc);
 }
 
 bool M17LinkSetupFrame::valid() const
 {
-    uint16_t crc = crc16(&data, 28);
+    uint16_t crc = crc_m17(&data, 28);
     if(data.crc == __builtin_bswap16(crc)) return true;
 
     return false;
@@ -163,25 +164,4 @@ void M17LinkSetupFrame::setGnssData(const gps_t *position,
     // Structure numeric fields that need offset and steps
     uint16_t alt = (uint16_t)1000 + position->altitude * 2;
     data.meta.gnss_data.altitude = __builtin_bswap16(alt);
-}
-
-uint16_t M17LinkSetupFrame::crc16(const void *data, const size_t len) const
-{
-    const uint8_t *ptr = reinterpret_cast< const uint8_t *>(data);
-    uint16_t crc = 0xFFFF;
-
-    for(size_t i = 0; i < len; i++)
-    {
-        crc ^= (ptr[i] << 8);
-
-        for(uint8_t j = 0; j < 8; j++)
-        {
-            if(crc & 0x8000)
-                crc = (crc << 1) ^ 0x5935;
-            else
-                crc = (crc << 1);
-        }
-    }
-
-    return crc;
 }

--- a/scripts/clang_format.sh
+++ b/scripts/clang_format.sh
@@ -59,6 +59,7 @@ openrtx/include/peripherals/rng.h
 openrtx/include/peripherals/rtc.h
 openrtx/include/protocols/M17/Callsign.hpp
 openrtx/include/protocols/M17/M17FrameDecoder.hpp
+openrtx/src/core/crc.c
 openrtx/src/core/dsp.cpp
 openrtx/src/core/memory_profiling.cpp
 openrtx/src/protocols/M17/Callsign.cpp


### PR DESCRIPTION
This PR updates the CRC function used by M17 to use a 4-bit lookup table and moves it out of the `protocols/m17` to `core/crc.c`.

This addresses #413 and should allow an M17 LSF CRC to be calculated about 50% faster. It doesn't touch `crc_ccitt()` as that function with a lower-density polynomial is [already optimized beyond what a 4-bit lookup table can achieve](https://en.wikipedia.org/wiki/Computation_of_cyclic_redundancy_checks#Multi-bit_computation_using_lookup_tables).