### PR TITLE
At32f423 support

### DIFF
--- a/LICENSES/BSD-3-Clause-Clear.txt
+++ b/LICENSES/BSD-3-Clause-Clear.txt
@@ -1,0 +1,32 @@
+The Clear BSD License
+
+Copyright (c) 2023, Artery-MCU
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the disclaimer
+below) provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its contributors may be used
+  to endorse or promote products derived from this software without specific
+  prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY THIS
+LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -108,6 +108,15 @@ SPDX-License-Identifier = "BSD-3-Clause"
 SPDX-FileCopyrightText = "2017 STMicroelectronics"
 
 [[annotations]]
+path = [
+    "platform/mcu/CMSIS/Device/Artery/AT32F423/Include/**/*",
+    "platform/mcu/CMSIS/Device/Artery/AT32F423/Source/system_at32f423.c"
+]
+precedence = "aggregate"
+SPDX-License-Identifier = "BSD-3-Clause-Clear"
+SPDX-FileCopyrightText = "2025, Artery Technology"
+
+[[annotations]]
 path = "lib/minmea/**/*"
 precedence = "aggregate"
 SPDX-License-Identifier = "WTFPL"

--- a/meson.build
+++ b/meson.build
@@ -307,6 +307,7 @@ at32f423_src = ['platform/mcu/AT32F423/boot/startup.cpp',
                 'platform/mcu/AT32F423/boot/bsp.cpp',
                 'platform/mcu/AT32F423/boot/libc_integration.cpp',
                 'platform/drivers/GPIO/gpio_at32f423.c',
+                'platform/mcu/AT32F423/drivers/delays.cpp',
                 'platform/mcu/CMSIS/Device/Artery/AT32F423/Source/system_at32f423.c']
 
 at32f423_inc = ['platform/mcu/AT32F423',

--- a/meson.build
+++ b/meson.build
@@ -300,6 +300,26 @@ stm32h743_inc += miosix_cm7_inc
 stm32h743_def += miosix_cm7_def
 
 ##
+## AT32F423
+##
+
+at32f423_src = ['platform/mcu/AT32F423/boot/startup.cpp',
+                'platform/mcu/AT32F423/boot/bsp.cpp',
+                'platform/mcu/AT32F423/boot/libc_integration.cpp',
+                'platform/drivers/GPIO/gpio_at32f423.c',
+                'platform/mcu/CMSIS/Device/Artery/AT32F423/Source/system_at32f423.c']
+
+at32f423_inc = ['platform/mcu/AT32F423',
+                'platform/mcu/CMSIS/Include',
+                'platform/mcu/CMSIS/Device/Artery/AT32F423/Include']
+
+at32f423_def = {'AT32F423CCT7':''}
+
+at32f423_src += miosix_cm4f_src
+at32f423_inc += miosix_cm4f_inc
+at32f423_def += miosix_cm4f_def
+
+##
 ## ----------------------- Platform specializations ----------------------------
 ##
 

--- a/meson.build
+++ b/meson.build
@@ -309,6 +309,7 @@ at32f423_src = ['platform/mcu/AT32F423/boot/startup.cpp',
                 'platform/drivers/ADC/adc_at32.c',
                 'platform/drivers/GPIO/gpio_at32f423.c',
                 'platform/mcu/AT32F423/drivers/delays.cpp',
+                'platform/mcu/AT32F423/drivers/USART6.cpp',
                 'platform/mcu/CMSIS/Device/Artery/AT32F423/Source/system_at32f423.c']
 
 at32f423_inc = ['platform/mcu/AT32F423',

--- a/meson.build
+++ b/meson.build
@@ -316,7 +316,7 @@ at32f423_inc = ['platform/mcu/AT32F423',
                 'platform/mcu/CMSIS/Include',
                 'platform/mcu/CMSIS/Device/Artery/AT32F423/Include']
 
-at32f423_def = {'AT32F423CCT7':''}
+at32f423_def = {'AT32F423CCT7':'', 'AT32F423xx':''}
 
 at32f423_src += miosix_cm4f_src
 at32f423_inc += miosix_cm4f_inc

--- a/meson.build
+++ b/meson.build
@@ -306,11 +306,13 @@ stm32h743_def += miosix_cm7_def
 at32f423_src = ['platform/mcu/AT32F423/boot/startup.cpp',
                 'platform/mcu/AT32F423/boot/bsp.cpp',
                 'platform/mcu/AT32F423/boot/libc_integration.cpp',
+                'platform/drivers/ADC/adc_at32.c',
                 'platform/drivers/GPIO/gpio_at32f423.c',
                 'platform/mcu/AT32F423/drivers/delays.cpp',
                 'platform/mcu/CMSIS/Device/Artery/AT32F423/Source/system_at32f423.c']
 
 at32f423_inc = ['platform/mcu/AT32F423',
+                'platform/mcu/AT32F423/drivers',
                 'platform/mcu/CMSIS/Include',
                 'platform/mcu/CMSIS/Device/Artery/AT32F423/Include']
 

--- a/platform/drivers/ADC/adc_at32.c
+++ b/platform/drivers/ADC/adc_at32.c
@@ -1,0 +1,97 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <at32f423.h>
+#include <pthread.h>
+#include "adc_at32.h"
+#include <stdio.h>
+
+uint16_t adcAt32_sample(const struct Adc *adc, const uint32_t channel);
+
+int adcAt32_init(const struct Adc *adc)
+{
+    CRM->apb2en_bit.adc1en = TRUE;
+    __DSB();
+    CRM->misc1_bit.pllclk_to_adc = CRM_ADC_CLOCK_SOURCE_HCLK;
+
+    adc_type *pAdc = ((adc_type *) adc->priv);
+
+    ADCCOM->cctrl_bit.adcdiv = ADC_HCLK_DIV_4;
+    ADCCOM->cctrl_bit.itsrven = FALSE;
+
+    pAdc->ctrl1_bit.sqen = FALSE;
+    pAdc->ctrl2_bit.rpen = FALSE;
+    pAdc->ctrl2_bit.dtalign = ADC_RIGHT_ALIGNMENT;
+    pAdc->osq1_bit.oclen = 2;
+    pAdc->ctrl1_bit.crsel = ADC_RESOLUTION_12B;
+    pAdc->misc = 0x09;
+    pAdc->ctrl2_bit.adcen = TRUE;
+
+    while(pAdc->sts_bit.rdy == 0) ;
+
+    pAdc->ctrl2_bit.adcal = TRUE;
+    while(pAdc->ctrl2_bit.adcal) ;
+
+    if(adc->mutex != NULL)
+        pthread_mutex_init((pthread_mutex_t *) adc->mutex, NULL);
+
+    return 0;
+}
+
+void adcAt32_terminate(const struct Adc *adc)
+{
+    /* A conversion may be in progress, wait until it finishes */
+    if(adc->mutex != NULL)
+        pthread_mutex_lock((pthread_mutex_t *) adc->mutex);
+
+
+    if(adc->mutex != NULL)
+        pthread_mutex_destroy((pthread_mutex_t *) adc->mutex);
+}
+
+uint16_t adcAt32_sample(const struct Adc *adc, const uint32_t channel)
+{
+    if(channel > 27)
+        return 0;
+
+    adc_type *pAdc = ((adc_type *) adc->priv);
+
+    /* Channel 16 is internal temperature */
+    if(channel == 16)
+        ((adccom_type*)ADCCOM_BASE)->cctrl_bit.itsrven = TRUE;
+    /* Channel 17 is internal reference voltage */
+    if(channel == 17)
+        ((adccom_type*)ADCCOM_BASE)->cctrl_bit.itsrven = TRUE;
+
+    if(channel < ADC_CHANNEL_10)
+    {
+        pAdc->spt2 = (pAdc->spt2 & ~(0x07 << 3 * channel)) | (ADC_SAMPLETIME_12_5 << 3 * channel);
+    }
+    else if(channel < ADC_CHANNEL_20)
+    {
+        pAdc->spt1 = (pAdc->spt1 & ~(0x07 << (3 * (channel - ADC_CHANNEL_10)))) | (ADC_SAMPLETIME_12_5 << (3 * (channel - ADC_CHANNEL_10)));
+    }
+    else
+    {
+        pAdc->spt3 = (pAdc->spt3 & ~(0x07 << (3 * (channel - ADC_CHANNEL_20)))) | (ADC_SAMPLETIME_12_5 << (3 * (channel - ADC_CHANNEL_20)));
+    }
+    pAdc->osq3_bit.osn1 = channel;
+    pAdc->ctrl2_bit.octesel = ADC_PREEMPT_TRIG_SOFTWARE;
+    pAdc->ctrl2_bit.ocswtrg = TRUE;
+
+    while((pAdc->sts_bit.occe) == 0) ;
+
+    uint16_t value = pAdc->odt_bit.odt;
+
+    /* Disconnect Vbat channel. Vbat has an internal x2 voltage divider */
+    if(channel == 16 || channel == 17)
+    {
+        value *= 2;
+        ((adccom_type*)ADCCOM_BASE)->cctrl_bit.itsrven = FALSE;
+    }
+
+    return (uint16_t) value;
+}

--- a/platform/drivers/ADC/adc_at32.h
+++ b/platform/drivers/ADC/adc_at32.h
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef ADC_STM32_H
+#define ADC_STM32_H
+
+#include <peripherals/adc.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Define an instance of an AT32 ADC device driver.
+ *
+ * @param name: instance name.
+ * @param periph: pointer to hardware peripheral.
+ * @param mutx: pointer to mutex for concurrent access, can be NULL.
+ * @param vref: ADC reference voltage, in uV.
+ */
+#define ADC_AT32_DEVICE_DEFINE(name, periph, mutx, vref) \
+extern uint16_t adcAt32_sample(const struct Adc *adc,    \
+                                const uint32_t channel);  \
+const struct Adc name =                                   \
+{                                                         \
+    .sample     = &adcAt32_sample,                       \
+    .priv       = periph,                                 \
+    .mutex      = mutx,                                   \
+    .countsTouV = ADC_COUNTS_TO_UV(vref, 12)              \
+};
+
+/**
+ * Initialize an AT32 ADC peripheral.
+ *
+ * @param adc: pointer to ADC device handle.
+ * @return zero on success, a negative error code otherwise.
+ */
+int adcAt32_init(const struct Adc *adc);
+
+/**
+ * Shut down an AT32 ADC peripheral.
+ *
+ * @param adc: pointer to ADC device handle.
+ * @return zero on success, a negative error code otherwise.
+ */
+void adcAt32_terminate(const struct Adc *adc);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADC_STM32_H */

--- a/platform/drivers/GPIO/gpio-native.h
+++ b/platform/drivers/GPIO/gpio-native.h
@@ -15,6 +15,8 @@
 #include "drivers/GPIO/gpio_stm32.h"
 #elif defined(MK22FN512xx)
 #include "drivers/GPIO/gpio_mk22.h"
+#elif defined(AT32F423xx)
+#include "gpio_at32f423.h"
 #endif
 
 #endif /* GPIO_NATIVE_H */

--- a/platform/drivers/GPIO/gpio_at32f423.c
+++ b/platform/drivers/GPIO/gpio_at32f423.c
@@ -1,0 +1,156 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <errno.h>
+#include "at32f423.h"
+#include "gpio_at32f423.h"
+
+static inline void setGpioAf(void *port, uint8_t pin, const uint8_t af)
+{
+    gpio_type *p  = (gpio_type *)(port);
+    uint8_t afNum = af;
+    afNum &= 0x0F;
+    if(pin < 8)
+    {
+        p->muxl &= ~(0x0F << (pin*4));
+        p->muxl |= (afNum << (pin*4));
+    }
+    else
+    {
+        pin -= 8;
+        p->muxh &= ~(0x0F << (pin*4));
+        p->muxh |= (afNum << (pin*4));
+    }
+}
+
+void gpio_setMode(const void *port, const uint8_t pin, const uint16_t mode)
+{
+    gpio_type *p = (gpio_type *)(port);
+    p->cfgr  &= ~(3 << (pin*2));
+    p->omode &= ~(1 << pin);
+    p->odrvr &= ~(3 << (pin*2));
+    p->pull  &= ~(3 << (pin*2));
+
+    switch(mode)
+    {
+        case INPUT:
+            // (CFGR=00 OMODE=0 PULL=00)
+            p->cfgr  |= GPIO_MODE_INPUT << (pin*2);
+            p->omode |= GPIO_OUTPUT_PUSH_PULL << pin;
+            p->pull  |= GPIO_PULL_NONE << (pin*2);
+            break;
+
+        case INPUT_PULL_UP:
+            // (MODE=00 TYPE=0 PUP=01)
+            p->cfgr  |= GPIO_MODE_INPUT << (pin*2);
+            p->omode |= GPIO_OUTPUT_PUSH_PULL << pin;
+            p->pull  |= GPIO_PULL_UP << (pin*2);
+            break;
+
+        case INPUT_PULL_DOWN:
+            // (MODE=00 TYPE=0 PUP=10)
+            p->cfgr  |= GPIO_MODE_INPUT << (pin*2);
+            p->omode |= GPIO_OUTPUT_PUSH_PULL << pin;
+            p->pull  |= GPIO_PULL_DOWN << (pin*2);
+            break;
+
+        case ANALOG:
+            // (MODE=11 TYPE=0 PUP=00)
+            p->cfgr  |= GPIO_MODE_ANALOG << (pin*2);
+            p->omode |= GPIO_OUTPUT_PUSH_PULL << pin;
+            p->pull  |= GPIO_PULL_NONE << (pin*2);
+            break;
+
+        case OUTPUT:
+            // (MODE=01 TYPE=0 PUP=00)
+            p->cfgr  |= GPIO_MODE_OUTPUT << (pin*2);
+            p->omode |= GPIO_OUTPUT_PUSH_PULL << pin;
+            p->pull  |= GPIO_PULL_NONE << (pin*2);
+            break;
+
+        case OPEN_DRAIN:
+            // (MODE=01 TYPE=1 PUP=00)
+            p->cfgr  |= GPIO_MODE_OUTPUT << (pin*2);
+            p->omode |= GPIO_OUTPUT_OPEN_DRAIN << pin;
+            p->pull  |= GPIO_PULL_NONE << (pin*2);
+            break;
+
+        case OPEN_DRAIN_PU:
+            // (MODE=01 TYPE=1 PUP=00)
+            p->cfgr  |= GPIO_MODE_OUTPUT << (pin*2);
+            p->omode |= GPIO_OUTPUT_OPEN_DRAIN << pin;
+            p->pull  |= GPIO_PULL_UP << (pin*2);
+            break;
+
+        case ALTERNATE:
+            // (MODE=10 TYPE=0 PUP=00)
+            p->cfgr  |= GPIO_MODE_MUX << (pin*2);
+            p->omode |= GPIO_OUTPUT_PUSH_PULL << pin;
+            p->pull  |= GPIO_PULL_NONE << (pin*2);
+            break;
+
+        case ALTERNATE_OD:
+            // (MODE=10 TYPE=1 PUP=00)
+            p->cfgr  |= GPIO_MODE_MUX << (pin*2);
+            p->omode |= GPIO_OUTPUT_OPEN_DRAIN << pin;
+            p->pull  |= GPIO_PULL_NONE << (pin*2);
+            break;
+
+        default:
+            // Default to INPUT mode
+            p->cfgr  |= GPIO_MODE_INPUT << (pin*2);
+            p->omode |= GPIO_OUTPUT_PUSH_PULL << pin;
+            p->pull  |= GPIO_PULL_NONE << (pin*2);
+            break;
+    }
+}
+
+void gpio_setOutputSpeed(const void *port, const uint8_t pin, const enum Speed spd)
+{
+    ((gpio_type *)(port))->odrvr &= ~(3 << (pin*2));   // Clear old value
+    ((gpio_type *)(port))->odrvr |= spd << (pin*2);    // Set new value
+}
+
+static int gpioApi_mode(const struct gpioDev *dev, const uint8_t pin,
+                        const uint16_t mode)
+{
+    if(pin > 15)
+        return -EINVAL;
+
+    gpio_setMode((void *) dev->priv, pin, mode);
+    return 0;
+}
+
+static void gpioApi_set(const struct gpioDev *dev, const uint8_t pin)
+{
+    gpio_setPin((void *) dev->priv, pin);
+}
+
+static void gpioApi_clear(const struct gpioDev *dev, const uint8_t pin)
+{
+    gpio_clearPin((void *) dev->priv, pin);
+}
+
+static bool gpioApi_read(const struct gpioDev *dev, const uint8_t pin)
+{
+    uint8_t val = gpio_readPin(dev->priv, pin);
+    return (val != 0) ? true : false;
+}
+
+static const struct gpioApi gpioApi =
+{
+    .mode  = gpioApi_mode,
+    .set   = gpioApi_set,
+    .clear = gpioApi_clear,
+    .read  = gpioApi_read
+};
+
+const struct gpioDev GpioA = { .api = &gpioApi, .priv = GPIOA };
+const struct gpioDev GpioB = { .api = &gpioApi, .priv = GPIOB };
+const struct gpioDev GpioC = { .api = &gpioApi, .priv = GPIOC };
+const struct gpioDev GpioD = { .api = &gpioApi, .priv = GPIOD };
+const struct gpioDev GpioE = { .api = &gpioApi, .priv = GPIOE };
+const struct gpioDev GpioF = { .api = &gpioApi, .priv = GPIOF };

--- a/platform/drivers/GPIO/gpio_at32f423.h
+++ b/platform/drivers/GPIO/gpio_at32f423.h
@@ -1,0 +1,104 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef GPIO_STM32_H
+#define GPIO_STM32_H
+
+#include <peripherals/gpio.h>
+#include <at32f423.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * This file provides the interface for STM32 gpio.
+ */
+
+/**
+ * Maximum GPIO switching speed.
+ * For more details see microcontroller's reference manual and datasheet.
+ */
+enum Speed
+{
+    LOW    = 0x0,   ///< 2MHz
+    MEDIUM = 0x1,   ///< 25MHz
+    FAST   = 0x2,   ///< 50MHz
+    HIGH   = 0x3    ///< 100MHz
+};
+
+/**
+ * STM32 gpio devices
+ */
+extern const struct gpioDev GpioA;
+extern const struct gpioDev GpioB;
+extern const struct gpioDev GpioC;
+extern const struct gpioDev GpioD;
+extern const struct gpioDev GpioE;
+extern const struct gpioDev GpioF;
+
+/**
+ * Configure gpio pin functional mode.
+ *
+ * @param port: gpio port.
+ * @param pin: gpio pin number, between 0 and 15.
+ * @param mode: bit 7:0 set gpio functional mode, bit 15:8 manage gpio alternate
+ * function mapping.
+ */
+void gpio_setMode(const void *port, const uint8_t pin, const uint16_t mode);
+
+/**
+ * Configure gpio pin maximum output speed.
+ *
+ * @param port: gpio port.
+ * @param pin: gpio pin number, between 0 and 15.
+ * @param spd: gpio output speed to be set.
+ */
+void gpio_setOutputSpeed(const void *port, const uint8_t pin, const enum Speed spd);
+
+/**
+ * Set gpio pin to high logic level.
+ * NOTE: this operation is performed atomically.
+ *
+ * @param port: gpio port.
+ * @param pin: gpio pin number, between 0 and 15.
+ */
+static inline void gpio_setPin(const void *port, const uint8_t pin)
+{
+    ((gpio_type *)(port))->scr = (1 << pin);
+}
+
+/**
+ * Set gpio pin to low logic level.
+ * NOTE: this operation is performed atomically.
+ *
+ * @param port: gpio port.
+ * @param pin: gpio pin number, between 0 and 15.
+ */
+static inline void gpio_clearPin(const void *port, const uint8_t pin)
+{
+    ((gpio_type *)(port))->scr = (1 << (pin + 16));
+}
+
+/**
+ * Read gpio pin's logic level.
+ *
+ * @param port: gpio port.
+ * @param pin: gpio pin number, between 0 and 15.
+ * @return 1 if pin is at high logic level, 0 if pin is at low logic level.
+ */
+static inline uint8_t gpio_readPin(const void *port, const uint8_t pin)
+{
+    gpio_type *p = (gpio_type *)(port);
+    return ((p->idt & (1 << pin)) != 0) ? 1 : 0;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_STM32_H */

--- a/platform/mcu/AT32F423/boot/arch_registers_impl.h
+++ b/platform/mcu/AT32F423/boot/arch_registers_impl.h
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+#ifndef ARCH_REGISTERS_IMPL_H
+#define	ARCH_REGISTERS_IMPL_H
+
+//Always include stm32f4xx.h before core_cm4.h, there's some nasty dependency
+#include "at32f423.h"
+#include "core_cm4.h"
+#include "system_at32f423.h"
+
+#define RCC_SYNC() //Workaround for a bug in stm32f42x
+
+#endif	//ARCH_REGISTERS_IMPL_H

--- a/platform/mcu/AT32F423/boot/bsp.cpp
+++ b/platform/mcu/AT32F423/boot/bsp.cpp
@@ -9,9 +9,13 @@
 * Board support package, this file initializes hardware.
 ************************************************************************/
 
+#include <interfaces/platform.h>
+#include <peripherals/gpio.h>
+#include <drivers/USART6.h>
 #include <interfaces/bsp.h>
 #include <kernel/kernel.h>
 #include <kernel/sync.h>
+#include <hwconfig.h>
 
 namespace miosix
 {
@@ -29,6 +33,14 @@ void IRQbspInit()
 
     // Configure SysTick
     SysTick->LOAD = SystemCoreClock / miosix::TICK_FREQ;
+
+
+
+
+    // Bring up USART1
+    gpio_setMode(USART6_TX, ALTERNATE);
+    usart6_init(115200);
+    usart6_IRQwrite("Starting system...\r\n");
 }
 
 void bspInit2()

--- a/platform/mcu/AT32F423/boot/bsp.cpp
+++ b/platform/mcu/AT32F423/boot/bsp.cpp
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/***********************************************************************
+* bsp.cpp Part of the Miosix Embedded OS.
+* Board support package, this file initializes hardware.
+************************************************************************/
+
+#include <interfaces/bsp.h>
+#include <kernel/kernel.h>
+#include <kernel/sync.h>
+
+namespace miosix
+{
+
+//
+// Initialization
+//
+
+void IRQbspInit()
+{
+    CRM->ahben1 |= (1 << 0)     // Enable GPIOA
+                |  (1 << 1)     // Enable GPIOB
+                |  (1 << 2)     // Enable GPIOC
+                |  (1 << 5);    // Enable GPIOF
+
+    // Configure SysTick
+    SysTick->LOAD = SystemCoreClock / miosix::TICK_FREQ;
+}
+
+void bspInit2()
+{
+
+}
+
+//
+// Shutdown and reboot
+//
+
+void shutdown()
+{
+    reboot();
+}
+
+void reboot()
+{
+    disableInterrupts();
+    miosix_private::IRQsystemReboot();
+}
+
+} //namespace miosix

--- a/platform/mcu/AT32F423/boot/libc_integration.cpp
+++ b/platform/mcu/AT32F423/boot/libc_integration.cpp
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <reent.h>
 #include <filesystem/file_access.h>
+#include <drivers/USART6.h>
 
 using namespace std;
 
@@ -20,11 +21,19 @@ extern "C" {
  */
 int _write_r(struct _reent *ptr, int fd, const void *buf, size_t cnt)
 {
-
+#ifdef ENABLE_STDIO
+    if(fd == STDOUT_FILENO || fd == STDERR_FILENO)
+    {
+        usart6_writeBlock((void *) buf, cnt, 0);
+        return cnt;
+    }
+#else
     (void) ptr;
     (void) fd;
     (void) buf;
     (void) cnt;
+#endif
+
 
     /* If fd is not stdout or stderr */
     ptr->_errno = EBADF;
@@ -37,10 +46,26 @@ int _write_r(struct _reent *ptr, int fd, const void *buf, size_t cnt)
  */
 int _read_r(struct _reent *ptr, int fd, void *buf, size_t cnt)
 {
+#ifdef ENABLE_STDIO
+    if(fd == STDOUT_FILENO || fd == STDERR_FILENO)
+    {
+        usart6_readBlock((void *) buf, cnt, 0);
+        return cnt;
+    }
+    if(fd == STDIN_FILENO)
+    {
+        for(;;)
+        {
+            ssize_t r = usart6_readBlock((void *) buf, cnt, 0);
+            if((r < 0) || (r == (ssize_t)(cnt))) return r;
+        }
+    }
+#else
     (void) ptr;
     (void) fd;
     (void) buf;
     (void) cnt;
+#endif
 
     /* If fd is not stdin */
     ptr->_errno = EBADF;

--- a/platform/mcu/AT32F423/boot/libc_integration.cpp
+++ b/platform/mcu/AT32F423/boot/libc_integration.cpp
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <stdio.h>
+#include <reent.h>
+#include <filesystem/file_access.h>
+
+using namespace std;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \internal
+ * _write_r, write to a file
+ */
+int _write_r(struct _reent *ptr, int fd, const void *buf, size_t cnt)
+{
+
+    (void) ptr;
+    (void) fd;
+    (void) buf;
+    (void) cnt;
+
+    /* If fd is not stdout or stderr */
+    ptr->_errno = EBADF;
+    return -1;
+}
+
+/**
+ * \internal
+ * _read_r, read from a file.
+ */
+int _read_r(struct _reent *ptr, int fd, void *buf, size_t cnt)
+{
+    (void) ptr;
+    (void) fd;
+    (void) buf;
+    (void) cnt;
+
+    /* If fd is not stdin */
+    ptr->_errno = EBADF;
+    return -1;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/platform/mcu/AT32F423/boot/startup.cpp
+++ b/platform/mcu/AT32F423/boot/startup.cpp
@@ -1,0 +1,383 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/*
+ * startup.cpp
+ * STM32 C++ startup.
+ * NOTE: for stm32f4 devices ONLY.
+ * Supports interrupt handlers in C++ without extern "C"
+ * Developed by Terraneo Federico, based on ST startup code.
+ * Additionally modified to boot Miosix.
+ */
+
+#include "interfaces/arch_registers.h"
+#include "kernel/stage_2_boot.h"
+#include "core/interrupts.h" //For the unexpected interrupt call
+#include <string.h>
+
+/**
+ * Called by Reset_Handler, performs initialization and calls main.
+ * Never returns.
+ */
+void program_startup() __attribute__((noreturn));
+void program_startup()
+{
+    //Cortex M3 core appears to get out of reset with interrupts already enabled
+    __disable_irq();
+
+    //SystemInit() is called *before* initializing .data and zeroing .bss
+    //Despite all startup files provided by ST do the opposite, there are three
+    //good reasons to do so:
+    //First, the CMSIS specifications say that SystemInit() must not access
+    //global variables, so it is actually possible to call it before
+    //Second, when running Miosix with the xram linker scripts .data and .bss
+    //are placed in the external RAM, so we *must* call SystemInit(), which
+    //enables xram, before touching .data and .bss
+    //Third, this is a performance improvement since the loops that initialize
+    //.data and zeros .bss now run with the CPU at full speed instead of 8MHz
+    SystemInit();
+
+    //These are defined in the linker script
+    extern unsigned char _etext asm("_etext");
+    extern unsigned char _data asm("_data");
+    extern unsigned char _edata asm("_edata");
+    extern unsigned char _bss_start asm("_bss_start");
+    extern unsigned char _bss_end asm("_bss_end");
+
+    //Initialize .data section, clear .bss section
+    unsigned char *etext=&_etext;
+    unsigned char *data=&_data;
+    unsigned char *edata=&_edata;
+    unsigned char *bss_start=&_bss_start;
+    unsigned char *bss_end=&_bss_end;
+    memcpy(data, etext, edata-data);
+    memset(bss_start, 0, bss_end-bss_start);
+
+    //Move on to stage 2
+    _init();
+
+    //If main returns, reboot
+    NVIC_SystemReset();
+    for(;;) ;
+}
+
+/**
+ * Reset handler, called by hardware immediately after reset
+ */
+void Reset_Handler() __attribute__((__interrupt__, noreturn));
+void Reset_Handler()
+{
+    /*
+     * Initialize process stack and switch to it.
+     * This is required for booting Miosix, a small portion of the top of the
+     * heap area will be used as stack until the first thread starts. After,
+     * this stack will be abandoned and the process stack will point to the
+     * current thread's stack.
+     */
+    asm volatile("ldr r0,  =_heap_end          \n\t"
+                 "msr psp, r0                  \n\t"
+                 "movw r0, #2                  \n\n" //Privileged, process stack
+                 "msr control, r0              \n\t"
+                 "isb                          \n\t":::"r0");
+
+    program_startup();
+}
+
+/**
+ * All unused interrupts call this function.
+ */
+extern "C" void Default_Handler()
+{
+    unexpectedInterrupt();
+}
+
+//System handlers
+void /*__attribute__((weak))*/ Reset_Handler();     //These interrupts are not
+void /*__attribute__((weak))*/ NMI_Handler();       //weak because they are
+void /*__attribute__((weak))*/ HardFault_Handler(); //surely defined by Miosix
+void /*__attribute__((weak))*/ MemManage_Handler();
+void /*__attribute__((weak))*/ BusFault_Handler();
+void /*__attribute__((weak))*/ UsageFault_Handler();
+void /*__attribute__((weak))*/ SVC_Handler();
+void /*__attribute__((weak))*/ DebugMon_Handler();
+void /*__attribute__((weak))*/ PendSV_Handler();
+void /*__attribute__((weak))*/ SysTick_Handler();
+
+//Interrupt handlers
+void __attribute__((weak)) WWDT_IRQHandler();
+void __attribute__((weak)) PVM_IRQHandler();
+void __attribute__((weak)) TAMP_STAMP_IRQHandler();
+void __attribute__((weak)) ERTC_WKUP_IRQHandler();
+void __attribute__((weak)) FLASH_IRQHandler();
+void __attribute__((weak)) CRM_IRQHandler();
+void __attribute__((weak)) EXINT0_IRQHandler();
+void __attribute__((weak)) EXINT1_IRQHandler();
+void __attribute__((weak)) EXINT2_IRQHandler();
+void __attribute__((weak)) EXINT3_IRQHandler();
+void __attribute__((weak)) EXINT4_IRQHandler();
+void __attribute__((weak)) DMA1_Channel1_IRQHandler();
+void __attribute__((weak)) DMA1_Channel2_IRQHandler();
+void __attribute__((weak)) DMA1_Channel3_IRQHandler();
+void __attribute__((weak)) DMA1_Channel4_IRQHandler();
+void __attribute__((weak)) DMA1_Channel5_IRQHandler();
+void __attribute__((weak)) DMA1_Channel6_IRQHandler();
+void __attribute__((weak)) DMA1_Channel7_IRQHandler();
+void __attribute__((weak)) ADC1_IRQHandler();
+void __attribute__((weak)) CAN1_TX_IRQHandler();
+void __attribute__((weak)) CAN1_RX0_IRQHandler();
+void __attribute__((weak)) CAN1_RX1_IRQHandler();
+void __attribute__((weak)) CAN1_SE_IRQHandler();
+void __attribute__((weak)) EXINT9_5_IRQHandler();
+void __attribute__((weak)) TMR1_BRK_TMR9_IRQHandler();
+void __attribute__((weak)) TMR1_OVF_TMR10_IRQHandler();
+void __attribute__((weak)) TMR1_TRG_HALL_TMR11_IRQHandler();
+void __attribute__((weak)) TMR1_CH_IRQHandler();
+void __attribute__((weak)) TMR2_GLOBAL_IRQHandler();
+void __attribute__((weak)) TMR3_GLOBAL_IRQHandler();
+void __attribute__((weak)) TMR4_GLOBAL_IRQHandler();
+void __attribute__((weak)) I2C1_EVT_IRQHandler();
+void __attribute__((weak)) I2C1_ERR_IRQHandler();
+void __attribute__((weak)) I2C2_EVT_IRQHandler();
+void __attribute__((weak)) I2C2_ERR_IRQHandler();
+void __attribute__((weak)) SPI1_IRQHandler();
+void __attribute__((weak)) SPI2_IRQHandler();
+void __attribute__((weak)) USART1_IRQHandler();
+void __attribute__((weak)) USART2_IRQHandler();
+void __attribute__((weak)) USART3_IRQHandler();
+void __attribute__((weak)) EXINT15_10_IRQHandler();
+void __attribute__((weak)) ERTCAlarm_IRQHandler();
+void __attribute__((weak)) OTGFS1_WKUP_IRQHandler();
+void __attribute__((weak)) TMR12_GLOBAL_IRQHandler();
+void __attribute__((weak)) TMR13_GLOBAL_IRQHandler();
+void __attribute__((weak)) TMR14_GLOBAL_IRQHandler();
+void __attribute__((weak)) SPI3_IRQHandler();
+void __attribute__((weak)) USART4_IRQHandler();
+void __attribute__((weak)) USART5_IRQHandler();
+void __attribute__((weak)) TMR6_DAC_GLOBAL_IRQHandler();
+void __attribute__((weak)) TMR7_GLOBAL_IRQHandler();
+void __attribute__((weak)) DMA2_Channel1_IRQHandler();
+void __attribute__((weak)) DMA2_Channel2_IRQHandler();
+void __attribute__((weak)) DMA2_Channel3_IRQHandler();
+void __attribute__((weak)) DMA2_Channel4_IRQHandler();
+void __attribute__((weak)) DMA2_Channel5_IRQHandler();
+void __attribute__((weak)) CAN2_TX_IRQHandler();
+void __attribute__((weak)) CAN2_RX0_IRQHandler();
+void __attribute__((weak)) CAN2_RX1_IRQHandler();
+void __attribute__((weak)) CAN2_SE_IRQHandler();
+void __attribute__((weak)) OTGFS1_IRQHandler();
+void __attribute__((weak)) DMA2_Channel6_IRQHandler();
+void __attribute__((weak)) DMA2_Channel7_IRQHandler();
+void __attribute__((weak)) USART6_IRQHandler();
+void __attribute__((weak)) I2C3_EVT_IRQHandler();
+void __attribute__((weak)) I2C3_ERR_IRQHandler();
+void __attribute__((weak)) FPU_IRQHandler();
+void __attribute__((weak)) USART7_IRQHandler();
+void __attribute__((weak)) USART8_IRQHandler();
+void __attribute__((weak)) DMAMUX_IRQHandler();
+void __attribute__((weak)) ACC_IRQHandler();
+
+//Stack top, defined in the linker script
+extern char _main_stack_top asm("_main_stack_top");
+
+//Interrupt vectors, must be placed @ address 0x00000000
+//The extern declaration is required otherwise g++ optimizes it out
+extern void (* const __Vectors[])();
+void (* const __Vectors[])() __attribute__ ((section(".isr_vector"))) =
+{
+    reinterpret_cast<void (*)()>(&_main_stack_top),/* Stack pointer*/
+    Reset_Handler,
+    NMI_Handler,
+    HardFault_Handler,
+    MemManage_Handler,
+    BusFault_Handler,
+    UsageFault_Handler,
+    0,
+    0,
+    0,
+    0,
+    SVC_Handler,
+    DebugMon_Handler,
+    0,
+    PendSV_Handler,
+    SysTick_Handler,
+
+    WWDT_IRQHandler,                     /* Window Watchdog Timer                   */
+    PVM_IRQHandler,                      /* PVM through EXINT Line detect           */
+    TAMP_STAMP_IRQHandler,               /* Tamper and TimeStamps through the EXINT line */
+    ERTC_WKUP_IRQHandler,                /* ERTC Wakeup through the EXINT line      */
+    FLASH_IRQHandler,                    /* Flash                                   */
+    CRM_IRQHandler,                      /* CRM                                     */
+    EXINT0_IRQHandler,                   /* EXINT Line 0                            */
+    EXINT1_IRQHandler,                   /* EXINT Line 1                            */
+    EXINT2_IRQHandler,                   /* EXINT Line 2                            */
+    EXINT3_IRQHandler,                   /* EXINT Line 3                            */
+    EXINT4_IRQHandler,                   /* EXINT Line 4                            */
+    DMA1_Channel1_IRQHandler,            /* DMA1 Channel 1                          */
+    DMA1_Channel2_IRQHandler,            /* DMA1 Channel 2                          */
+    DMA1_Channel3_IRQHandler,            /* DMA1 Channel 3                          */
+    DMA1_Channel4_IRQHandler,            /* DMA1 Channel 4                          */
+    DMA1_Channel5_IRQHandler,            /* DMA1 Channel 5                          */
+    DMA1_Channel6_IRQHandler,            /* DMA1 Channel 6                          */
+    DMA1_Channel7_IRQHandler,            /* DMA1 Channel 7                          */
+    ADC1_IRQHandler,                     /* ADC1                                    */
+    CAN1_TX_IRQHandler,                  /* CAN1 TX                                 */
+    CAN1_RX0_IRQHandler,                 /* CAN1 RX0                                */
+    CAN1_RX1_IRQHandler,                 /* CAN1 RX1                                */
+    CAN1_SE_IRQHandler ,                 /* CAN1 SE                                 */
+    EXINT9_5_IRQHandler ,                /* EXINT Line [9:5]                        */
+    TMR1_BRK_TMR9_IRQHandler,            /* TMR1 Brake and TMR9                     */
+    TMR1_OVF_TMR10_IRQHandler,           /* TMR1 Overflow and TMR10                 */
+    TMR1_TRG_HALL_TMR11_IRQHandler,      /* TMR1 Trigger and hall and TMR11         */
+    TMR1_CH_IRQHandler,                  /* TMR1 Channel                            */
+    TMR2_GLOBAL_IRQHandler,              /* TMR2                                    */
+    TMR3_GLOBAL_IRQHandler,              /* TMR3                                    */
+    TMR4_GLOBAL_IRQHandler,              /* TMR4                                    */
+    I2C1_EVT_IRQHandler,                 /* I2C1 Event                              */
+    I2C1_ERR_IRQHandler,                 /* I2C1 Error                              */
+    I2C2_EVT_IRQHandler,                 /* I2C2 Event                              */
+    I2C2_ERR_IRQHandler,                 /* I2C2 Error                              */
+    SPI1_IRQHandler,                     /* SPI1                                    */
+    SPI2_IRQHandler,                     /* SPI2                                    */
+    USART1_IRQHandler,                   /* USART1                                  */
+    USART2_IRQHandler,                   /* USART2                                  */
+    USART3_IRQHandler,                   /* USART3                                  */
+    EXINT15_10_IRQHandler,               /* EXINT Line [15:10]                      */
+    ERTCAlarm_IRQHandler,                /* RTC Alarm through EXINT Line            */
+    OTGFS1_WKUP_IRQHandler,              /* OTGFS1 Wakeup from suspend              */
+    TMR12_GLOBAL_IRQHandler,             /* TMR12                                   */
+    TMR13_GLOBAL_IRQHandler,             /* TMR13                                   */
+    TMR14_GLOBAL_IRQHandler,             /* TMR14                                   */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    SPI3_IRQHandler,                     /* SPI3                                    */
+    USART4_IRQHandler,                   /* USART4                                  */
+    USART5_IRQHandler,                   /* USART5                                  */
+    TMR6_DAC_GLOBAL_IRQHandler,          /* TMR6 & DAC                              */
+    TMR7_GLOBAL_IRQHandler,              /* TMR7                                    */
+    DMA2_Channel1_IRQHandler,            /* DMA2 Channel 1                          */
+    DMA2_Channel2_IRQHandler,            /* DMA2 Channel 2                          */
+    DMA2_Channel3_IRQHandler,            /* DMA2 Channel 3                          */
+    DMA2_Channel4_IRQHandler,            /* DMA2 Channel 4                          */
+    DMA2_Channel5_IRQHandler,            /* DMA2 Channel 5                          */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    CAN2_TX_IRQHandler,                  /* CAN2 TX                                 */
+    CAN2_RX0_IRQHandler,                 /* CAN2 RX0                                */
+    CAN2_RX1_IRQHandler,                 /* CAN2 RX1                                */
+    CAN2_SE_IRQHandler,                  /* CAN2 SE                                 */
+    OTGFS1_IRQHandler,                   /* OTGFS1                                  */
+    DMA2_Channel6_IRQHandler,            /* DMA2 Channel 6                          */
+    DMA2_Channel7_IRQHandler,            /* DMA2 Channel 7                          */
+    0,                                   /* Reserved                                */
+    USART6_IRQHandler,                   /* USART6                                  */
+    I2C3_EVT_IRQHandler,                 /* I2C3 Event                              */
+    I2C3_ERR_IRQHandler,                 /* I2C3 Error                              */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    FPU_IRQHandler,                      /* FPU                                     */
+    USART7_IRQHandler,                   /* USART7                                  */
+    USART8_IRQHandler,                   /* USART8                                  */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    DMAMUX_IRQHandler,                   /* DMAMUX                                  */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    0,                                   /* Reserved                                */
+    ACC_IRQHandler                       /* ACC                                     */
+};
+
+#pragma weak WWDT_IRQHandler = Default_Handler
+#pragma weak PVM_IRQHandler = Default_Handler
+#pragma weak TAMP_STAMP_IRQHandler = Default_Handler
+#pragma weak ERTC_WKUP_IRQHandler = Default_Handler
+#pragma weak FLASH_IRQHandler = Default_Handler
+#pragma weak CRM_IRQHandler = Default_Handler
+#pragma weak EXINT0_IRQHandler = Default_Handler
+#pragma weak EXINT1_IRQHandler = Default_Handler
+#pragma weak EXINT2_IRQHandler = Default_Handler
+#pragma weak EXINT3_IRQHandler = Default_Handler
+#pragma weak EXINT4_IRQHandler = Default_Handler
+#pragma weak DMA1_Channel1_IRQHandler = Default_Handler
+#pragma weak DMA1_Channel2_IRQHandler = Default_Handler
+#pragma weak DMA1_Channel3_IRQHandler = Default_Handler
+#pragma weak DMA1_Channel4_IRQHandler = Default_Handler
+#pragma weak DMA1_Channel5_IRQHandler = Default_Handler
+#pragma weak DMA1_Channel6_IRQHandler = Default_Handler
+#pragma weak DMA1_Channel7_IRQHandler = Default_Handler
+#pragma weak ADC1_IRQHandler = Default_Handler
+#pragma weak CAN1_TX_IRQHandler = Default_Handler
+#pragma weak CAN1_RX0_IRQHandler = Default_Handler
+#pragma weak CAN1_RX1_IRQHandler = Default_Handler
+#pragma weak CAN1_SE_IRQHandler = Default_Handler
+#pragma weak EXINT9_5_IRQHandler = Default_Handler
+#pragma weak TMR1_BRK_TMR9_IRQHandler = Default_Handler
+#pragma weak TMR1_OVF_TMR10_IRQHandler = Default_Handler
+#pragma weak TMR1_TRG_HALL_TMR11_IRQHandler = Default_Handler
+#pragma weak TMR1_CH_IRQHandler = Default_Handler
+#pragma weak TMR2_GLOBAL_IRQHandler = Default_Handler
+#pragma weak TMR3_GLOBAL_IRQHandler = Default_Handler
+#pragma weak TMR4_GLOBAL_IRQHandler = Default_Handler
+#pragma weak I2C1_EVT_IRQHandler = Default_Handler
+#pragma weak I2C1_ERR_IRQHandler = Default_Handler
+#pragma weak I2C2_EVT_IRQHandler = Default_Handler
+#pragma weak I2C2_ERR_IRQHandler = Default_Handler
+#pragma weak SPI1_IRQHandler = Default_Handler
+#pragma weak SPI2_IRQHandler = Default_Handler
+#pragma weak USART1_IRQHandler = Default_Handler
+#pragma weak USART2_IRQHandler = Default_Handler
+#pragma weak USART3_IRQHandler = Default_Handler
+#pragma weak EXINT15_10_IRQHandler = Default_Handler
+#pragma weak ERTCAlarm_IRQHandler = Default_Handler
+#pragma weak OTGFS1_WKUP_IRQHandler = Default_Handler
+#pragma weak TMR12_GLOBAL_IRQHandler = Default_Handler
+#pragma weak TMR13_GLOBAL_IRQHandler = Default_Handler
+#pragma weak TMR14_GLOBAL_IRQHandler = Default_Handler
+#pragma weak SPI3_IRQHandler = Default_Handler
+#pragma weak USART4_IRQHandler = Default_Handler
+#pragma weak USART5_IRQHandler = Default_Handler
+#pragma weak TMR6_DAC_GLOBAL_IRQHandler = Default_Handler
+#pragma weak TMR7_GLOBAL_IRQHandler = Default_Handler
+#pragma weak DMA2_Channel1_IRQHandler = Default_Handler
+#pragma weak DMA2_Channel2_IRQHandler = Default_Handler
+#pragma weak DMA2_Channel3_IRQHandler = Default_Handler
+#pragma weak DMA2_Channel4_IRQHandler = Default_Handler
+#pragma weak DMA2_Channel5_IRQHandler = Default_Handler
+#pragma weak CAN2_TX_IRQHandler = Default_Handler
+#pragma weak CAN2_RX0_IRQHandler = Default_Handler
+#pragma weak CAN2_RX1_IRQHandler = Default_Handler
+#pragma weak CAN2_SE_IRQHandler = Default_Handler
+#pragma weak OTGFS1_IRQHandler = Default_Handler
+#pragma weak DMA2_Channel6_IRQHandler = Default_Handler
+#pragma weak DMA2_Channel7_IRQHandler = Default_Handler
+#pragma weak USART6_IRQHandler = Default_Handler
+#pragma weak I2C3_EVT_IRQHandler = Default_Handler
+#pragma weak I2C3_ERR_IRQHandler = Default_Handler
+#pragma weak FPU_IRQHandler = Default_Handler
+#pragma weak USART7_IRQHandler = Default_Handler
+#pragma weak USART8_IRQHandler = Default_Handler
+#pragma weak DMAMUX_IRQHandler = Default_Handler
+#pragma weak ACC_IRQHandler = Default_Handler

--- a/platform/mcu/AT32F423/drivers/USART6.cpp
+++ b/platform/mcu/AT32F423/drivers/USART6.cpp
@@ -1,0 +1,183 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <kernel/scheduler/scheduler.h>
+#include <kernel/queue.h>
+#include <miosix.h>
+#include <at32f423.h>
+#include "USART6.h"
+
+using namespace miosix;
+
+static constexpr int rxQueueMin = 16; //  Minimum queue size
+
+static DynUnsyncQueue< char > rxQueue(128);  // Queue for incoming data
+static Thread   *rxWaiting = 0;              // Thread waiting on RX
+static bool      rxIdle    = true;           // Flag for RX idle
+static FastMutex rxMutex;                    // Mutex locked during reception
+static FastMutex txMutex;                    // Mutex locked during transmission
+
+/**
+ * \internal
+ * Wait until all characters have been written to the serial port.
+ * Needs to be callable from interrupts disabled (it is used in IRQwrite)
+ */
+static inline void waitSerialTxFifoEmpty()
+{
+    while((USART6->sts & (1 << 6)) == 0) ;
+}
+
+/**
+ * \internal
+ * Interrupt handler function, called by USART1_IRQHandler.
+ */
+void __attribute__((noinline)) usart6irqImpl()
+{
+    unsigned int status = USART6->sts;
+    char c;
+
+    // New character received
+    if(status & (1 << 5))
+    {
+        //Always read data, since this clears interrupt flags
+        c = USART6->dt;
+
+        //If no error put data in buffer
+        if((status & (1 << 1)) == 0)
+        {
+            if(rxQueue.tryPut(c) == false) {/*fifo overflow*/}
+        }
+
+        rxIdle = false;
+    }
+
+    // Idle line
+    if(status & (1 << 4))
+    {
+        c = USART6->dt; //clears interrupt flags
+        rxIdle = true;
+    }
+
+    // Enough data in buffer or idle line, awake thread
+    if((status & (1 << 4)) || rxQueue.size() >= rxQueueMin)
+    {
+        if(rxWaiting)
+        {
+            rxWaiting->IRQwakeup();
+            if(rxWaiting->IRQgetPriority()>
+                Thread::IRQgetCurrentThread()->IRQgetPriority())
+                    Scheduler::IRQfindNextThread();
+            rxWaiting = 0;
+        }
+    }
+}
+
+void __attribute__((naked)) USART6_IRQHandler()
+{
+    saveContext();
+    asm volatile("bl _Z13usart6irqImplv");
+    restoreContext();
+}
+
+
+void usart6_init(unsigned int baudrate)
+{
+    CRM->apb2en |= (1 << 5);
+    __DSB();
+
+    // Get current frequency of APB2 clock
+    unsigned int freq = SystemCoreClock;
+    if(CRM->cfg_bit.apb2div != 0)
+        freq /= ((CRM->cfg_bit.apb2div & 0x03) + 1);
+
+    const unsigned int quot = 2*freq/baudrate; // 2*freq for round to nearest
+    USART6->baudr = quot/2 + (quot & 1);       // Round to nearest
+    USART6->ctrl1_bit.ren = 1;                 // Reception enabled
+    USART6->ctrl1_bit.ten = 1;                 // Transmission enabled
+    USART6->ctrl1_bit.idleien = 1;             // Interrupt on idle line
+    USART6->ctrl1_bit.rdbfien = 1;             // Interrupt on data received
+    USART6->ctrl1_bit.uen = 1;                 // Enable port
+
+    NVIC_SetPriority(USART6_IRQn, 15);         // Lowest priority for serial
+    NVIC_EnableIRQ(USART6_IRQn);
+}
+
+void usart6_terminate()
+{
+    waitSerialTxFifoEmpty();
+
+    NVIC_DisableIRQ(USART6_IRQn);
+
+    USART6->ctrl1 &= ~(1 << 13);
+    CRM->apb2en   &= ~(1 << 14);
+    __DSB();
+}
+
+ssize_t usart6_readBlock(void *buffer, size_t size, off_t where)
+{
+    (void) where;
+
+    miosix::Lock< miosix::FastMutex > l(rxMutex);
+    char *buf = reinterpret_cast< char* >(buffer);
+    size_t result = 0;
+    FastInterruptDisableLock dLock;
+
+    for(;;)
+    {
+        //Try to get data from the queue
+        for(; result < size; result++)
+        {
+            if(rxQueue.tryGet(buf[result])==false) break;
+            //This is here just not to keep IRQ disabled for the whole loop
+            FastInterruptEnableLock eLock(dLock);
+        }
+        if(rxIdle && result > 0) break;
+        if(result == size) break;
+        //Wait for data in the queue
+        do {
+            rxWaiting = Thread::IRQgetCurrentThread();
+            Thread::IRQwait();
+            {
+                FastInterruptEnableLock eLock(dLock);
+                Thread::yield();
+            }
+        } while(rxWaiting);
+    }
+
+    return result;
+}
+
+ssize_t usart6_writeBlock(void *buffer, size_t size, off_t where)
+{
+    (void) where;
+
+    miosix::Lock< miosix::FastMutex > l(txMutex);
+    const char *buf = reinterpret_cast< const char* >(buffer);
+    for(size_t i = 0; i < size; i++)
+    {
+        while(USART6->sts_bit.tdbe == 0) ;
+        USART6->dt_bit.dt = *buf++;
+    }
+
+    return size;
+}
+
+void usart6_IRQwrite(const char *str)
+{
+    // We can reach here also with only kernel paused, so make sure
+    // interrupts are disabled. This is important for the DMA case
+    bool interrupts = areInterruptsEnabled();
+    if(interrupts) fastDisableInterrupts();
+
+    while(*str)
+    {
+        while((USART6->sts & (1 << 7)) == 0) ;
+        USART6->dt = *str++;
+    }
+
+    waitSerialTxFifoEmpty();
+    if(interrupts) fastEnableInterrupts();
+}

--- a/platform/mcu/AT32F423/drivers/USART6.h
+++ b/platform/mcu/AT32F423/drivers/USART6.h
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef USART6_H
+#define USART6_H
+
+#include <stdint.h>
+#include <unistd.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Initialise USART1 peripheral with a given baud rate. Serial communication is
+ * configured for 8 data bits, no parity, one stop bit.
+ *
+ * @param baudrate: serial port baud rate, in bits per second.
+ */
+void usart6_init(unsigned int baudrate);
+
+/**
+ * Shut down USART1 peripheral.
+ */
+void usart6_terminate();
+
+/**
+ * Read a block of data.
+ *
+ * \param buffer buffer where read data will be stored.
+ * \param size buffer size.
+ * \param where where to read from.
+ * \return number of bytes read or a negative number on failure. Note that
+ * it is normal for this function to return less character than the amount
+ * asked.
+ */
+ssize_t usart6_readBlock(void *buffer, size_t size, off_t where);
+
+/**
+ * Write a block of data.
+ *
+ * \param buffer buffer where take data to write.
+ * \param size buffer size.
+ * \param where where to write to.
+ * \return number of bytes written or a negative number on failure.
+ */
+ssize_t usart6_writeBlock(void *buffer, size_t size, off_t where);
+
+/**
+ * Write a string.
+ * Can be used to write debug information before the kernel is started or in
+ * case of serious errors, right before rebooting.
+ * Can ONLY be called when the kernel is not yet started, paused or within
+ * an interrupt. This default implementation ignores writes.
+ *
+ * \param str the string to write. The string must be NUL terminated.
+ */
+void usart6_IRQwrite(const char *str);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* USART6_H */

--- a/platform/mcu/AT32F423/drivers/delays.cpp
+++ b/platform/mcu/AT32F423/drivers/delays.cpp
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <interfaces/delays.h>
+#include <miosix.h>
+
+/**
+ * Implementation of the delay functions for AT32F421 MCU.
+ * Delays have been calibrated for a clock frequency of 120MHz.
+ */
+
+void delayUs(unsigned int useconds)
+{
+    // This delay has been calibrated to take x microseconds
+    // It is written in assembler to be independent on compiler optimization
+    asm volatile("           mov   r1, #18    \n"
+                 "           mul   r2, %0, r1 \n"
+                 "           mov   r1, #0     \n"
+                 "___loop_u: cmp   r1, r2     \n"
+                 "           itt   lo         \n"
+                 "           addlo r1, r1, #1 \n"
+                 "           blo   ___loop_u  \n"::"r"(useconds):"r1","r2");
+}
+
+void delayMs(unsigned int mseconds)
+{
+    register const unsigned int count=18012;
+
+    for(unsigned int i=0;i<mseconds;i++)
+    {
+        // This delay has been calibrated to take 1 millisecond
+        // It is written in assembler to be independent on compiler optimization
+        asm volatile("           mov   r1, #0     \n"
+                     "___loop_m: cmp   r1, %0     \n"
+                     "           itt   lo         \n"
+                     "           addlo r1, r1, #1 \n"
+                     "           blo   ___loop_m  \n"::"r"(count):"r1");
+    }
+}
+
+void sleepFor(unsigned int seconds, unsigned int mseconds)
+{
+    unsigned int time = (seconds * 1000) + mseconds;
+    miosix::Thread::sleep(time);
+}
+
+void sleepUntil(long long timestamp)
+{
+    miosix::Thread::sleepUntil(timestamp);
+}
+
+long long getTick()
+{
+    return miosix::getTick();
+}

--- a/platform/mcu/AT32F423/linker_script.ld
+++ b/platform/mcu/AT32F423/linker_script.ld
@@ -1,0 +1,165 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/*
+ * This linker script puts:
+ * - read only data and code (.text, .rodata, .eh_*) in flash
+ * - stacks, heap and sections .data and .bss in the internal ram
+ * - the external ram (if available) is not used.
+ */
+
+/*
+ * The main stack is used for interrupt handling by the kernel.
+ *
+ * *** Readme ***
+ * This linker script places the main stack (used by the kernel for interrupts)
+ * at the bottom of the ram, instead of the top. This is done for two reasons:
+ *
+ * - as an optimization for microcontrollers with little ram memory. In fact
+ *   the implementation of malloc from newlib requests memory to the OS in 4KB
+ *   block (except the first block that can be smaller). This is probably done
+ *   for compatibility with OSes with an MMU and paged memory. To see why this
+ *   is bad, consider a microcontroller with 8KB of ram: when malloc finishes
+ *   up the first 4KB it will call _sbrk_r asking for a 4KB block, but this will
+ *   fail because the top part of the ram is used by the main stack. As a
+ *   result, the top part of the memory will not be used by malloc, even if
+ *   available (and it is nearly *half* the ram on an 8KB mcu). By placing the
+ *   main stack at the bottom of the ram, the upper 4KB block will be entirely
+ *   free and available as heap space.
+ *
+ * - In case of main stack overflow the cpu will fault because access to memory
+ *   before the beginning of the ram faults. Instead with the default stack
+ *   placement the main stack will silently collide with the heap.
+ * Note: if increasing the main stack size also increase the ORIGIN value in
+ * the MEMORY definitions below accordingly.
+ */
+_main_stack_size = 0x00000200;                     /* main stack = 512Bytes */
+_main_stack_top  = 0x20000000 + _main_stack_size;
+ASSERT(_main_stack_size   % 8 == 0, "MAIN stack size error");
+
+_heap_end = 0x2000C000;                            /* end of available ram  */
+
+/* identify the Entry Point  */
+ENTRY(_Z13Reset_Handlerv)
+
+/* specify the memory areas  */
+MEMORY
+{
+    flash(rx) : ORIGIN = 0x08002800, LENGTH = 246K
+    ram(wx)   : ORIGIN = 0x20000200, LENGTH = 48K - 0x200
+}
+
+/* now define the output sections  */
+SECTIONS
+{
+    . = 0;
+
+    /* .text section: code goes to flash */
+    .text :
+    {
+        /* Startup code must go at address 0 */
+        KEEP(*(.isr_vector))
+
+        *(.text)
+        *(.text.*)
+        *(.gnu.linkonce.t.*)
+        /* these sections for thumb interwork? */
+        *(.glue_7)
+        *(.glue_7t)
+        /* these sections for C++? */
+        *(.gcc_except_table)
+        *(.gcc_except_table.*)
+        *(.ARM.extab*)
+        *(.gnu.linkonce.armextab.*)
+
+        . = ALIGN(4);
+        /* .rodata: constant data */
+        *(.rodata)
+        *(.rodata.*)
+        *(.gnu.linkonce.r.*)
+
+        /* C++ Static constructors/destructors (eabi) */
+        . = ALIGN(4);
+        KEEP(*(.init))
+
+        . = ALIGN(4);
+        __miosix_init_array_start = .;
+        KEEP (*(SORT(.miosix_init_array.*)))
+        KEEP (*(.miosix_init_array))
+        __miosix_init_array_end = .;
+
+        . = ALIGN(4);
+        __preinit_array_start = .;
+        KEEP (*(.preinit_array))
+        __preinit_array_end = .;
+
+        . = ALIGN(4);
+        __init_array_start = .;
+        KEEP (*(SORT(.init_array.*)))
+        KEEP (*(.init_array))
+        __init_array_end = .;
+
+        . = ALIGN(4);
+        KEEP(*(.fini))
+
+        . = ALIGN(4);
+        __fini_array_start = .;
+        KEEP (*(.fini_array))
+        KEEP (*(SORT(.fini_array.*)))
+        __fini_array_end = .;
+
+        /* C++ Static constructors/destructors (elf)  */
+        . = ALIGN(4);
+        _ctor_start = .;
+        KEEP (*crtbegin.o(.ctors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .ctors))
+        KEEP (*(SORT(.ctors.*)))
+        KEEP (*crtend.o(.ctors))
+       _ctor_end = .;
+
+        . = ALIGN(4);
+        KEEP (*crtbegin.o(.dtors))
+        KEEP (*(EXCLUDE_FILE (*crtend.o) .dtors))
+        KEEP (*(SORT(.dtors.*)))
+        KEEP (*crtend.o(.dtors))
+    } > flash
+
+    /* .ARM.exidx is sorted, so has to go in its own output section.  */
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > flash
+    __exidx_end = .;
+
+	/* .data section: global variables go to ram, but also store a copy to
+       flash to initialize them */
+    .data : ALIGN(8)
+    {
+        _data = .;
+        *(.data)
+        *(.data.*)
+        *(.gnu.linkonce.d.*)
+        . = ALIGN(8);
+        _edata = .;
+    } > ram AT > flash
+
+    _etext = LOADADDR(.data);
+
+    /* .bss section: uninitialized global variables go to ram */
+    _bss_start = .;
+    .bss :
+    {
+        *(.bss)
+        *(.bss.*)
+        *(.gnu.linkonce.b.*)
+        . = ALIGN(8);
+    } > ram
+    _bss_end = .;
+
+    _end = .;
+    PROVIDE(end = .);
+}

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423.h
@@ -1,0 +1,490 @@
+/**
+  **************************************************************************
+  * @file     at32f423.h
+  * @brief    at32f423 header file
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+#ifndef __AT32F423_H
+#define __AT32F423_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined (__CC_ARM)
+ #pragma anon_unions
+#endif
+
+
+/** @addtogroup CMSIS
+  * @{
+  */
+
+/** @addtogroup AT32F423
+  * @{
+  */
+
+/** @addtogroup Library_configuration_section
+  * @{
+  */
+
+/**
+  * tip: to avoid modifying this file each time you need to switch between these
+  *      devices, you can define the device in your toolchain compiler preprocessor.
+  */
+
+#if !defined (AT32F423K8U7_4) && !defined (AT32F423KBU7_4) && !defined (AT32F423KCU7_4) && \
+    !defined (AT32F423T8U7)   && !defined (AT32F423TBU7)   && !defined (AT32F423TCU7)   && \
+    !defined (AT32F423C8U7)   && !defined (AT32F423CBU7)   && !defined (AT32F423CCU7)   && \
+    !defined (AT32F423C8T7)   && !defined (AT32F423CBT7)   && !defined (AT32F423CCT7)   && \
+    !defined (AT32F423R8T7_7) && !defined (AT32F423RBT7_7) && !defined (AT32F423RCT7_7) && \
+    !defined (AT32F423R8T7)   && !defined (AT32F423RBT7)   && !defined (AT32F423RCT7)   && \
+    !defined (AT32F423V8T7)   && !defined (AT32F423VBT7)   && !defined (AT32F423VCT7)   && \
+    !defined (AT32F423CBU7_7)
+
+    #error "Please select first the target device used in your application (in at32f423.h file)"
+#endif
+
+#if defined (AT32F423K8U7_4) || defined (AT32F423KBU7_4) || defined (AT32F423KCU7_4) || \
+    defined (AT32F423T8U7)   || defined (AT32F423TBU7)   || defined (AT32F423TCU7)   || \
+    defined (AT32F423C8U7)   || defined (AT32F423CBU7)   || defined (AT32F423CCU7)   || \
+    defined (AT32F423C8T7)   || defined (AT32F423CBT7)   || defined (AT32F423CCT7)   || \
+    defined (AT32F423R8T7_7) || defined (AT32F423RBT7_7) || defined (AT32F423RCT7_7) || \
+    defined (AT32F423R8T7)   || defined (AT32F423RBT7)   || defined (AT32F423RCT7)   || \
+    defined (AT32F423V8T7)   || defined (AT32F423VBT7)   || defined (AT32F423VCT7)   || \
+    defined (AT32F423CBU7_7)
+
+    #define AT32F423xx
+#endif
+
+/**
+  * define with package
+  */
+#if defined (AT32F423K8U7_4) || defined (AT32F423KBU7_4) || defined (AT32F423KCU7_4)
+
+    #define AT32F423Kx
+#endif
+
+#if defined (AT32F423T8U7)   || defined (AT32F423TBU7)   || defined (AT32F423TCU7)
+
+    #define AT32F423Tx
+#endif
+
+#if defined (AT32F423C8U7)   || defined (AT32F423CBU7)   || defined (AT32F423CCU7)   || \
+    defined (AT32F423C8T7)   || defined (AT32F423CBT7)   || defined (AT32F423CCT7)   || \
+    defined (AT32F423CBU7_7)
+
+    #define AT32F423Cx
+#endif
+
+#if defined (AT32F423R8T7_7) || defined (AT32F423RBT7_7) || defined (AT32F423RCT7_7) || \
+    defined (AT32F423R8T7)   || defined (AT32F423RBT7)   || defined (AT32F423RCT7)
+
+    #define AT32F423Rx
+#endif
+
+#if defined (AT32F423V8T7)   || defined (AT32F423VBT7)   || defined (AT32F423VCT7)
+
+    #define AT32F423Vx
+#endif
+
+/**
+  * define with memory density
+  */
+#if defined (AT32F423K8U7_4) || defined (AT32F423T8U7)   || defined (AT32F423C8U7)   || \
+    defined (AT32F423C8T7)   || defined (AT32F423R8T7_7) || defined (AT32F423R8T7)   || \
+    defined (AT32F423V8T7)
+
+    #define AT32F423x8
+#endif
+
+#if defined (AT32F423KBU7_4) || defined (AT32F423TBU7)   || defined (AT32F423CBU7)   || \
+    defined (AT32F423CBT7)   || defined (AT32F423RBT7_7) || defined (AT32F423RBT7)   || \
+    defined (AT32F423VBT7)   || defined (AT32F423CBU7_7)
+
+    #define AT32F423xB
+#endif
+
+#if defined (AT32F423KCU7_4) || defined (AT32F423TCU7)   || defined (AT32F423CCU7)   || \
+    defined (AT32F423CCT7)   || defined (AT32F423RCT7_7) || defined (AT32F423RCT7)   || \
+    defined (AT32F423VCT7)
+
+    #define AT32F423xC
+#endif
+
+#ifndef USE_STDPERIPH_DRIVER
+/**
+  * @brief comment the line below if you will not use the peripherals drivers.
+  * in this case, these drivers will not be included and the application code will
+  * be based on direct access to peripherals registers
+  */
+  #ifdef _RTE_
+    #include "RTE_Components.h"
+    #ifdef RTE_DEVICE_STDPERIPH_FRAMEWORK
+      #define USE_STDPERIPH_DRIVER
+    #endif
+  #endif
+#endif
+
+/**
+  * @brief at32f423 standard peripheral library version number
+  */
+#define __AT32F423_LIBRARY_VERSION_MAJOR    (0x02) /*!< [31:24] major version */
+#define __AT32F423_LIBRARY_VERSION_MIDDLE   (0x00) /*!< [23:16] middle version */
+#define __AT32F423_LIBRARY_VERSION_MINOR    (0x09) /*!< [15:8]  minor version */
+#define __AT32F423_LIBRARY_VERSION_RC       (0x00) /*!< [7:0]  release candidate */
+#define __AT32F423_LIBRARY_VERSION          ((__AT32F423_LIBRARY_VERSION_MAJOR << 24)  | \
+                                             (__AT32F423_LIBRARY_VERSION_MIDDLE << 16) | \
+                                             (__AT32F423_LIBRARY_VERSION_MINOR << 8)   | \
+                                             (__AT32F423_LIBRARY_VERSION_RC))
+
+/**
+  * @}
+  */
+
+/** @addtogroup configuration_section_for_cmsis
+  * @{
+  */
+
+/**
+  * @brief configuration of the cortex-m4 processor and core peripherals
+  */
+#define __CM4_REV                 0x0001U  /*!< core revision r0p1                           */
+#define __MPU_PRESENT             1        /*!< mpu present                                  */
+#define __NVIC_PRIO_BITS          4        /*!< at32 uses 4 bits for the priority levels     */
+#define __Vendor_SysTickConfig    0        /*!< set to 1 if different systick config is used */
+#define __FPU_PRESENT             1U       /*!< fpu present                                  */
+
+/**
+  * @brief at32f423 interrupt number definition, according to the selected device
+  *        in @ref library_configuration_section
+  */
+typedef enum IRQn
+{
+    /******  cortex-m4 processor exceptions numbers ***************************************************/
+    Reset_IRQn                  = -15,    /*!< 1 reset vector, invoked on power up and warm reset   */
+    NonMaskableInt_IRQn         = -14,    /*!< 2 non maskable interrupt                             */
+    HardFault_IRQn              = -13,    /*!< 3 hard fault, all classes of fault                   */
+    MemoryManagement_IRQn       = -12,    /*!< 4 cortex-m4 memory management interrupt              */
+    BusFault_IRQn               = -11,    /*!< 5 cortex-m4 bus fault interrupt                      */
+    UsageFault_IRQn             = -10,    /*!< 6 cortex-m4 usage fault interrupt                    */
+    SVCall_IRQn                 = -5,     /*!< 11 cortex-m4 sv call interrupt                       */
+    DebugMonitor_IRQn           = -4,     /*!< 12 cortex-m4 debug monitor interrupt                 */
+    PendSV_IRQn                 = -2,     /*!< 14 cortex-m4 pend sv interrupt                       */
+    SysTick_IRQn                = -1,     /*!< 15 cortex-m4 system tick interrupt                   */
+
+    /******  at32 specific interrupt numbers *********************************************************/
+    WWDT_IRQn                   = 0,      /*!< window watchdog timer interrupt                      */
+    PVM_IRQn                    = 1,      /*!< pvm through exint line detection interrupt           */
+    TAMP_STAMP_IRQn             = 2,      /*!< tamper and timestamp interrupts through the exint line */
+    ERTC_WKUP_IRQn              = 3,      /*!< ertc wakeup through the exint line                   */
+    FLASH_IRQn                  = 4,      /*!< flash global interrupt                               */
+    CRM_IRQn                    = 5,      /*!< crm global interrupt                                 */
+    EXINT0_IRQn                 = 6,      /*!< exint line0 interrupt                                */
+    EXINT1_IRQn                 = 7,      /*!< exint line1 interrupt                                */
+    EXINT2_IRQn                 = 8,      /*!< exint line2 interrupt                                */
+    EXINT3_IRQn                 = 9,      /*!< exint line3 interrupt                                */
+    EXINT4_IRQn                 = 10,     /*!< exint line4 interrupt                                */
+    DMA1_Channel1_IRQn          = 11,     /*!< dma1 channel 1 global interrupt                      */
+    DMA1_Channel2_IRQn          = 12,     /*!< dma1 channel 2 global interrupt                      */
+    DMA1_Channel3_IRQn          = 13,     /*!< dma1 channel 3 global interrupt                      */
+    DMA1_Channel4_IRQn          = 14,     /*!< dma1 channel 4 global interrupt                      */
+    DMA1_Channel5_IRQn          = 15,     /*!< dma1 channel 5 global interrupt                      */
+    DMA1_Channel6_IRQn          = 16,     /*!< dma1 channel 6 global interrupt                      */
+    DMA1_Channel7_IRQn          = 17,     /*!< dma1 channel 7 global interrupt                      */
+
+    ADC1_IRQn                   = 18,     /*!< adc1 global interrupt                                */
+    CAN1_TX_IRQn                = 19,     /*!< can1 tx interrupts                                   */
+    CAN1_RX0_IRQn               = 20,     /*!< can1 rx0 interrupts                                  */
+    CAN1_RX1_IRQn               = 21,     /*!< can1 rx1 interrupt                                   */
+    CAN1_SE_IRQn                = 22,     /*!< can1 se interrupt                                    */
+    EXINT9_5_IRQn               = 23,     /*!< external line[9:5] interrupts                        */
+    TMR1_BRK_TMR9_IRQn          = 24,     /*!< tmr1 brake interrupt                                 */
+    TMR1_OVF_TMR10_IRQn         = 25,     /*!< tmr1 overflow interrupt                              */
+    TMR1_TRG_HALL_TMR11_IRQn    = 26,     /*!< tmr1 trigger and hall interrupt                      */
+    TMR1_CH_IRQn                = 27,     /*!< tmr1 channel interrupt                               */
+    TMR2_GLOBAL_IRQn            = 28,     /*!< tmr2 global interrupt                                */
+    TMR3_GLOBAL_IRQn            = 29,     /*!< tmr3 global interrupt                                */
+    TMR4_GLOBAL_IRQn            = 30,     /*!< tmr4 global interrupt                                */
+    I2C1_EVT_IRQn               = 31,     /*!< i2c1 event interrupt                                 */
+    I2C1_ERR_IRQn               = 32,     /*!< i2c1 error interrupt                                 */
+    I2C2_EVT_IRQn               = 33,     /*!< i2c2 event interrupt                                 */
+    I2C2_ERR_IRQn               = 34,     /*!< i2c2 error interrupt                                 */
+    SPI1_IRQn                   = 35,     /*!< spi1 global interrupt                                */
+    SPI2_IRQn                   = 36,     /*!< spi2 global interrupt                                */
+    USART1_IRQn                 = 37,     /*!< usart1 global interrupt                              */
+    USART2_IRQn                 = 38,     /*!< usart2 global interrupt                              */
+    USART3_IRQn                 = 39,     /*!< usart3 global interrupt                              */
+    EXINT15_10_IRQn             = 40,     /*!< external line[15:10] interrupts                      */
+    ERTCAlarm_IRQn              = 41,     /*!< ertc alarm through exint line interrupt              */
+    OTGFS1_WKUP_IRQn            = 42,     /*!< otgfs1 wakeup from suspend through exint line interrupt */
+    TMR12_GLOBAL_IRQn           = 43,     /*!< tmr12 global interrupt                               */
+    TMR13_GLOBAL_IRQn           = 44,     /*!< tmr13 global interrupt                               */
+    TMR14_GLOBAL_IRQn           = 45,     /*!< tmr14 global interrupt                               */
+    SPI3_IRQn                   = 51,     /*!< spi3 global interrupt                                */
+    USART4_IRQn                 = 52,     /*!< usart4 global interrupt                              */
+    USART5_IRQn                 = 53,     /*!< usart5 global interrupt                              */
+    TMR6_DAC_GLOBAL_IRQn        = 54,     /*!< tmr6 and dac global interrupt                        */
+    TMR7_GLOBAL_IRQn            = 55,     /*!< tmr7 global interrupt                                */
+    DMA2_Channel1_IRQn          = 56,     /*!< dma2 channel 1 global interrupt                      */
+    DMA2_Channel2_IRQn          = 57,     /*!< dma2 channel 2 global interrupt                      */
+    DMA2_Channel3_IRQn          = 58,     /*!< dma2 channel 3 global interrupt                      */
+    DMA2_Channel4_IRQn          = 59,     /*!< dma2 channel 4 global interrupt                      */
+    DMA2_Channel5_IRQn          = 60,     /*!< dma2 channel 5 global interrupt                      */
+    CAN2_TX_IRQn                = 63,     /*!< can2 tx interrupt                                    */
+    CAN2_RX0_IRQn               = 64,     /*!< can2 rx0 interrupt                                   */
+    CAN2_RX1_IRQn               = 65,     /*!< can2 rx1 interrupt                                   */
+    CAN2_SE_IRQn                = 66,     /*!< can2 se interrupt                                    */
+    OTGFS1_IRQn                 = 67,     /*!< otgfs1 interrupt                                     */
+    DMA2_Channel6_IRQn          = 68,     /*!< dma2 channel 6 global interrupt                      */
+    DMA2_Channel7_IRQn          = 69,     /*!< dma2 channel 7 global interrupt                      */
+    USART6_IRQn                 = 71,     /*!< usart6 interrupt                                     */
+    I2C3_EVT_IRQn               = 72,     /*!< i2c3 event interrupt                                 */
+    I2C3_ERR_IRQn               = 73,     /*!< i2c3 error interrupt                                 */
+    FPU_IRQn                    = 81,     /*!< fpu interrupt                                        */
+    USART7_IRQn                 = 82,     /*!< usart7 interrupt                                     */
+    USART8_IRQn                 = 83,     /*!< usart8 interrupt                                     */
+    DMAMUX_IRQn                 = 94,     /*!< dmamux global interrupt                              */
+    ACC_IRQn                    = 103     /*!< acc interrupt                                        */
+
+} IRQn_Type;
+
+/**
+  * @}
+  */
+
+#include "core_cm4.h"
+#include "system_at32f423.h"
+#include <stdint.h>
+
+/** @addtogroup Exported_types
+  * @{
+  */
+
+typedef int32_t  INT32;
+typedef int16_t  INT16;
+typedef int8_t   INT8;
+typedef uint32_t UINT32;
+typedef uint16_t UINT16;
+typedef uint8_t  UINT8;
+
+typedef int32_t  s32;
+typedef int16_t  s16;
+typedef int8_t   s8;
+
+typedef const int32_t sc32;   /*!< read only */
+typedef const int16_t sc16;   /*!< read only */
+typedef const int8_t  sc8;    /*!< read only */
+
+typedef __IO int32_t  vs32;
+typedef __IO int16_t  vs16;
+typedef __IO int8_t   vs8;
+
+typedef __I int32_t vsc32;    /*!< read only */
+typedef __I int16_t vsc16;    /*!< read only */
+typedef __I int8_t  vsc8;     /*!< read only */
+
+typedef uint32_t u32;
+typedef uint16_t u16;
+typedef uint8_t  u8;
+
+typedef const uint32_t uc32;  /*!< read only */
+typedef const uint16_t uc16;  /*!< read only */
+typedef const uint8_t  uc8;   /*!< read only */
+
+typedef __IO uint32_t vu32;
+typedef __IO uint16_t vu16;
+typedef __IO uint8_t  vu8;
+
+typedef __I uint32_t vuc32;   /*!< read only */
+typedef __I uint16_t vuc16;   /*!< read only */
+typedef __I uint8_t  vuc8;    /*!< read only */
+
+typedef enum {RESET = 0, SET = !RESET} flag_status;
+typedef enum {FALSE = 0, TRUE = !FALSE} confirm_state;
+typedef enum {ERROR = 0, SUCCESS = !ERROR} error_status;
+
+/**
+  * @}
+  */
+
+/** @addtogroup Exported_macro
+  * @{
+  */
+
+#define REG8(addr)                       *(volatile uint8_t *)(addr)
+#define REG16(addr)                      *(volatile uint16_t *)(addr)
+#define REG32(addr)                      *(volatile uint32_t *)(addr)
+
+#define MAKE_VALUE(reg_offset, bit_num)  (((reg_offset) << 16) | (bit_num & 0x1f))
+
+#define PERIPH_REG(periph_base, value)   REG32((periph_base + (value >> 16)))
+#define PERIPH_REG_BIT(value)            (0x1u << (value & 0x1f))
+
+/**
+  * @}
+  */
+
+/** @addtogroup Peripheral_memory_map
+  * @{
+  */
+
+#define XMC_CARD_MEM_BASE                ((uint32_t)0xA8000000)
+#define XMC_REG_BASE                     ((uint32_t)0xA0000000)
+#define XMC_BANK1_REG_BASE               (XMC_REG_BASE + 0x0000)
+#define XMC_BANK2_REG_BASE               (XMC_REG_BASE + 0x0060)
+#define XMC_BANK3_REG_BASE               (XMC_REG_BASE + 0x0080)
+#define XMC_BANK4_REG_BASE               (XMC_REG_BASE + 0x00A0)
+#define XMC_MEM_BASE                     ((uint32_t)0x60000000)
+#define PERIPH_BASE                      ((uint32_t)0x40000000)
+#define SRAM_BB_BASE                     ((uint32_t)0x22000000)
+#define PERIPH_BB_BASE                   ((uint32_t)0x42000000)
+#define SRAM_BASE                        ((uint32_t)0x20000000)
+#define USD_BASE                         ((uint32_t)0x1FFFF800)
+#define FLASH_BASE                       ((uint32_t)0x08000000)
+
+#define DEBUG_BASE                       ((uint32_t)0xE0042000)
+
+#define APB1PERIPH_BASE                  (PERIPH_BASE)
+#define APB2PERIPH_BASE                  (PERIPH_BASE + 0x10000)
+#define AHBPERIPH1_BASE                  (PERIPH_BASE + 0x20000)
+#define AHBPERIPH2_BASE                  (PERIPH_BASE + 0x10000000)
+
+/* apb1 bus base address */
+#define USART8_BASE                      (APB1PERIPH_BASE + 0x7C00)
+#define USART7_BASE                      (APB1PERIPH_BASE + 0x7800)
+#define DAC_BASE                         (APB1PERIPH_BASE + 0x7400)
+#define PWC_BASE                         (APB1PERIPH_BASE + 0x7000)
+#define CAN2_BASE                        (APB1PERIPH_BASE + 0x6800)
+#define CAN1_BASE                        (APB1PERIPH_BASE + 0x6400)
+#define I2C3_BASE                        (APB1PERIPH_BASE + 0x5C00)
+#define I2C2_BASE                        (APB1PERIPH_BASE + 0x5800)
+#define I2C1_BASE                        (APB1PERIPH_BASE + 0x5400)
+#define USART5_BASE                      (APB1PERIPH_BASE + 0x5000)
+#define USART4_BASE                      (APB1PERIPH_BASE + 0x4C00)
+#define USART3_BASE                      (APB1PERIPH_BASE + 0x4800)
+#define USART2_BASE                      (APB1PERIPH_BASE + 0x4400)
+#define SPI3_BASE                        (APB1PERIPH_BASE + 0x3C00)
+#define SPI2_BASE                        (APB1PERIPH_BASE + 0x3800)
+#define WDT_BASE                         (APB1PERIPH_BASE + 0x3000)
+#define WWDT_BASE                        (APB1PERIPH_BASE + 0x2C00)
+#define ERTC_BASE                        (APB1PERIPH_BASE + 0x2800)
+#define TMR14_BASE                       (APB1PERIPH_BASE + 0x2000)
+#define TMR13_BASE                       (APB1PERIPH_BASE + 0x1C00)
+#define TMR12_BASE                       (APB1PERIPH_BASE + 0x1800)
+#define TMR7_BASE                        (APB1PERIPH_BASE + 0x1400)
+#define TMR6_BASE                        (APB1PERIPH_BASE + 0x1000)
+#define TMR4_BASE                        (APB1PERIPH_BASE + 0x0800)
+#define TMR3_BASE                        (APB1PERIPH_BASE + 0x0400)
+#define TMR2_BASE                        (APB1PERIPH_BASE + 0x0000)
+/* apb2 bus base address */
+#define ACC_BASE                         (APB2PERIPH_BASE + 0x7400)
+#define TMR11_BASE                       (APB2PERIPH_BASE + 0x4800)
+#define TMR10_BASE                       (APB2PERIPH_BASE + 0x4400)
+#define TMR9_BASE                        (APB2PERIPH_BASE + 0x4000)
+#define EXINT_BASE                       (APB2PERIPH_BASE + 0x3C00)
+#define SCFG_BASE                        (APB2PERIPH_BASE + 0x3800)
+#define SPI1_BASE                        (APB2PERIPH_BASE + 0x3000)
+#define ADC1_BASE                        (APB2PERIPH_BASE + 0x2000)
+#define ADCCOM_BASE                      (APB2PERIPH_BASE + 0x2300)
+#define USART6_BASE                      (APB2PERIPH_BASE + 0x1400)
+#define USART1_BASE                      (APB2PERIPH_BASE + 0x1000)
+#define TMR1_BASE                        (APB2PERIPH_BASE + 0x0000)
+/* ahb bus base address */
+#define GPIOF_BASE                       (AHBPERIPH1_BASE + 0x1400)
+#define GPIOE_BASE                       (AHBPERIPH1_BASE + 0x1000)
+#define GPIOD_BASE                       (AHBPERIPH1_BASE + 0x0C00)
+#define GPIOC_BASE                       (AHBPERIPH1_BASE + 0x0800)
+#define GPIOB_BASE                       (AHBPERIPH1_BASE + 0x0400)
+#define GPIOA_BASE                       (AHBPERIPH1_BASE + 0x0000)
+
+#define DMA1_BASE                        (AHBPERIPH1_BASE + 0x6000)
+#define DMA1_CHANNEL1_BASE               (DMA1_BASE + 0x0008)
+#define DMA1_CHANNEL2_BASE               (DMA1_BASE + 0x001C)
+#define DMA1_CHANNEL3_BASE               (DMA1_BASE + 0x0030)
+#define DMA1_CHANNEL4_BASE               (DMA1_BASE + 0x0044)
+#define DMA1_CHANNEL5_BASE               (DMA1_BASE + 0x0058)
+#define DMA1_CHANNEL6_BASE               (DMA1_BASE + 0x006C)
+#define DMA1_CHANNEL7_BASE               (DMA1_BASE + 0x0080)
+
+#define DMA1MUX_BASE                     (DMA1_BASE + 0x0104)
+#define DMA1MUX_CHANNEL1_BASE            (DMA1MUX_BASE)
+#define DMA1MUX_CHANNEL2_BASE            (DMA1MUX_BASE + 0x0004)
+#define DMA1MUX_CHANNEL3_BASE            (DMA1MUX_BASE + 0x0008)
+#define DMA1MUX_CHANNEL4_BASE            (DMA1MUX_BASE + 0x000C)
+#define DMA1MUX_CHANNEL5_BASE            (DMA1MUX_BASE + 0x0010)
+#define DMA1MUX_CHANNEL6_BASE            (DMA1MUX_BASE + 0x0014)
+#define DMA1MUX_CHANNEL7_BASE            (DMA1MUX_BASE + 0x0018)
+
+#define DMA1MUX_GENERATOR1_BASE          (DMA1_BASE + 0x0120)
+#define DMA1MUX_GENERATOR2_BASE          (DMA1_BASE + 0x0124)
+#define DMA1MUX_GENERATOR3_BASE          (DMA1_BASE + 0x0128)
+#define DMA1MUX_GENERATOR4_BASE          (DMA1_BASE + 0x012C)
+
+#define DMA2_BASE                        (AHBPERIPH1_BASE + 0x6400)
+#define DMA2_CHANNEL1_BASE               (DMA2_BASE + 0x0008)
+#define DMA2_CHANNEL2_BASE               (DMA2_BASE + 0x001C)
+#define DMA2_CHANNEL3_BASE               (DMA2_BASE + 0x0030)
+#define DMA2_CHANNEL4_BASE               (DMA2_BASE + 0x0044)
+#define DMA2_CHANNEL5_BASE               (DMA2_BASE + 0x0058)
+#define DMA2_CHANNEL6_BASE               (DMA2_BASE + 0x006C)
+#define DMA2_CHANNEL7_BASE               (DMA2_BASE + 0x0080)
+
+#define DMA2MUX_BASE                     (DMA2_BASE + 0x0104)
+#define DMA2MUX_CHANNEL1_BASE            (DMA2MUX_BASE)
+#define DMA2MUX_CHANNEL2_BASE            (DMA2MUX_BASE + 0x0004)
+#define DMA2MUX_CHANNEL3_BASE            (DMA2MUX_BASE + 0x0008)
+#define DMA2MUX_CHANNEL4_BASE            (DMA2MUX_BASE + 0x000C)
+#define DMA2MUX_CHANNEL5_BASE            (DMA2MUX_BASE + 0x0010)
+#define DMA2MUX_CHANNEL6_BASE            (DMA2MUX_BASE + 0x0014)
+#define DMA2MUX_CHANNEL7_BASE            (DMA2MUX_BASE + 0x0018)
+
+#define DMA2MUX_GENERATOR1_BASE          (DMA2_BASE + 0x0120)
+#define DMA2MUX_GENERATOR2_BASE          (DMA2_BASE + 0x0124)
+#define DMA2MUX_GENERATOR3_BASE          (DMA2_BASE + 0x0128)
+#define DMA2MUX_GENERATOR4_BASE          (DMA2_BASE + 0x012C)
+
+#define FLASH_REG_BASE                   (AHBPERIPH1_BASE + 0x3C00)
+#define CRM_BASE                         (AHBPERIPH1_BASE + 0x3800)
+#define CRC_BASE                         (AHBPERIPH1_BASE + 0x3000)
+#define OTGFS1_BASE                      (AHBPERIPH2_BASE + 0x00000)
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#include "at32f423_def.h"
+#include "at32f423_conf.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423.h
@@ -73,7 +73,7 @@ extern "C" {
     defined (AT32F423V8T7)   || defined (AT32F423VBT7)   || defined (AT32F423VCT7)   || \
     defined (AT32F423CBU7_7)
 
-    #define AT32F423xx
+    // #define AT32F423xx
 #endif
 
 /**

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_acc.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_acc.h
@@ -1,0 +1,202 @@
+/**
+  **************************************************************************
+  * @file     at32f423_acc.h
+  * @brief    at32f423 acc header file
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __AT32F423_ACC_H
+#define __AT32F423_ACC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "at32f423.h"
+
+/** @addtogroup AT32F423_periph_driver
+  * @{
+  */
+
+/** @addtogroup ACC
+  * @{
+  */
+
+/** @defgroup ACC_exported_constants
+  * @{
+  */
+
+#define ACC_CAL_HICKCAL                  ((uint16_t)0x0000) /*!< acc hick calibration */
+#define ACC_CAL_HICKTRIM                 ((uint16_t)0x0002) /*!< acc hick trim */
+
+#define ACC_RSLOST_FLAG                  ((uint16_t)0x0002) /*!< acc reference signal lost error flag */
+#define ACC_CALRDY_FLAG                  ((uint16_t)0x0001) /*!< acc internal high-speed clock calibration ready error flag */
+
+#define ACC_CALRDYIEN_INT                ((uint16_t)0x0020) /*!< acc internal high-speed clock calibration ready interrupt enable */
+#define ACC_EIEN_INT                     ((uint16_t)0x0010) /*!< acc reference signal lost interrupt enable */
+
+
+/**
+  * @}
+  */
+
+/** @defgroup ACC_exported_types
+  * @{
+  */
+
+/**
+  * @brief type define acc register all
+  */
+typedef struct
+{
+
+  /**
+    * @brief acc sts register, offset:0x00
+    */
+  union
+  {
+    __IO uint32_t sts;
+    struct
+    {
+      __IO uint32_t calrdy               : 1; /* [0] */
+      __IO uint32_t rslost               : 1; /* [1] */
+      __IO uint32_t reserved1            : 30;/* [31:2] */
+    } sts_bit;
+  };
+
+  /**
+    * @brief acc ctrl1 register, offset:0x04
+    */
+  union
+  {
+    __IO uint32_t ctrl1;
+    struct
+    {
+      __IO uint32_t calon                : 1; /* [0] */
+      __IO uint32_t entrim               : 1; /* [1] */
+      __IO uint32_t reserved1            : 2; /* [3:2] */
+      __IO uint32_t eien                 : 1; /* [4] */
+      __IO uint32_t calrdyien            : 1; /* [5] */
+      __IO uint32_t reserved2            : 2; /* [7:6] */
+      __IO uint32_t step                 : 4; /* [11:8] */
+      __IO uint32_t reserved3            : 20;/* [31:12] */
+    } ctrl1_bit;
+  };
+
+   /**
+    * @brief acc ctrl2 register, offset:0x08
+    */
+  union
+  {
+    __IO uint32_t ctrl2;
+    struct
+    {
+      __IO uint32_t hickcal              : 8; /* [7:0] */
+      __IO uint32_t hicktrim             : 6; /* [13:8] */
+      __IO uint32_t reserved1            : 18;/* [31:14] */
+    } ctrl2_bit;
+  };
+
+  /**
+  * @brief acc acc_c1 register, offset:0x0C
+  */
+  union
+  {
+    __IO uint32_t c1;
+    struct
+    {
+      __IO uint32_t c1                   : 16;/* [15:0] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } c1_bit;
+  };
+
+  /**
+  * @brief acc acc_c2 register, offset:0x10
+  */
+  union
+  {
+    __IO uint32_t c2;
+    struct
+    {
+      __IO uint32_t c2                   : 16;/* [15:0] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } c2_bit;
+  };
+
+  /**
+  * @brief acc acc_c3 register, offset:0x14
+  */
+  union
+  {
+    __IO uint32_t c3;
+    struct
+    {
+      __IO uint32_t c3                   : 16;/* [15:0] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } c3_bit;
+  };
+} acc_type;
+
+/**
+  * @}
+  */
+
+#define ACC                             ((acc_type *) ACC_BASE)
+
+/** @defgroup ACC_exported_functions
+  * @{
+  */
+
+void acc_calibration_mode_enable(uint16_t acc_trim, confirm_state new_state);
+void acc_step_set(uint8_t step_value);
+void acc_interrupt_enable(uint16_t acc_int, confirm_state new_state);
+uint8_t acc_hicktrim_get(void);
+uint8_t acc_hickcal_get(void);
+void acc_write_c1(uint16_t acc_c1_value);
+void acc_write_c2(uint16_t acc_c2_value);
+void acc_write_c3(uint16_t acc_c3_value);
+uint16_t acc_read_c1(void);
+uint16_t acc_read_c2(void);
+uint16_t acc_read_c3(void);
+flag_status acc_flag_get(uint16_t acc_flag);
+flag_status acc_interrupt_flag_get(uint16_t acc_flag);
+void acc_flag_clear(uint16_t acc_flag);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_adc.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_adc.h
@@ -1,0 +1,869 @@
+/**
+  **************************************************************************
+  * @file     at32f423_adc.h
+  * @brief    at32f423 adc header file
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __AT32F423_ADC_H
+#define __AT32F423_ADC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "at32f423.h"
+
+
+/** @addtogroup AT32F423_periph_driver
+  * @{
+  */
+
+/** @addtogroup ADC
+  * @{
+  */
+
+/** @defgroup ADC_interrupts_definition
+  * @brief adc interrupt
+  * @{
+  */
+
+#define ADC_OCCE_INT                     ((uint32_t)0x00000020) /*!< ordinary channels conversion end interrupt */
+#define ADC_VMOR_INT                     ((uint32_t)0x00000040) /*!< voltage monitoring out of range interrupt */
+#define ADC_PCCE_INT                     ((uint32_t)0x00000080) /*!< preempt channels conversion end interrupt */
+#define ADC_OCCO_INT                     ((uint32_t)0x04000000) /*!< ordinary channel conversion overflow interrupt */
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_flags_definition
+  * @brief adc flag
+  * @{
+  */
+
+#define ADC_VMOR_FLAG                    ((uint8_t)0x01) /*!< voltage monitoring out of range flag */
+#define ADC_OCCE_FLAG                    ((uint8_t)0x02) /*!< ordinary channels conversion end flag */
+#define ADC_PCCE_FLAG                    ((uint8_t)0x04) /*!< preempt channels conversion end flag */
+#define ADC_PCCS_FLAG                    ((uint8_t)0x08) /*!< preempt channel conversion start flag */
+#define ADC_OCCS_FLAG                    ((uint8_t)0x10) /*!< ordinary channel conversion start flag */
+#define ADC_OCCO_FLAG                    ((uint8_t)0x20) /*!< ordinary channel conversion overflow flag */
+#define ADC_RDY_FLAG                     ((uint8_t)0x40) /*!< adc ready to conversion flag */
+
+/**
+  * @}
+  */
+
+/** @defgroup ADC_exported_types
+  * @{
+  */
+
+/**
+  * @brief adc division type
+  */
+typedef enum
+{
+  ADC_HCLK_DIV_2                         = 0x00, /*!< adcclk is hclk/2 */
+  ADC_HCLK_DIV_3                         = 0x01, /*!< adcclk is hclk/3 */
+  ADC_HCLK_DIV_4                         = 0x02, /*!< adcclk is hclk/4 */
+  ADC_HCLK_DIV_5                         = 0x03, /*!< adcclk is hclk/5 */
+  ADC_HCLK_DIV_6                         = 0x04, /*!< adcclk is hclk/6 */
+  ADC_HCLK_DIV_7                         = 0x05, /*!< adcclk is hclk/7 */
+  ADC_HCLK_DIV_8                         = 0x06, /*!< adcclk is hclk/8 */
+  ADC_HCLK_DIV_9                         = 0x07, /*!< adcclk is hclk/9 */
+  ADC_HCLK_DIV_10                        = 0x08, /*!< adcclk is hclk/10 */
+  ADC_HCLK_DIV_11                        = 0x09, /*!< adcclk is hclk/11 */
+  ADC_HCLK_DIV_12                        = 0x0A, /*!< adcclk is hclk/12 */
+  ADC_HCLK_DIV_13                        = 0x0B, /*!< adcclk is hclk/13 */
+  ADC_HCLK_DIV_14                        = 0x0C, /*!< adcclk is hclk/14 */
+  ADC_HCLK_DIV_15                        = 0x0D, /*!< adcclk is hclk/15 */
+  ADC_HCLK_DIV_16                        = 0x0E, /*!< adcclk is hclk/16 */
+  ADC_HCLK_DIV_17                        = 0x0F  /*!< adcclk is hclk/17 */
+} adc_div_type;
+
+
+/**
+  * @brief adc conversion resolution type
+  */
+typedef enum
+{
+  ADC_RESOLUTION_12B                     = 0x00, /*!< conversion resolution 12 bit */
+  ADC_RESOLUTION_10B                     = 0x01, /*!< conversion resolution 10 bit */
+  ADC_RESOLUTION_8B                      = 0x02, /*!< conversion resolution 8 bit */
+  ADC_RESOLUTION_6B                      = 0x03  /*!< conversion resolution 6 bit */
+} adc_resolution_type;
+
+/**
+  * @brief adc data align type
+  */
+typedef enum
+{
+  ADC_RIGHT_ALIGNMENT                    = 0x00, /*!< data right alignment */
+  ADC_LEFT_ALIGNMENT                     = 0x01  /*!< data left alignment */
+} adc_data_align_type;
+
+/**
+  * @brief adc channel select type
+  */
+typedef enum
+{
+  ADC_CHANNEL_0                          = 0x00, /*!< adc channel 0 */
+  ADC_CHANNEL_1                          = 0x01, /*!< adc channel 1 */
+  ADC_CHANNEL_2                          = 0x02, /*!< adc channel 2 */
+  ADC_CHANNEL_3                          = 0x03, /*!< adc channel 3 */
+  ADC_CHANNEL_4                          = 0x04, /*!< adc channel 4 */
+  ADC_CHANNEL_5                          = 0x05, /*!< adc channel 5 */
+  ADC_CHANNEL_6                          = 0x06, /*!< adc channel 6 */
+  ADC_CHANNEL_7                          = 0x07, /*!< adc channel 7 */
+  ADC_CHANNEL_8                          = 0x08, /*!< adc channel 8 */
+  ADC_CHANNEL_9                          = 0x09, /*!< adc channel 9 */
+  ADC_CHANNEL_10                         = 0x0A, /*!< adc channel 10 */
+  ADC_CHANNEL_11                         = 0x0B, /*!< adc channel 11 */
+  ADC_CHANNEL_12                         = 0x0C, /*!< adc channel 12 */
+  ADC_CHANNEL_13                         = 0x0D, /*!< adc channel 13 */
+  ADC_CHANNEL_14                         = 0x0E, /*!< adc channel 14 */
+  ADC_CHANNEL_15                         = 0x0F, /*!< adc channel 15 */
+  ADC_CHANNEL_16                         = 0x10, /*!< adc channel 16 */
+  ADC_CHANNEL_17                         = 0x11, /*!< adc channel 17 */
+  ADC_CHANNEL_20                         = 0x14, /*!< adc channel 20 */
+  ADC_CHANNEL_21                         = 0x15, /*!< adc channel 21 */
+  ADC_CHANNEL_22                         = 0x16, /*!< adc channel 22 */
+  ADC_CHANNEL_23                         = 0x17, /*!< adc channel 23 */
+  ADC_CHANNEL_24                         = 0x18, /*!< adc channel 24 */
+  ADC_CHANNEL_25                         = 0x19, /*!< adc channel 25 */
+  ADC_CHANNEL_26                         = 0x1A, /*!< adc channel 26 */
+  ADC_CHANNEL_27                         = 0x1B  /*!< adc channel 27 */
+} adc_channel_select_type;
+
+/**
+  * @brief adc sampletime select type
+  */
+typedef enum
+{
+  ADC_SAMPLETIME_2_5                     = 0x00, /*!< adc sample time 2.5 cycle */
+  ADC_SAMPLETIME_6_5                     = 0x01, /*!< adc sample time 6.5 cycle */
+  ADC_SAMPLETIME_12_5                    = 0x02, /*!< adc sample time 12.5 cycle */
+  ADC_SAMPLETIME_24_5                    = 0x03, /*!< adc sample time 24.5 cycle */
+  ADC_SAMPLETIME_47_5                    = 0x04, /*!< adc sample time 47.5 cycle */
+  ADC_SAMPLETIME_92_5                    = 0x05, /*!< adc sample time 92.5 cycle */
+  ADC_SAMPLETIME_247_5                   = 0x06, /*!< adc sample time 247.5 cycle */
+  ADC_SAMPLETIME_640_5                   = 0x07  /*!< adc sample time 640.5 cycle */
+} adc_sampletime_select_type;
+
+/**
+  * @brief adc ordinary group trigger event select type
+  */
+typedef enum
+{
+  ADC_ORDINARY_TRIG_TMR1TRGOUT           = 0x00, /*!< timer1 trgout event as trigger source of ordinary sequence */
+  ADC_ORDINARY_TRIG_TMR1CH4              = 0x01, /*!< timer1 ch4 event as trigger source of ordinary sequence */
+  ADC_ORDINARY_TRIG_TMR2TRGOUT           = 0x02, /*!< timer2 trgout event as trigger source of ordinary sequence */
+  ADC_ORDINARY_TRIG_TMR3TRGOUT           = 0x03, /*!< timer3 trgout event as trigger source of ordinary sequence */
+  ADC_ORDINARY_TRIG_TMR9TRGOUT           = 0x04, /*!< timer9 trgout event as trigger source of ordinary sequence */
+  ADC_ORDINARY_TRIG_TMR1CH1              = 0x05, /*!< timer1 ch1 event as trigger source of ordinary sequence */
+  ADC_ORDINARY_TRIG_EXINT11              = 0x06, /*!< exint line11 event as trigger source of ordinary sequence */
+  ADC_ORDINARY_TRIG_SOFTWARE             = 0x07  /*!< software(OCSWTRG) as trigger source of ordinary sequence */
+} adc_ordinary_trig_select_type;
+
+/**
+  * @brief adc ordinary channel conversion's external_trigger_edge type
+  */
+typedef enum
+{
+  ADC_ORDINARY_TRIG_EDGE_NONE            = 0x00, /*!< ordinary channels trigger detection disabled */
+  ADC_ORDINARY_TRIG_EDGE_RISING          = 0x01, /*!< ordinary channels trigger detection on the rising edge */
+  ADC_ORDINARY_TRIG_EDGE_FALLING         = 0x02, /*!< ordinary channels trigger detection on the falling edge */
+  ADC_ORDINARY_TRIG_EDGE_RISING_FALLING  = 0x03  /*!< ordinary channels trigger detection on both the rising and falling edges */
+} adc_ordinary_trig_edge_type;
+
+/**
+  * @brief adc preempt group external trigger event select type
+  */
+typedef enum
+{
+  ADC_PREEMPT_TRIG_TMR1CH2               = 0x00, /*!< timer1 ch2 event as trigger source of preempt sequence */
+  ADC_PREEMPT_TRIG_TMR1CH3               = 0x01, /*!< timer1 ch3 event as trigger source of preempt sequence */
+  ADC_PREEMPT_TRIG_TMR2CH4               = 0x02, /*!< timer2 ch4 event as trigger source of preempt sequence */
+  ADC_PREEMPT_TRIG_TMR3CH4               = 0x03, /*!< timer3 ch4 event as trigger source of preempt sequence */
+  ADC_PREEMPT_TRIG_TMR9CH1               = 0x04, /*!< timer9 ch1 event as trigger source of preempt sequence */
+  ADC_PREEMPT_TRIG_TMR6TRGOUT            = 0x05, /*!< timer6 trgout event as trigger source of preempt sequence */
+  ADC_PREEMPT_TRIG_EXINT15               = 0x06, /*!< exint line15 event as trigger source of preempt sequence */
+  ADC_PREEMPT_TRIG_SOFTWARE              = 0x07  /*!< software(PCSWTRG) as trigger source of preempt sequence */
+} adc_preempt_trig_select_type;
+
+/**
+  * @brief adc preempt channel conversion's external_trigger_edge type
+  */
+typedef enum
+{
+  ADC_PREEMPT_TRIG_EDGE_NONE             = 0x00, /*!< preempt channels trigger detection disabled */
+  ADC_PREEMPT_TRIG_EDGE_RISING           = 0x01, /*!< preempt channels trigger detection on the rising edge */
+  ADC_PREEMPT_TRIG_EDGE_FALLING          = 0x02, /*!< preempt channels trigger detection on the falling edge */
+  ADC_PREEMPT_TRIG_EDGE_RISING_FALLING   = 0x03  /*!< preempt channels trigger detection on both the rising and falling edges */
+} adc_preempt_trig_edge_type;
+
+/**
+  * @brief adc preempt channel type
+  */
+typedef enum
+{
+  ADC_PREEMPT_CHANNEL_1                  = 0x00, /*!< adc preempt channel 1 */
+  ADC_PREEMPT_CHANNEL_2                  = 0x01, /*!< adc preempt channel 2 */
+  ADC_PREEMPT_CHANNEL_3                  = 0x02, /*!< adc preempt channel 3 */
+  ADC_PREEMPT_CHANNEL_4                  = 0x03  /*!< adc preempt channel 4 */
+} adc_preempt_channel_type;
+
+/**
+  * @brief adc voltage_monitoring type
+  */
+typedef enum
+{
+  ADC_VMONITOR_SINGLE_ORDINARY           = 0x00800200, /*!< voltage_monitoring on a single ordinary channel */
+  ADC_VMONITOR_SINGLE_PREEMPT            = 0x00400200, /*!< voltage_monitoring on a single preempt channel */
+  ADC_VMONITOR_SINGLE_ORDINARY_PREEMPT   = 0x00C00200, /*!< voltage_monitoring on a single ordinary or preempt channel */
+  ADC_VMONITOR_ALL_ORDINARY              = 0x00800000, /*!< voltage_monitoring on all ordinary channel */
+  ADC_VMONITOR_ALL_PREEMPT               = 0x00400000, /*!< voltage_monitoring on all preempt channel */
+  ADC_VMONITOR_ALL_ORDINARY_PREEMPT      = 0x00C00000, /*!< voltage_monitoring on all ordinary and preempt channel */
+  ADC_VMONITOR_NONE                      = 0x00000000  /*!< no channel guarded by the voltage_monitoring */
+} adc_voltage_monitoring_type;
+
+/**
+  * @brief adc oversample ratio type
+  */
+typedef enum
+{
+  ADC_OVERSAMPLE_RATIO_2                 = 0x00, /*!< adc oversample ratio 2 */
+  ADC_OVERSAMPLE_RATIO_4                 = 0x01, /*!< adc oversample ratio 4 */
+  ADC_OVERSAMPLE_RATIO_8                 = 0x02, /*!< adc oversample ratio 8 */
+  ADC_OVERSAMPLE_RATIO_16                = 0x03, /*!< adc oversample ratio 16 */
+  ADC_OVERSAMPLE_RATIO_32                = 0x04, /*!< adc oversample ratio 32 */
+  ADC_OVERSAMPLE_RATIO_64                = 0x05, /*!< adc oversample ratio 64 */
+  ADC_OVERSAMPLE_RATIO_128               = 0x06, /*!< adc oversample ratio 128 */
+  ADC_OVERSAMPLE_RATIO_256               = 0x07  /*!< adc oversample ratio 256 */
+} adc_oversample_ratio_type;
+
+/**
+  * @brief adc oversample shift type
+  */
+typedef enum
+{
+  ADC_OVERSAMPLE_SHIFT_0                 = 0x00, /*!< adc oversample shift 0 */
+  ADC_OVERSAMPLE_SHIFT_1                 = 0x01, /*!< adc oversample shift 1 */
+  ADC_OVERSAMPLE_SHIFT_2                 = 0x02, /*!< adc oversample shift 2 */
+  ADC_OVERSAMPLE_SHIFT_3                 = 0x03, /*!< adc oversample shift 3 */
+  ADC_OVERSAMPLE_SHIFT_4                 = 0x04, /*!< adc oversample shift 4 */
+  ADC_OVERSAMPLE_SHIFT_5                 = 0x05, /*!< adc oversample shift 5 */
+  ADC_OVERSAMPLE_SHIFT_6                 = 0x06, /*!< adc oversample shift 6 */
+  ADC_OVERSAMPLE_SHIFT_7                 = 0x07, /*!< adc oversample shift 7 */
+  ADC_OVERSAMPLE_SHIFT_8                 = 0x08  /*!< adc oversample shift 8 */
+} adc_oversample_shift_type;
+
+/**
+  * @brief adc ordinary oversample recover type
+  */
+typedef enum
+{
+  ADC_OVERSAMPLE_CONTINUE                = 0x00, /*!< continue mode:when preempt triggered,oversampling is temporary stopped and continued after preempt sequence */
+  ADC_OVERSAMPLE_RESTART                 = 0x01  /*!< restart mode:when preempt triggered,oversampling is aborted and resumed from start after preempt sequence */
+} adc_ordinary_oversample_restart_type;
+
+/**
+  * @brief adc common config type
+  */
+typedef struct
+{
+  adc_div_type                           div;                             /*!< adc division select */
+  confirm_state                          tempervintrv_state;              /*!< adc temperature sensor and vintrv state */
+} adc_common_config_type;
+
+/**
+  * @brief adc base config type
+  */
+typedef struct
+{
+  confirm_state                          sequence_mode;           /*!< adc sequence mode */
+  confirm_state                          repeat_mode;             /*!< adc repeat mode */
+  adc_data_align_type                    data_align;              /*!< adc data alignment */
+  uint8_t                                ordinary_channel_length; /*!< adc ordinary channel sequence length*/
+} adc_base_config_type;
+
+/**
+  * @brief type define adc register all
+  */
+typedef struct
+{
+
+  /**
+    * @brief adc sts register, offset:0x00
+    */
+  union
+  {
+    __IO uint32_t sts;
+    struct
+    {
+      __IO uint32_t vmor                 : 1; /* [0] */
+      __IO uint32_t occe                 : 1; /* [1] */
+      __IO uint32_t pcce                 : 1; /* [2] */
+      __IO uint32_t pccs                 : 1; /* [3] */
+      __IO uint32_t occs                 : 1; /* [4] */
+      __IO uint32_t occo                 : 1; /* [5] */
+      __IO uint32_t rdy                  : 1; /* [6] */
+      __IO uint32_t reserved1            : 25;/* [31:7] */
+    } sts_bit;
+  };
+
+  /**
+    * @brief adc ctrl1 register, offset:0x04
+    */
+  union
+  {
+    __IO uint32_t ctrl1;
+    struct
+    {
+      __IO uint32_t vmcsel               : 5; /* [4:0] */
+      __IO uint32_t occeien              : 1; /* [5] */
+      __IO uint32_t vmorien              : 1; /* [6] */
+      __IO uint32_t pcceien              : 1; /* [7] */
+      __IO uint32_t sqen                 : 1; /* [8] */
+      __IO uint32_t vmsgen               : 1; /* [9] */
+      __IO uint32_t pcautoen             : 1; /* [10] */
+      __IO uint32_t ocpen                : 1; /* [11] */
+      __IO uint32_t pcpen                : 1; /* [12] */
+      __IO uint32_t ocpcnt               : 3; /* [15:13] */
+      __IO uint32_t reserved1            : 6; /* [21:16] */
+      __IO uint32_t pcvmen               : 1; /* [22] */
+      __IO uint32_t ocvmen               : 1; /* [23] */
+      __IO uint32_t crsel                : 2; /* [25:24] */
+      __IO uint32_t occoien              : 1; /* [26] */
+      __IO uint32_t reserved2            : 5; /* [31:27] */
+    } ctrl1_bit;
+  };
+
+   /**
+    * @brief adc ctrl2 register, offset:0x08
+    */
+  union
+  {
+    __IO uint32_t ctrl2;
+    struct
+    {
+      __IO uint32_t adcen                : 1; /* [0] */
+      __IO uint32_t rpen                 : 1; /* [1] */
+      __IO uint32_t adcal                : 1; /* [2] */
+      __IO uint32_t adcalinit            : 1; /* [3] */
+      __IO uint32_t adabrt               : 1; /* [4] */
+      __IO uint32_t reserved1            : 3; /* [7:5] */
+      __IO uint32_t ocdmaen              : 1; /* [8] */
+      __IO uint32_t ocdrcen              : 1; /* [9] */
+      __IO uint32_t eocsfen              : 1; /* [10] */
+      __IO uint32_t dtalign              : 1; /* [11] */
+      __IO uint32_t reserved2            : 4; /* [15:12] */
+      __IO uint32_t pctesel              : 4; /* [19:16] */
+      __IO uint32_t pcete                : 2; /* [21:20] */
+      __IO uint32_t pcswtrg              : 1; /* [22] */
+      __IO uint32_t reserved3            : 1; /* [23] */
+      __IO uint32_t octesel              : 4; /* [27:24] */
+      __IO uint32_t ocete                : 2; /* [29:28] */
+      __IO uint32_t ocswtrg              : 1; /* [30] */
+      __IO uint32_t reserved4            : 1; /* [31] */
+    } ctrl2_bit;
+  };
+
+  /**
+  * @brief adc spt1 register, offset:0x0C
+  */
+  union
+  {
+    __IO uint32_t spt1;
+    struct
+    {
+      __IO uint32_t cspt10               : 3; /* [2:0] */
+      __IO uint32_t cspt11               : 3; /* [5:3] */
+      __IO uint32_t cspt12               : 3; /* [8:6] */
+      __IO uint32_t cspt13               : 3; /* [11:9] */
+      __IO uint32_t cspt14               : 3; /* [14:12] */
+      __IO uint32_t cspt15               : 3; /* [17:15] */
+      __IO uint32_t cspt16               : 3; /* [20:18] */
+      __IO uint32_t cspt17               : 3; /* [23:21] */
+      __IO uint32_t reserved1            : 8; /* [31:24] */
+    } spt1_bit;
+  };
+
+  /**
+  * @brief adc spt2 register, offset:0x10
+  */
+  union
+  {
+    __IO uint32_t spt2;
+    struct
+    {
+      __IO uint32_t cspt0                : 3;/* [2:0] */
+      __IO uint32_t cspt1                : 3;/* [5:3] */
+      __IO uint32_t cspt2                : 3;/* [8:6] */
+      __IO uint32_t cspt3                : 3;/* [11:9] */
+      __IO uint32_t cspt4                : 3;/* [14:12] */
+      __IO uint32_t cspt5                : 3;/* [17:15] */
+      __IO uint32_t cspt6                : 3;/* [20:18] */
+      __IO uint32_t cspt7                : 3;/* [23:21] */
+      __IO uint32_t cspt8                : 3;/* [26:24] */
+      __IO uint32_t cspt9                : 3;/* [29:27] */
+      __IO uint32_t reserved1            : 2;/* [31:30] */
+    } spt2_bit;
+  };
+
+  /**
+  * @brief adc pcdto1 register, offset:0x14
+  */
+  union
+  {
+    __IO uint32_t pcdto1;
+    struct
+    {
+      __IO uint32_t pcdto1               : 12; /* [11:0] */
+      __IO uint32_t reserved1            : 20; /* [31:12] */
+    } pcdto1_bit;
+  };
+
+  /**
+  * @brief adc pcdto2 register, offset:0x18
+  */
+  union
+  {
+    __IO uint32_t pcdto2;
+    struct
+    {
+      __IO uint32_t pcdto2               : 12; /* [11:0] */
+      __IO uint32_t reserved1            : 20; /* [31:12] */
+    } pcdto2_bit;
+  };
+
+  /**
+  * @brief adc pcdto3 register, offset:0x1C
+  */
+  union
+  {
+    __IO uint32_t pcdto3;
+    struct
+    {
+      __IO uint32_t pcdto3               : 12; /* [11:0] */
+      __IO uint32_t reserved1            : 20; /* [31:12] */
+    } pcdto3_bit;
+  };
+
+  /**
+  * @brief adc pcdto4 register, offset:0x20
+  */
+  union
+  {
+    __IO uint32_t pcdto4;
+    struct
+    {
+      __IO uint32_t pcdto4               : 12; /* [11:0] */
+      __IO uint32_t reserved1            : 20; /* [31:12] */
+    } pcdto4_bit;
+  };
+
+  /**
+  * @brief adc vmhb register, offset:0x24
+  */
+  union
+  {
+    __IO uint32_t vmhb;
+    struct
+    {
+      __IO uint32_t vmhb                 : 16; /* [15:0] */
+      __IO uint32_t reserved1            : 16; /* [31:16] */
+    } vmhb_bit;
+  };
+
+  /**
+  * @brief adc vmlb register, offset:0x28
+  */
+  union
+  {
+    __IO uint32_t vmlb;
+    struct
+    {
+      __IO uint32_t vmlb                 : 16; /* [15:0] */
+      __IO uint32_t reserved1            : 16; /* [31:16] */
+    } vmlb_bit;
+  };
+
+  /**
+  * @brief adc osq1 register, offset:0x2C
+  */
+  union
+  {
+    __IO uint32_t osq1;
+    struct
+    {
+      __IO uint32_t osn13                : 5; /* [4:0] */
+      __IO uint32_t osn14                : 5; /* [9:5] */
+      __IO uint32_t osn15                : 5; /* [14:10] */
+      __IO uint32_t osn16                : 5; /* [19:15] */
+      __IO uint32_t oclen                : 5; /* [24:20] */
+      __IO uint32_t reserved1            : 7; /* [31:25] */
+    } osq1_bit;
+  };
+
+  /**
+  * @brief adc osq2 register, offset:0x30
+  */
+  union
+  {
+    __IO uint32_t osq2;
+    struct
+    {
+      __IO uint32_t osn7                 : 5; /* [4:0] */
+      __IO uint32_t osn8                 : 5; /* [9:5] */
+      __IO uint32_t osn9                 : 5; /* [14:10] */
+      __IO uint32_t osn10                : 5; /* [19:15] */
+      __IO uint32_t osn11                : 5; /* [24:20] */
+      __IO uint32_t osn12                : 5; /* [29:25] */
+      __IO uint32_t reserved1            : 2; /* [31:30] */
+    } osq2_bit;
+  };
+
+  /**
+  * @brief adc osq3 register, offset:0x34
+  */
+  union
+  {
+    __IO uint32_t osq3;
+    struct
+    {
+      __IO uint32_t osn1                 : 5; /* [4:0] */
+      __IO uint32_t osn2                 : 5; /* [9:5] */
+      __IO uint32_t osn3                 : 5; /* [14:10] */
+      __IO uint32_t osn4                 : 5; /* [19:15] */
+      __IO uint32_t osn5                 : 5; /* [24:20] */
+      __IO uint32_t osn6                 : 5; /* [29:25] */
+      __IO uint32_t reserved1            : 2; /* [31:30] */
+    } osq3_bit;
+  };
+
+  /**
+  * @brief adc psq register, offset:0x38
+  */
+  union
+  {
+    __IO uint32_t psq;
+    struct
+    {
+      __IO uint32_t psn1                 : 5; /* [4:0] */
+      __IO uint32_t psn2                 : 5; /* [9:5] */
+      __IO uint32_t psn3                 : 5; /* [14:10] */
+      __IO uint32_t psn4                 : 5; /* [19:15] */
+      __IO uint32_t pclen                : 2; /* [21:20] */
+      __IO uint32_t reserved1            : 10;/* [31:22] */
+    } psq_bit;
+  };
+
+  /**
+  * @brief adc pdt1 register, offset:0x3C
+  */
+  union
+  {
+    __IO uint32_t pdt1;
+    struct
+    {
+      __IO uint32_t pdt1                 : 16; /* [15:0] */
+      __IO uint32_t reserved1            : 16; /* [31:16] */
+    } pdt1_bit;
+  };
+
+  /**
+  * @brief adc pdt2 register, offset:0x40
+  */
+  union
+  {
+    __IO uint32_t pdt2;
+    struct
+    {
+      __IO uint32_t pdt2                 : 16; /* [15:0] */
+      __IO uint32_t reserved1            : 16; /* [31:16] */
+    } pdt2_bit;
+  };
+
+  /**
+  * @brief adc pdt3 register, offset:0x44
+  */
+  union
+  {
+    __IO uint32_t pdt3;
+    struct
+    {
+      __IO uint32_t pdt3                 : 16; /* [15:0] */
+      __IO uint32_t reserved1            : 16; /* [31:16] */
+    } pdt3_bit;
+  };
+
+  /**
+  * @brief adc pdt4 register, offset:0x48
+  */
+  union
+  {
+    __IO uint32_t pdt4;
+    struct
+    {
+      __IO uint32_t pdt4                 : 16; /* [15:0] */
+      __IO uint32_t reserved1            : 16; /* [31:16] */
+    } pdt4_bit;
+  };
+
+  /**
+  * @brief adc odt register, offset:0x4C
+  */
+  union
+  {
+    __IO uint32_t odt;
+    struct
+    {
+      __IO uint32_t odt                  : 16; /* [15:0] */
+      __IO uint32_t reserved1            : 16; /* [31:16] */
+    } odt_bit;
+  };
+
+  /**
+  * @brief adc spt3 register, offset:0x50
+  */
+  union
+  {
+    __IO uint32_t spt3;
+    struct
+    {
+      __IO uint32_t cspt20               : 3;/* [2:0] */
+      __IO uint32_t cspt21               : 3;/* [5:3] */
+      __IO uint32_t cspt22               : 3;/* [8:6] */
+      __IO uint32_t cspt23               : 3;/* [11:9] */
+      __IO uint32_t cspt24               : 3;/* [14:12] */
+      __IO uint32_t cspt25               : 3;/* [17:15] */
+      __IO uint32_t cspt26               : 3;/* [20:18] */
+      __IO uint32_t cspt27               : 3;/* [23:21] */
+      __IO uint32_t reserved1            : 8;/* [31:24] */
+    } spt3_bit;
+  };
+
+  /**
+  * @brief adc osq4 register, offset:0x54
+  */
+  union
+  {
+    __IO uint32_t osq4;
+    struct
+    {
+      __IO uint32_t osn17                : 5; /* [4:0] */
+      __IO uint32_t osn18                : 5; /* [9:5] */
+      __IO uint32_t osn19                : 5; /* [14:10] */
+      __IO uint32_t osn20                : 5; /* [19:15] */
+      __IO uint32_t osn21                : 5; /* [24:20] */
+      __IO uint32_t osn22                : 5; /* [29:25] */
+      __IO uint32_t reserved1            : 2; /* [31:30] */
+    } osq4_bit;
+  };
+
+  /**
+  * @brief adc osq5 register, offset:0x58
+  */
+  union
+  {
+    __IO uint32_t osq5;
+    struct
+    {
+      __IO uint32_t osn23                : 5; /* [4:0] */
+      __IO uint32_t osn24                : 5; /* [9:5] */
+      __IO uint32_t osn25                : 5; /* [14:10] */
+      __IO uint32_t osn26                : 5; /* [19:15] */
+      __IO uint32_t osn27                : 5; /* [24:20] */
+      __IO uint32_t osn28                : 5; /* [29:25] */
+      __IO uint32_t reserved1            : 2; /* [31:30] */
+    } osq5_bit;
+  };
+
+  /**
+  * @brief adc osq6 register, offset:0x5c
+  */
+  union
+  {
+    __IO uint32_t osq6;
+    struct
+    {
+      __IO uint32_t osn29                : 5; /* [4:0] */
+      __IO uint32_t osn30                : 5; /* [9:5] */
+      __IO uint32_t osn31                : 5; /* [14:10] */
+      __IO uint32_t osn32                : 5; /* [19:15] */
+      __IO uint32_t reserved1            : 12; /* [31:20] */
+    } osq6_bit;
+  };
+
+  __IO uint32_t reserved1[8];
+
+  /**
+  * @brief adc ovsp register, offset:0x80
+  */
+  union
+  {
+    __IO uint32_t ovsp;
+    struct
+    {
+      __IO uint32_t oosen                : 1; /* [0] */
+      __IO uint32_t posen                : 1; /* [1] */
+      __IO uint32_t osrsel               : 3; /* [4:2] */
+      __IO uint32_t osssel               : 4; /* [8:5] */
+      __IO uint32_t oostren              : 1; /* [9] */
+      __IO uint32_t oosrsel              : 1; /* [10] */
+      __IO uint32_t reserved1            : 21; /* [31:11] */
+    } ovsp_bit;
+  };
+
+  __IO uint32_t reserved2[12];
+
+  /**
+  * @brief adc calval register, offset:0xB4
+  */
+  union
+  {
+    __IO uint32_t calval;
+    struct
+    {
+      __IO uint32_t calval               : 7; /* [6:0] */
+      __IO uint32_t reserved1            : 25; /* [31:7] */
+    } calval_bit;
+  };
+  
+  __IO uint32_t reserved3[6];
+  
+  /**
+  * @brief adc misc register, offset:0xD0
+  */
+  union
+  {
+    __IO uint32_t misc;
+    struct
+    {
+      __IO uint32_t xtest                : 6; /* [5:0] */
+      __IO uint32_t reserved1            : 26; /* [31:6] */
+    } misc_bit;
+  };
+} adc_type;
+
+/**
+  * @brief type define adc register all
+  */
+typedef struct
+{
+  __IO uint32_t reserved1;
+
+  /**
+    * @brief adc cctrl register, offset:0x04
+    */
+  union
+  {
+    __IO uint32_t cctrl;
+    struct
+    {
+      __IO uint32_t reserved1            : 16;/* [15:0] */
+      __IO uint32_t adcdiv               : 4; /* [19:16] */
+      __IO uint32_t reserved2            : 3; /* [22:20] */
+      __IO uint32_t itsrven              : 1; /* [23] */
+      __IO uint32_t reserved3            : 8; /* [31:24] */
+    } cctrl_bit;
+  };
+
+} adccom_type;
+
+/**
+  * @}
+  */
+
+#define ADC1                             ((adc_type *) ADC1_BASE)
+#define ADCCOM                           ((adccom_type *) ADCCOM_BASE)
+
+/** @defgroup ADC_exported_functions
+  * @{
+  */
+
+void adc_reset(void);
+void adc_enable(adc_type *adc_x, confirm_state new_state);
+void adc_base_default_para_init(adc_base_config_type *adc_base_struct);
+void adc_base_config(adc_type *adc_x, adc_base_config_type *adc_base_struct);
+void adc_common_default_para_init(adc_common_config_type *adc_common_struct);
+void adc_common_config(adc_common_config_type *adc_common_struct);
+void adc_resolution_set(adc_type *adc_x, adc_resolution_type resolution);
+void adc_dma_mode_enable(adc_type *adc_x, confirm_state new_state);
+void adc_dma_request_repeat_enable(adc_type *adc_x, confirm_state new_state);
+void adc_interrupt_enable(adc_type *adc_x, uint32_t adc_int, confirm_state new_state);
+void adc_calibration_value_set(adc_type *adc_x, uint8_t adc_calibration_value);
+void adc_calibration_init(adc_type *adc_x);
+flag_status adc_calibration_init_status_get(adc_type *adc_x);
+void adc_calibration_start(adc_type *adc_x);
+flag_status adc_calibration_status_get(adc_type *adc_x);
+void adc_voltage_monitor_enable(adc_type *adc_x, adc_voltage_monitoring_type adc_voltage_monitoring);
+void adc_voltage_monitor_threshold_value_set(adc_type *adc_x, uint16_t adc_high_threshold, uint16_t adc_low_threshold);
+void adc_voltage_monitor_single_channel_select(adc_type *adc_x, adc_channel_select_type adc_channel);
+void adc_ordinary_channel_set(adc_type *adc_x, adc_channel_select_type adc_channel, uint8_t adc_sequence, adc_sampletime_select_type adc_sampletime);
+void adc_preempt_channel_length_set(adc_type *adc_x, uint8_t adc_channel_lenght);
+void adc_preempt_channel_set(adc_type *adc_x, adc_channel_select_type adc_channel, uint8_t adc_sequence, adc_sampletime_select_type adc_sampletime);
+void adc_ordinary_conversion_trigger_set(adc_type *adc_x, adc_ordinary_trig_select_type adc_ordinary_trig, adc_ordinary_trig_edge_type adc_ordinary_trig_edge);
+void adc_preempt_conversion_trigger_set(adc_type *adc_x, adc_preempt_trig_select_type adc_preempt_trig, adc_preempt_trig_edge_type adc_preempt_trig_edge);
+void adc_preempt_offset_value_set(adc_type *adc_x, adc_preempt_channel_type adc_preempt_channel, uint16_t adc_offset_value);
+void adc_ordinary_part_count_set(adc_type *adc_x, uint8_t adc_channel_count);
+void adc_ordinary_part_mode_enable(adc_type *adc_x, confirm_state new_state);
+void adc_preempt_part_mode_enable(adc_type *adc_x, confirm_state new_state);
+void adc_preempt_auto_mode_enable(adc_type *adc_x, confirm_state new_state);
+void adc_conversion_stop(adc_type *adc_x);
+flag_status adc_conversion_stop_status_get(adc_type *adc_x);
+void adc_occe_each_conversion_enable(adc_type *adc_x, confirm_state new_state);
+void adc_ordinary_software_trigger_enable(adc_type *adc_x, confirm_state new_state);
+flag_status adc_ordinary_software_trigger_status_get(adc_type *adc_x);
+void adc_preempt_software_trigger_enable(adc_type *adc_x, confirm_state new_state);
+flag_status adc_preempt_software_trigger_status_get(adc_type *adc_x);
+uint16_t adc_ordinary_conversion_data_get(adc_type *adc_x);
+uint16_t adc_preempt_conversion_data_get(adc_type *adc_x, adc_preempt_channel_type adc_preempt_channel);
+flag_status adc_flag_get(adc_type *adc_x, uint8_t adc_flag);
+flag_status adc_interrupt_flag_get(adc_type *adc_x, uint8_t adc_flag);
+void adc_flag_clear(adc_type *adc_x, uint32_t adc_flag);
+void adc_ordinary_oversample_enable(adc_type *adc_x, confirm_state new_state);
+void adc_preempt_oversample_enable(adc_type *adc_x, confirm_state new_state);
+void adc_oversample_ratio_shift_set(adc_type *adc_x, adc_oversample_ratio_type adc_oversample_ratio, adc_oversample_shift_type adc_oversample_shift);
+void adc_ordinary_oversample_trig_enable(adc_type *adc_x, confirm_state new_state);
+void adc_ordinary_oversample_restart_set(adc_type *adc_x, adc_ordinary_oversample_restart_type adc_ordinary_oversample_restart);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_can.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_can.h
@@ -1,0 +1,986 @@
+/**
+  **************************************************************************
+  * @file     at32f423_can.h
+  * @brief    at32f423 can header file
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+/* define to prevent recursive inclusion -------------------------------------*/
+#ifndef __AT32F423_CAN_H
+#define __AT32F423_CAN_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* includes ------------------------------------------------------------------*/
+#include "at32f423.h"
+
+/** @addtogroup AT32F423_periph_driver
+  * @{
+  */
+
+/** @addtogroup CAN
+  * @{
+  */
+
+
+/** @defgroup CAN_timeout_count
+  * @{
+  */
+
+#define FZC_TIMEOUT                      ((uint32_t)0x0000FFFF) /*!< time out for fzc bit */
+#define DZC_TIMEOUT                      ((uint32_t)0x0000FFFF) /*!< time out for dzc bit */
+
+/**
+  * @}
+  */
+
+/** @defgroup CAN_flags_definition
+  * @brief can flag
+  * @{
+  */
+
+#define CAN_EAF_FLAG                     ((uint32_t)0x01) /*!< error active flag */
+#define CAN_EPF_FLAG                     ((uint32_t)0x02) /*!< error passive flag */
+#define CAN_BOF_FLAG                     ((uint32_t)0x03) /*!< bus-off flag */
+#define CAN_ETR_FLAG                     ((uint32_t)0x04) /*!< error type record flag */
+#define CAN_EOIF_FLAG                    ((uint32_t)0x05) /*!< error occur interrupt flag */
+#define CAN_TM0TCF_FLAG                  ((uint32_t)0x06) /*!< transmit mailbox 0 transmission completed flag */
+#define CAN_TM1TCF_FLAG                  ((uint32_t)0x07) /*!< transmit mailbox 1 transmission completed flag */
+#define CAN_TM2TCF_FLAG                  ((uint32_t)0x08) /*!< transmit mailbox 2 transmission completed flag */
+#define CAN_RF0MN_FLAG                   ((uint32_t)0x09) /*!< receive fifo 0 message num flag */
+#define CAN_RF0FF_FLAG                   ((uint32_t)0x0A) /*!< receive fifo 0 full flag */
+#define CAN_RF0OF_FLAG                   ((uint32_t)0x0B) /*!< receive fifo 0 overflow flag */
+#define CAN_RF1MN_FLAG                   ((uint32_t)0x0C) /*!< receive fifo 1 message num flag */
+#define CAN_RF1FF_FLAG                   ((uint32_t)0x0D) /*!< receive fifo 1 full flag */
+#define CAN_RF1OF_FLAG                   ((uint32_t)0x0E) /*!< receive fifo 1 overflow flag */
+#define CAN_QDZIF_FLAG                   ((uint32_t)0x0F) /*!< quit doze mode interrupt flag */
+#define CAN_EDZC_FLAG                    ((uint32_t)0x10) /*!< enter doze mode confirm flag */
+#define CAN_TMEF_FLAG                    ((uint32_t)0x11) /*!< transmit mailbox empty flag */
+
+/**
+  * @}
+  */
+
+/** @defgroup CAN_interrupts_definition
+  * @brief can interrupt
+  * @{
+  */
+
+#define CAN_TCIEN_INT                    ((uint32_t)0x00000001) /*!< transmission complete interrupt */
+#define CAN_RF0MIEN_INT                  ((uint32_t)0x00000002) /*!< receive fifo 0 message interrupt */
+#define CAN_RF0FIEN_INT                  ((uint32_t)0x00000004) /*!< receive fifo 0 full interrupt */
+#define CAN_RF0OIEN_INT                  ((uint32_t)0x00000008) /*!< receive fifo 0 overflow interrupt */
+#define CAN_RF1MIEN_INT                  ((uint32_t)0x00000010) /*!< receive fifo 1 message interrupt */
+#define CAN_RF1FIEN_INT                  ((uint32_t)0x00000020) /*!< receive fifo 1 full interrupt */
+#define CAN_RF1OIEN_INT                  ((uint32_t)0x00000040) /*!< receive fifo 1 overflow interrupt */
+#define CAN_EAIEN_INT                    ((uint32_t)0x00000100) /*!< error active interrupt */
+#define CAN_EPIEN_INT                    ((uint32_t)0x00000200) /*!< error passive interrupt */
+#define CAN_BOIEN_INT                    ((uint32_t)0x00000400) /*!< bus-off interrupt */
+#define CAN_ETRIEN_INT                   ((uint32_t)0x00000800) /*!< error type record interrupt */
+#define CAN_EOIEN_INT                    ((uint32_t)0x00008000) /*!< error occur interrupt */
+#define CAN_QDZIEN_INT                   ((uint32_t)0x00010000) /*!< quit doze mode interrupt */
+#define CAN_EDZIEN_INT                   ((uint32_t)0x00020000) /*!< enter doze mode confirm interrupt */
+
+/**
+  * @}
+  */
+
+/**
+  * @brief  can flag clear operation macro definition val
+  */
+#define CAN_MSTS_EOIF_VAL                ((uint32_t)0x00000004) /*!< eoif bit value, it clear by writing 1 */
+#define CAN_MSTS_QDZIF_VAL               ((uint32_t)0x00000008) /*!< qdzif bit value, it clear by writing 1 */
+#define CAN_MSTS_EDZIF_VAL               ((uint32_t)0x00000010) /*!< edzif bit value, it clear by writing 1 */
+#define CAN_TSTS_TM0TCF_VAL              ((uint32_t)0x00000001) /*!< tm0tcf bit value, it clear by writing 1 */
+#define CAN_TSTS_TM1TCF_VAL              ((uint32_t)0x00000100) /*!< tm1tcf bit value, it clear by writing 1 */
+#define CAN_TSTS_TM2TCF_VAL              ((uint32_t)0x00010000) /*!< tm2tcf bit value, it clear by writing 1 */
+#define CAN_TSTS_TM0CT_VAL               ((uint32_t)0x00000080) /*!< tm0ct bit value, it clear by writing 1 */
+#define CAN_TSTS_TM1CT_VAL               ((uint32_t)0x00008000) /*!< tm1ct bit value, it clear by writing 1 */
+#define CAN_TSTS_TM2CT_VAL               ((uint32_t)0x00800000) /*!< tm2ct bit value, it clear by writing 1 */
+#define CAN_RF0_RF0FF_VAL                ((uint32_t)0x00000008) /*!< rf0ff bit value, it clear by writing 1 */
+#define CAN_RF0_RF0OF_VAL                ((uint32_t)0x00000010) /*!< rf0of bit value, it clear by writing 1 */
+#define CAN_RF0_RF0R_VAL                 ((uint32_t)0x00000020) /*!< rf0r bit value, it clear by writing 1 */
+#define CAN_RF1_RF1FF_VAL                ((uint32_t)0x00000008) /*!< rf1ff bit value, it clear by writing 1 */
+#define CAN_RF1_RF1OF_VAL                ((uint32_t)0x00000010) /*!< rf1of bit value, it clear by writing 1 */
+#define CAN_RF1_RF1R_VAL                 ((uint32_t)0x00000020) /*!< rf1r bit value, it clear by writing 1 */
+
+/** @defgroup CAN_exported_types
+  * @{
+  */
+
+/**
+  * @brief  can filter fifo
+  */
+typedef enum
+{
+  CAN_FILTER_FIFO0                       = 0x00, /*!< filter fifo 0 assignment for filter x */
+  CAN_FILTER_FIFO1                       = 0x01  /*!< filter fifo 1 assignment for filter x */
+} can_filter_fifo_type;
+
+/**
+  * @brief  can filter mode
+  */
+typedef enum
+{
+  CAN_FILTER_MODE_ID_MASK                = 0x00, /*!< identifier mask mode */
+  CAN_FILTER_MODE_ID_LIST                = 0x01  /*!< identifier list mode */
+} can_filter_mode_type;
+
+/**
+  * @brief  can filter bit width select
+  */
+typedef enum
+{
+  CAN_FILTER_16BIT                       = 0x00, /*!< two 16-bit filters */
+  CAN_FILTER_32BIT                       = 0x01  /*!< one 32-bit filter */
+} can_filter_bit_width_type;
+
+/**
+  * @brief  can mode
+  */
+typedef enum
+{
+  CAN_MODE_COMMUNICATE                   = 0x00, /*!< communication mode */
+  CAN_MODE_LOOPBACK                      = 0x01, /*!< loopback mode */
+  CAN_MODE_LISTENONLY                    = 0x02, /*!< listen-only mode */
+  CAN_MODE_LISTENONLY_LOOPBACK           = 0x03  /*!< loopback combined with listen-only mode */
+} can_mode_type;
+
+/**
+  * @brief  can operating mode
+  */
+typedef enum
+{
+  CAN_OPERATINGMODE_FREEZE               = 0x00, /*!< freeze mode */
+  CAN_OPERATINGMODE_DOZE                 = 0x01, /*!< doze mode */
+  CAN_OPERATINGMODE_COMMUNICATE          = 0x02  /*!< communication mode */
+} can_operating_mode_type;
+
+/**
+  * @brief  can resynchronization adjust width
+  */
+typedef enum
+{
+  CAN_RSAW_1TQ                           = 0x00, /*!< 1 time quantum */
+  CAN_RSAW_2TQ                           = 0x01, /*!< 2 time quantum */
+  CAN_RSAW_3TQ                           = 0x02, /*!< 3 time quantum */
+  CAN_RSAW_4TQ                           = 0x03  /*!< 4 time quantum */
+} can_rsaw_type;
+
+/**
+  * @brief  can bit time segment 1
+  */
+typedef enum
+{
+  CAN_BTS1_1TQ                           = 0x00, /*!< 1 time quantum */
+  CAN_BTS1_2TQ                           = 0x01, /*!< 2 time quantum */
+  CAN_BTS1_3TQ                           = 0x02, /*!< 3 time quantum */
+  CAN_BTS1_4TQ                           = 0x03, /*!< 4 time quantum */
+  CAN_BTS1_5TQ                           = 0x04, /*!< 5 time quantum */
+  CAN_BTS1_6TQ                           = 0x05, /*!< 6 time quantum */
+  CAN_BTS1_7TQ                           = 0x06, /*!< 7 time quantum */
+  CAN_BTS1_8TQ                           = 0x07, /*!< 8 time quantum */
+  CAN_BTS1_9TQ                           = 0x08, /*!< 9 time quantum */
+  CAN_BTS1_10TQ                          = 0x09, /*!< 10 time quantum */
+  CAN_BTS1_11TQ                          = 0x0A, /*!< 11 time quantum */
+  CAN_BTS1_12TQ                          = 0x0B, /*!< 12 time quantum */
+  CAN_BTS1_13TQ                          = 0x0C, /*!< 13 time quantum */
+  CAN_BTS1_14TQ                          = 0x0D, /*!< 14 time quantum */
+  CAN_BTS1_15TQ                          = 0x0E, /*!< 15 time quantum */
+  CAN_BTS1_16TQ                          = 0x0F  /*!< 16 time quantum */
+} can_bts1_type;
+
+/**
+  * @brief  can bit time segment 2
+  */
+typedef enum
+{
+  CAN_BTS2_1TQ                           = 0x00, /*!< 1 time quantum */
+  CAN_BTS2_2TQ                           = 0x01, /*!< 2 time quantum */
+  CAN_BTS2_3TQ                           = 0x02, /*!< 3 time quantum */
+  CAN_BTS2_4TQ                           = 0x03, /*!< 4 time quantum */
+  CAN_BTS2_5TQ                           = 0x04, /*!< 5 time quantum */
+  CAN_BTS2_6TQ                           = 0x05, /*!< 6 time quantum */
+  CAN_BTS2_7TQ                           = 0x06, /*!< 7 time quantum */
+  CAN_BTS2_8TQ                           = 0x07  /*!< 8 time quantum */
+} can_bts2_type;
+
+/**
+  * @brief  can identifier type
+  */
+typedef enum
+{
+  CAN_ID_STANDARD                        = 0x00, /*!< standard Id */
+  CAN_ID_EXTENDED                        = 0x01  /*!< extended Id */
+} can_identifier_type;
+
+/**
+  * @brief  can transmission frame type
+  */
+typedef enum
+{
+  CAN_TFT_DATA                           = 0x00, /*!< data frame */
+  CAN_TFT_REMOTE                         = 0x01  /*!< remote frame */
+} can_trans_frame_type;
+
+/**
+  * @brief  can tx mailboxes
+  */
+typedef enum
+{
+  CAN_TX_MAILBOX0                        = 0x00, /*!< can tx mailbox 0 */
+  CAN_TX_MAILBOX1                        = 0x01, /*!< can tx mailbox 1 */
+  CAN_TX_MAILBOX2                        = 0x02  /*!< can tx mailbox 2 */
+} can_tx_mailbox_num_type;
+
+/**
+  * @brief  can receive fifo
+  */
+typedef enum
+{
+  CAN_RX_FIFO0                           = 0x00, /*!< can fifo 0 used to receive */
+  CAN_RX_FIFO1                           = 0x01  /*!< can fifo 1 used to receive */
+} can_rx_fifo_num_type;
+
+/**
+  * @brief  can transmit status
+  */
+typedef enum
+{
+  CAN_TX_STATUS_FAILED                   = 0x00, /*!< can transmission failed */
+  CAN_TX_STATUS_SUCCESSFUL               = 0x01, /*!< can transmission successful */
+  CAN_TX_STATUS_PENDING                  = 0x02, /*!< can transmission pending */
+  CAN_TX_STATUS_NO_EMPTY                 = 0x04  /*!< can transmission no empty mailbox */
+} can_transmit_status_type;
+
+/**
+  * @brief  can enter doze mode status
+  */
+typedef enum
+{
+  CAN_ENTER_DOZE_FAILED                  = 0x00, /*!< can enter the doze mode failed */
+  CAN_ENTER_DOZE_SUCCESSFUL              = 0x01  /*!< can enter the doze mode successful */
+} can_enter_doze_status_type;
+
+/**
+  * @brief  can quit doze mode status
+  */
+typedef enum
+{
+  CAN_QUIT_DOZE_FAILED                   = 0x00, /*!< can quit doze mode failed */
+  CAN_QUIT_DOZE_SUCCESSFUL               = 0x01  /*!< can quit doze mode successful */
+} can_quit_doze_status_type;
+
+/**
+  * @brief  can message discarding rule select when overflow
+  */
+typedef enum
+{
+  CAN_DISCARDING_FIRST_RECEIVED          = 0x00, /*!< can discarding the first received message */
+  CAN_DISCARDING_LAST_RECEIVED           = 0x01  /*!< can discarding the last received message */
+} can_msg_discarding_rule_type;
+
+/**
+  * @brief  can multiple message sending sequence rule
+  */
+typedef enum
+{
+  CAN_SENDING_BY_ID                      = 0x00, /*!< can sending the minimum id message first*/
+  CAN_SENDING_BY_REQUEST                 = 0x01  /*!< can sending the first request message first */
+} can_msg_sending_rule_type;
+
+/**
+  * @brief  can error type record
+  */
+typedef enum
+{
+  CAN_ERRORRECORD_NOERR                  = 0x00, /*!< no error */
+  CAN_ERRORRECORD_STUFFERR               = 0x01, /*!< stuff error */
+  CAN_ERRORRECORD_FORMERR                = 0x02, /*!< form error */
+  CAN_ERRORRECORD_ACKERR                 = 0x03, /*!< acknowledgment error */
+  CAN_ERRORRECORD_BITRECESSIVEERR        = 0x04, /*!< bit recessive error */
+  CAN_ERRORRECORD_BITDOMINANTERR         = 0x05, /*!< bit dominant error */
+  CAN_ERRORRECORD_CRCERR                 = 0x06, /*!< crc error */
+  CAN_ERRORRECORD_SOFTWARESETERR         = 0x07  /*!< software set error */
+} can_error_record_type;
+
+/**
+  * @brief  can init structure definition
+  */
+typedef struct
+{
+  can_mode_type mode_selection;          /*!< specifies the can mode.*/
+
+  confirm_state ttc_enable;              /*!< time triggered communication mode enable */
+
+  confirm_state aebo_enable;             /*!< automatic exit bus-off enable */
+
+  confirm_state aed_enable;              /*!< automatic exit doze mode enable */
+
+  confirm_state prsf_enable;             /*!< prohibit retransmission when sending fails enable */
+
+  can_msg_discarding_rule_type mdrsel_selection; /*!< message discarding rule select when overflow */
+
+  can_msg_sending_rule_type mmssr_selection;     /*!< multiple message sending sequence rule */
+
+} can_base_type;
+
+/**
+  * @brief  can baudrate structure definition
+  */
+typedef struct
+{
+  uint16_t baudrate_div;                  /*!< baudrate division,this parameter can be 0x001~0x1000.*/
+
+  can_rsaw_type rsaw_size;                /*!< resynchronization adjust width */
+
+  can_bts1_type bts1_size;                /*!< bit time segment 1 */
+
+  can_bts2_type bts2_size;                /*!< bit time segment 2 */
+
+} can_baudrate_type;
+
+/**
+  * @brief  can filter init structure definition
+  */
+typedef struct
+{
+  confirm_state filter_activate_enable;  /*!< enable or disable the filter activate.*/
+
+  can_filter_mode_type filter_mode;      /*!< config the filter mode mask or list.*/
+
+  can_filter_fifo_type filter_fifo;      /*!< config the fifo which will be assigned to the filter. */
+
+  uint8_t filter_number;                 /*!< config the filter number, parameter ranges from 0 to 13. */
+
+  can_filter_bit_width_type filter_bit;  /*!< config the filter bit width 16bit or 32bit.*/
+
+  uint16_t filter_id_high;               /*!< config the filter identification, for 32-bit configuration
+                                              it's high 16 bits, for 16-bit configuration it's first. */
+
+  uint16_t filter_id_low;                /*!< config the filter identification, for 32-bit configuration
+                                              it's low 16 bits, for 16-bit configuration it's second. */
+
+  uint16_t filter_mask_high;             /*!< config the filter mask or identification, according to the filtering mode,
+                                              for 32-bit configuration it's high 16 bits, for 16-bit configuration it's first. */
+
+  uint16_t filter_mask_low;              /*!< config the filter mask or identification, according to the filtering mode,
+                                              for 32-bit configuration it's low 16 bits, for 16-bit configuration it's second. */
+} can_filter_init_type;
+
+/**
+  * @brief  can tx message structure definition
+  */
+typedef struct
+{
+  uint32_t standard_id;                  /*!< specifies the 11 bits standard identifier.
+                                              this parameter can be a value between 0 to 0x7FF. */
+
+  uint32_t extended_id;                  /*!< specifies the 29 bits extended identifier.
+                                              this parameter can be a value between 0 to 0x1FFFFFFF. */
+
+  can_identifier_type id_type;           /*!< specifies identifier type for the transmit message.*/
+
+  can_trans_frame_type frame_type;       /*!< specifies frame type for the transmit message.*/
+
+  uint8_t dlc;                           /*!< specifies frame data length that will be transmitted.
+                                              this parameter can be a value between 0 to 8 */
+
+  uint8_t data[8];                       /*!< contains the transmit data. it ranges from 0 to 0xFF. */
+
+} can_tx_message_type;
+
+/**
+  * @brief  can rx message structure definition
+  */
+typedef struct
+{
+    uint32_t standard_id;                /*!< specifies the 11 bits standard identifier
+                                              this parameter can be a value between 0 to 0x7FF. */
+
+    uint32_t extended_id;                /*!< specifies the 29 bits extended identifier.
+                                              this parameter can be a value between 0 to 0x1FFFFFFF. */
+
+    can_identifier_type id_type;         /*!< specifies identifier type for the receive message.*/
+
+    can_trans_frame_type frame_type;     /*!< specifies frame type for the receive message.*/
+
+    uint8_t dlc;                         /*!< specifies the frame data length that will be received.
+                                              this parameter can be a value between 0 to 8 */
+
+    uint8_t data[8];                     /*!< contains the receive data. it ranges from 0 to 0xFF.*/
+
+    uint8_t filter_index;                /*!< specifies the message stored in which filter
+                                              this parameter can be a value between 0 to 0xFF */
+} can_rx_message_type;
+
+/**
+  * @brief can controller area network tx mailbox
+  */
+typedef struct
+{
+  /**
+    * @brief can tmi register
+    */
+  union
+  {
+    __IO uint32_t tmi;
+    struct
+    {
+      __IO uint32_t tmsr                 : 1; /* [0] */
+      __IO uint32_t tmfrsel              : 1; /* [1] */
+      __IO uint32_t tmidsel              : 1; /* [2] */
+      __IO uint32_t tmeid                : 18;/* [20:3] */
+      __IO uint32_t tmsid                : 11;/* [31:21] */
+    } tmi_bit;
+  };
+
+  /**
+    * @brief can tmc register
+    */
+  union
+  {
+    __IO uint32_t tmc;
+    struct
+    {
+      __IO uint32_t tmdtbl               : 4; /* [3:0] */
+      __IO uint32_t reserved1            : 4; /* [7:4] */
+      __IO uint32_t tmtsten              : 1; /* [8] */
+      __IO uint32_t reserved2            : 7; /* [15:9] */
+      __IO uint32_t tmts                 : 16;/* [31:16] */
+    } tmc_bit;
+  };
+
+  /**
+    * @brief can tmdtl register
+    */
+  union
+  {
+    __IO uint32_t tmdtl;
+    struct
+    {
+      __IO uint32_t tmdt0                : 8; /* [7:0] */
+      __IO uint32_t tmdt1                : 8; /* [15:8] */
+      __IO uint32_t tmdt2                : 8; /* [23:16] */
+      __IO uint32_t tmdt3                : 8; /* [31:24] */
+    } tmdtl_bit;
+  };
+
+  /**
+    * @brief can tmdth register
+    */
+  union
+  {
+    __IO uint32_t tmdth;
+    struct
+    {
+      __IO uint32_t tmdt4                : 8; /* [7:0] */
+      __IO uint32_t tmdt5                : 8; /* [15:8] */
+      __IO uint32_t tmdt6                : 8; /* [23:16] */
+      __IO uint32_t tmdt7                : 8; /* [31:24] */
+    } tmdth_bit;
+  };
+} can_tx_mailbox_type;
+
+/**
+  * @brief can controller area network fifo mailbox
+  */
+typedef struct
+{
+  /**
+    * @brief can rfi register
+    */
+  union
+  {
+    __IO uint32_t rfi;
+    struct
+    {
+      __IO uint32_t reserved1            : 1; /* [0] */
+      __IO uint32_t rffri                : 1; /* [1] */
+      __IO uint32_t rfidi                : 1; /* [2] */
+      __IO uint32_t rfeid                : 18;/* [20:3] */
+      __IO uint32_t rfsid                : 11;/* [31:21] */
+    } rfi_bit;
+  };
+
+  /**
+    * @brief can rfc register
+    */
+  union
+  {
+    __IO uint32_t rfc;
+    struct
+    {
+      __IO uint32_t rfdtl                : 4; /* [3:0] */
+      __IO uint32_t reserved1            : 4; /* [7:4] */
+      __IO uint32_t rffmn                : 8; /* [15:8] */
+      __IO uint32_t rfts                 : 16;/* [31:16] */
+    } rfc_bit;
+  };
+
+  /**
+    * @brief can rfdtl register
+    */
+  union
+  {
+    __IO uint32_t rfdtl;
+    struct
+    {
+      __IO uint32_t rfdt0                : 8; /* [7:0] */
+      __IO uint32_t rfdt1                : 8; /* [15:8] */
+      __IO uint32_t rfdt2                : 8; /* [23:16] */
+      __IO uint32_t rfdt3                : 8; /* [31:24] */
+    } rfdtl_bit;
+  };
+
+  /**
+    * @brief can rfdth register
+    */
+  union
+  {
+    __IO uint32_t rfdth;
+    struct
+    {
+      __IO uint32_t rfdt4                : 8; /* [7:0] */
+      __IO uint32_t rfdt5                : 8; /* [15:8] */
+      __IO uint32_t rfdt6                : 8; /* [23:16] */
+      __IO uint32_t rfdt7                : 8; /* [31:24] */
+    } rfdth_bit;
+  };
+} can_fifo_mailbox_type;
+
+/**
+  * @brief can controller area network filter bit register
+  */
+typedef struct
+{
+  __IO uint32_t ffdb1;
+  __IO uint32_t ffdb2;
+} can_filter_register_type;
+
+/**
+  * @brief type define can register all
+  */
+typedef struct
+{
+
+  /**
+    * @brief can mctrl register, offset:0x00
+    */
+  union
+  {
+    __IO uint32_t mctrl;
+    struct
+    {
+      __IO uint32_t fzen                 : 1; /* [0] */
+      __IO uint32_t dzen                 : 1; /* [1] */
+      __IO uint32_t mmssr                : 1; /* [2] */
+      __IO uint32_t mdrsel               : 1; /* [3] */
+      __IO uint32_t prsfen               : 1; /* [4] */
+      __IO uint32_t aeden                : 1; /* [5] */
+      __IO uint32_t aeboen               : 1; /* [6] */
+      __IO uint32_t ttcen                : 1; /* [7] */
+      __IO uint32_t reserved1            : 7; /* [14:8] */
+      __IO uint32_t sprst                : 1; /* [15] */
+      __IO uint32_t ptd                  : 1; /* [16] */
+      __IO uint32_t reserved2            : 15;/*[31:17] */
+    } mctrl_bit;
+  };
+
+  /**
+    * @brief can msts register, offset:0x04
+    */
+  union
+  {
+    __IO uint32_t msts;
+    struct
+    {
+      __IO uint32_t fzc                  : 1; /* [0] */
+      __IO uint32_t dzc                  : 1; /* [1] */
+      __IO uint32_t eoif                 : 1; /* [2] */
+      __IO uint32_t qdzif                : 1; /* [3] */
+      __IO uint32_t edzif                : 1; /* [4] */
+      __IO uint32_t reserved1            : 3; /* [7:5] */
+      __IO uint32_t cuss                 : 1; /* [8] */
+      __IO uint32_t curs                 : 1; /* [9] */
+      __IO uint32_t lsamprx              : 1; /* [10] */
+      __IO uint32_t realrx               : 1; /* [11] */
+      __IO uint32_t reserved2            : 20;/*[31:12] */
+    } msts_bit;
+  };
+
+   /**
+     * @brief can tsts register, offset:0x08
+     */
+  union
+  {
+    __IO uint32_t tsts;
+    struct
+    {
+      __IO uint32_t tm0tcf               : 1; /* [0] */
+      __IO uint32_t tm0tsf               : 1; /* [1] */
+      __IO uint32_t tm0alf               : 1; /* [2] */
+      __IO uint32_t tm0tef               : 1; /* [3] */
+      __IO uint32_t reserved1            : 3; /* [6:4] */
+      __IO uint32_t tm0ct                : 1; /* [7] */
+      __IO uint32_t tm1tcf               : 1; /* [8] */
+      __IO uint32_t tm1tsf               : 1; /* [9] */
+      __IO uint32_t tm1alf               : 1; /* [10] */
+      __IO uint32_t tm1tef               : 1; /* [11] */
+      __IO uint32_t reserved2            : 3; /* [14:12] */
+      __IO uint32_t tm1ct                : 1; /* [15] */
+      __IO uint32_t tm2tcf               : 1; /* [16] */
+      __IO uint32_t tm2tsf               : 1; /* [17] */
+      __IO uint32_t tm2alf               : 1; /* [18] */
+      __IO uint32_t tm2tef               : 1; /* [19] */
+      __IO uint32_t reserved3            : 3; /* [22:20] */
+      __IO uint32_t tm2ct                : 1; /* [23] */
+      __IO uint32_t tmnr                 : 2; /* [25:24] */
+      __IO uint32_t tm0ef                : 1; /* [26] */
+      __IO uint32_t tm1ef                : 1; /* [27] */
+      __IO uint32_t tm2ef                : 1; /* [28] */
+      __IO uint32_t tm0lpf               : 1; /* [29] */
+      __IO uint32_t tm1lpf               : 1; /* [30] */
+      __IO uint32_t tm2lpf               : 1; /* [31] */
+    } tsts_bit;
+  };
+
+  /**
+    * @brief can rf0 register, offset:0x0C
+    */
+  union
+  {
+    __IO uint32_t rf0;
+    struct
+    {
+      __IO uint32_t rf0mn                : 2; /* [1:0] */
+      __IO uint32_t reserved1            : 1; /* [2] */
+      __IO uint32_t rf0ff                : 1; /* [3] */
+      __IO uint32_t rf0of                : 1; /* [4] */
+      __IO uint32_t rf0r                 : 1; /* [5] */
+      __IO uint32_t reserved2            : 26;/* [31:6] */
+    } rf0_bit;
+  };
+
+  /**
+    * @brief can rf1 register, offset:0x10
+    */
+  union
+  {
+    __IO uint32_t rf1;
+    struct
+    {
+      __IO uint32_t rf1mn                : 2; /* [1:0] */
+      __IO uint32_t reserved1            : 1; /* [2] */
+      __IO uint32_t rf1ff                : 1; /* [3] */
+      __IO uint32_t rf1of                : 1; /* [4] */
+      __IO uint32_t rf1r                 : 1; /* [5] */
+      __IO uint32_t reserved2            : 26;/* [31:6] */
+    } rf1_bit;
+  };
+
+  /**
+    * @brief can inten register, offset:0x14
+    */
+  union
+  {
+    __IO uint32_t inten;
+    struct
+    {
+      __IO uint32_t tcien               : 1; /* [0] */
+      __IO uint32_t rf0mien              : 1; /* [1] */
+      __IO uint32_t rf0fien              : 1; /* [2] */
+      __IO uint32_t rf0oien              : 1; /* [3] */
+      __IO uint32_t rf1mien              : 1; /* [4] */
+      __IO uint32_t rf1fien              : 1; /* [5] */
+      __IO uint32_t rf1oien              : 1; /* [6] */
+      __IO uint32_t reserved1            : 1; /* [7] */
+      __IO uint32_t eaien                : 1; /* [8] */
+      __IO uint32_t epien                : 1; /* [9] */
+      __IO uint32_t boien                : 1; /* [10] */
+      __IO uint32_t etrien               : 1; /* [11] */
+      __IO uint32_t reserved2            : 3; /* [14:12] */
+      __IO uint32_t eoien                : 1; /* [15] */
+      __IO uint32_t qdzien               : 1; /* [16] */
+      __IO uint32_t edzien               : 1; /* [17] */
+      __IO uint32_t reserved3            : 14;/* [31:18] */
+    } inten_bit;
+  };
+
+  /**
+    * @brief can ests register, offset:0x18
+    */
+  union
+  {
+    __IO uint32_t ests;
+    struct
+    {
+      __IO uint32_t eaf                  : 1; /* [0] */
+      __IO uint32_t epf                  : 1; /* [1] */
+      __IO uint32_t bof                  : 1; /* [2] */
+      __IO uint32_t reserved1            : 1; /* [3] */
+      __IO uint32_t etr                  : 3; /* [6:4] */
+      __IO uint32_t reserved2            : 9; /* [15:7] */
+      __IO uint32_t tec                  : 8; /* [23:16] */
+      __IO uint32_t rec                  : 8; /* [31:24] */
+    } ests_bit;
+  };
+
+  /**
+    * @brief can btmg register, offset:0x1C
+    */
+  union
+  {
+    __IO uint32_t btmg;
+    struct
+    {
+      __IO uint32_t brdiv                : 12;/* [11:0] */
+      __IO uint32_t reserved1            : 4; /* [15:12] */
+      __IO uint32_t bts1                 : 4; /* [19:16] */
+      __IO uint32_t bts2                 : 3; /* [22:20] */
+      __IO uint32_t reserved2            : 1; /* [23] */
+      __IO uint32_t rsaw                 : 2; /* [25:24] */
+      __IO uint32_t reserved3            : 4; /* [29:26] */
+      __IO uint32_t lben                 : 1; /* [30] */
+      __IO uint32_t loen                 : 1; /* [31] */
+    } btmg_bit;
+  };
+
+  /**
+    * @brief can reserved register, offset:0x20~0x17C
+    */
+  __IO uint32_t reserved1[88];
+
+  /**
+    * @brief can controller area network tx mailbox register, offset:0x180~0x1AC
+    */
+  can_tx_mailbox_type tx_mailbox[3];
+
+  /**
+    * @brief can controller area network fifo mailbox register, offset:0x1B0~0x1CC
+    */
+  can_fifo_mailbox_type fifo_mailbox[2];
+
+  /**
+    * @brief can reserved register, offset:0x1D0~0x1FC
+    */
+  __IO uint32_t reserved2[12];
+
+  /**
+    * @brief can fctrl register, offset:0x200
+    */
+  union
+  {
+    __IO uint32_t fctrl;
+    struct
+    {
+      __IO uint32_t fcs                  : 1; /* [0] */
+      __IO uint32_t reserved1            : 31;/* [31:1] */
+    } fctrl_bit;
+  };
+
+  /**
+    * @brief can fmcfg register, offset:0x204
+    */
+  union
+  {
+    __IO uint32_t fmcfg;
+    struct
+    {
+      __IO uint32_t fmsel0               : 1; /* [0] */
+      __IO uint32_t fmsel1               : 1; /* [1] */
+      __IO uint32_t fmsel2               : 1; /* [2] */
+      __IO uint32_t fmsel3               : 1; /* [3] */
+      __IO uint32_t fmsel4               : 1; /* [4] */
+      __IO uint32_t fmsel5               : 1; /* [5] */
+      __IO uint32_t fmsel6               : 1; /* [6] */
+      __IO uint32_t fmsel7               : 1; /* [7] */
+      __IO uint32_t fmsel8               : 1; /* [8] */
+      __IO uint32_t fmsel9               : 1; /* [9] */
+      __IO uint32_t fmsel10              : 1; /* [10] */
+      __IO uint32_t fmsel11              : 1; /* [11] */
+      __IO uint32_t fmsel12              : 1; /* [12] */
+      __IO uint32_t fmsel13              : 1; /* [13] */
+      __IO uint32_t reserved1            : 18;/* [31:14] */
+    } fmcfg_bit;
+  };
+
+  /**
+    * @brief can reserved register, offset:0x208
+    */
+  __IO uint32_t reserved3;
+
+  /**
+    * @brief can fbwcfg register, offset:0x20C
+    */
+  union
+  {
+    __IO uint32_t fbwcfg;
+    struct
+    {
+      __IO uint32_t fbwsel0              : 1; /* [0] */
+      __IO uint32_t fbwsel1              : 1; /* [1] */
+      __IO uint32_t fbwsel2              : 1; /* [2] */
+      __IO uint32_t fbwsel3              : 1; /* [3] */
+      __IO uint32_t fbwsel4              : 1; /* [4] */
+      __IO uint32_t fbwsel5              : 1; /* [5] */
+      __IO uint32_t fbwsel6              : 1; /* [6] */
+      __IO uint32_t fbwsel7              : 1; /* [7] */
+      __IO uint32_t fbwsel8              : 1; /* [8] */
+      __IO uint32_t fbwsel9              : 1; /* [9] */
+      __IO uint32_t fbwsel10             : 1; /* [10] */
+      __IO uint32_t fbwsel11             : 1; /* [11] */
+      __IO uint32_t fbwsel12             : 1; /* [12] */
+      __IO uint32_t fbwsel13             : 1; /* [13] */
+      __IO uint32_t reserved1            : 18;/* [31:14] */
+    } fbwcfg_bit;
+  };
+
+  /**
+    * @brief can reserved register, offset:0x210
+    */
+  __IO uint32_t reserved4;
+
+  /**
+    * @brief can frf register, offset:0x214
+    */
+  union
+  {
+    __IO uint32_t frf;
+    struct
+    {
+      __IO uint32_t frfsel0              : 1; /* [0] */
+      __IO uint32_t frfsel1              : 1; /* [1] */
+      __IO uint32_t frfsel2              : 1; /* [2] */
+      __IO uint32_t frfsel3              : 1; /* [3] */
+      __IO uint32_t frfsel4              : 1; /* [4] */
+      __IO uint32_t frfsel5              : 1; /* [5] */
+      __IO uint32_t frfsel6              : 1; /* [6] */
+      __IO uint32_t frfsel7              : 1; /* [7] */
+      __IO uint32_t frfsel8              : 1; /* [8] */
+      __IO uint32_t frfsel9              : 1; /* [9] */
+      __IO uint32_t frfsel10             : 1; /* [10] */
+      __IO uint32_t frfsel11             : 1; /* [11] */
+      __IO uint32_t frfsel12             : 1; /* [12] */
+      __IO uint32_t frfsel13             : 1; /* [13] */
+      __IO uint32_t reserved1            : 18;/* [31:14] */
+    } frf_bit;
+  };
+
+  /**
+    * @brief can reserved register, offset:0x218
+    */
+  __IO uint32_t reserved5;
+
+  /**
+    * @brief can facfg register, offset:0x21C
+    */
+  union
+  {
+    __IO uint32_t facfg;
+    struct
+    {
+      __IO uint32_t faen0                : 1; /* [0] */
+      __IO uint32_t faen1                : 1; /* [1] */
+      __IO uint32_t faen2                : 1; /* [2] */
+      __IO uint32_t faen3                : 1; /* [3] */
+      __IO uint32_t faen4                : 1; /* [4] */
+      __IO uint32_t faen5                : 1; /* [5] */
+      __IO uint32_t faen6                : 1; /* [6] */
+      __IO uint32_t faen7                : 1; /* [7] */
+      __IO uint32_t faen8                : 1; /* [8] */
+      __IO uint32_t faen9                : 1; /* [9] */
+      __IO uint32_t faen10               : 1; /* [10] */
+      __IO uint32_t faen11               : 1; /* [11] */
+      __IO uint32_t faen12               : 1; /* [12] */
+      __IO uint32_t faen13               : 1; /* [13] */
+      __IO uint32_t reserved1            : 18;/* [31:14] */
+    } facfg_bit;
+  };
+
+  /**
+    * @brief can reserved register, offset:0x220~0x23C
+    */
+  __IO uint32_t reserved6[8];
+
+  /**
+    * @brief can ffb register, offset:0x240~0x2AC
+    */
+  can_filter_register_type ffb[14];
+} can_type;
+
+/**
+  * @}
+  */
+
+#define CAN1                             ((can_type *) CAN1_BASE)
+#define CAN2                             ((can_type *) CAN2_BASE)
+
+/** @defgroup CAN_exported_functions
+  * @{
+  */
+
+void can_reset(can_type* can_x);
+void can_baudrate_default_para_init(can_baudrate_type* can_baudrate_struct);
+error_status can_baudrate_set(can_type* can_x, can_baudrate_type* can_baudrate_struct);
+void can_default_para_init(can_base_type* can_base_struct);
+error_status can_base_init(can_type* can_x, can_base_type* can_base_struct);
+void can_filter_default_para_init(can_filter_init_type* can_filter_init_struct);
+void can_filter_init(can_type* can_x, can_filter_init_type* can_filter_init_struct);
+void can_debug_transmission_prohibit(can_type* can_x, confirm_state new_state);
+void can_ttc_mode_enable(can_type* can_x, confirm_state new_state);
+uint8_t can_message_transmit(can_type* can_x, can_tx_message_type* tx_message_struct);
+can_transmit_status_type can_transmit_status_get(can_type* can_x, can_tx_mailbox_num_type transmit_mailbox);
+void can_transmit_cancel(can_type* can_x, can_tx_mailbox_num_type transmit_mailbox);
+void can_message_receive(can_type* can_x, can_rx_fifo_num_type fifo_number, can_rx_message_type* rx_message_struct);
+void can_receive_fifo_release(can_type* can_x, can_rx_fifo_num_type fifo_number);
+uint8_t can_receive_message_pending_get(can_type* can_x, can_rx_fifo_num_type fifo_number);
+error_status can_operating_mode_set(can_type* can_x, can_operating_mode_type can_operating_mode);
+can_enter_doze_status_type can_doze_mode_enter(can_type* can_x);
+can_quit_doze_status_type can_doze_mode_exit(can_type* can_x);
+can_error_record_type can_error_type_record_get(can_type* can_x);
+uint8_t can_receive_error_counter_get(can_type* can_x);
+uint8_t can_transmit_error_counter_get(can_type* can_x);
+void can_interrupt_enable(can_type* can_x, uint32_t can_int, confirm_state new_state);
+flag_status can_interrupt_flag_get(can_type* can_x, uint32_t can_flag);
+flag_status can_flag_get(can_type* can_x, uint32_t can_flag);
+void can_flag_clear(can_type* can_x, uint32_t can_flag);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_conf.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_conf.h
@@ -1,0 +1,154 @@
+/**
+ * *************************************************************************
+ * @file     at32f423_conf.h
+ * @brief    at32f423 config header file
+ **************************************************************************
+ *
+ * Copyright (c) 2025, Artery Technology, All rights reserved.
+ *
+ * The software Board Support Package (BSP) that is made available to
+ * download from Artery official website is the copyrighted work of Artery.
+ * Artery authorizes customers to use, copy, and distribute the BSP
+ * software and its related documentation for the purpose of design and
+ * development in conjunction with Artery microcontrollers. Use of the
+ * software is governed by this copyright notice and the following disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+ * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+ * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+ * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+ * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+ *
+ **************************************************************************
+ */
+
+/* define to prevent recursive inclusion -------------------------------------*/
+#ifndef __AT32F423_CONF_H
+#define __AT32F423_CONF_H
+
+#ifdef __cplusplus
+extern "C" {
+  #endif
+  
+  /**
+   * @brief in the following line adjust the value of high speed external crystal (hext)
+   * used in your application
+   *
+   * tip: to avoid modifying this file each time you need to use different hext, you
+   *      can define the hext value in your toolchain compiler preprocessor.
+   *
+   */
+  #if !defined  HEXT_VALUE
+  #define HEXT_VALUE                       ((uint32_t)8000000) /*!< value of the high speed external crystal in hz */
+  #endif
+  
+  /**
+   * @brief in the following line adjust the high speed external crystal (hext) startup
+   * timeout value
+   */
+  #define HEXT_STARTUP_TIMEOUT             ((uint16_t)0x3000)  /*!< time out for hext start up */
+  #define HICK_VALUE                       ((uint32_t)8000000) /*!< value of the high speed internal clock in hz */
+  #define LEXT_VALUE                       ((uint32_t)32768)   /*!< value of the low speed external clock in hz */
+  
+  /* module define -------------------------------------------------------------*/
+  #define CRM_MODULE_ENABLED
+  #define TMR_MODULE_ENABLED
+  #define ERTC_MODULE_ENABLED
+  #define GPIO_MODULE_ENABLED
+  #define I2C_MODULE_ENABLED
+  #define USART_MODULE_ENABLED
+  #define PWC_MODULE_ENABLED
+  #define CAN_MODULE_ENABLED
+  #define ADC_MODULE_ENABLED
+  #define DAC_MODULE_ENABLED
+  #define SPI_MODULE_ENABLED
+  #define DMA_MODULE_ENABLED
+  #define DEBUG_MODULE_ENABLED
+  #define FLASH_MODULE_ENABLED
+  #define CRC_MODULE_ENABLED
+  #define WWDT_MODULE_ENABLED
+  #define WDT_MODULE_ENABLED
+  #define EXINT_MODULE_ENABLED
+  #define XMC_MODULE_ENABLED
+  #define USB_MODULE_ENABLED
+  #define ACC_MODULE_ENABLED
+  #define MISC_MODULE_ENABLED
+  #define SCFG_MODULE_ENABLED
+  
+  /* includes ------------------------------------------------------------------*/
+  #ifdef CRM_MODULE_ENABLED
+  #include "at32f423_crm.h"
+  #endif
+  #ifdef TMR_MODULE_ENABLED
+  #include "at32f423_tmr.h"
+  #endif
+  #ifdef ERTC_MODULE_ENABLED
+  #include "at32f423_ertc.h"
+  #endif
+  #ifdef GPIO_MODULE_ENABLED
+  #include "at32f423_gpio.h"
+  #endif
+  #ifdef I2C_MODULE_ENABLED
+  #include "at32f423_i2c.h"
+  #endif
+  #ifdef USART_MODULE_ENABLED
+  #include "at32f423_usart.h"
+  #endif
+  #ifdef PWC_MODULE_ENABLED
+  #include "at32f423_pwc.h"
+  #endif
+  #ifdef CAN_MODULE_ENABLED
+  #include "at32f423_can.h"
+  #endif
+  #ifdef ADC_MODULE_ENABLED
+  #include "at32f423_adc.h"
+  #endif
+  #ifdef DAC_MODULE_ENABLED
+  #include "at32f423_dac.h"
+  #endif
+  #ifdef SPI_MODULE_ENABLED
+  #include "at32f423_spi.h"
+  #endif
+  #ifdef DMA_MODULE_ENABLED
+  #include "at32f423_dma.h"
+  #endif
+  #ifdef DEBUG_MODULE_ENABLED
+  #include "at32f423_debug.h"
+  #endif
+  #ifdef FLASH_MODULE_ENABLED
+  #include "at32f423_flash.h"
+  #endif
+  #ifdef CRC_MODULE_ENABLED
+  #include "at32f423_crc.h"
+  #endif
+  #ifdef WWDT_MODULE_ENABLED
+  #include "at32f423_wwdt.h"
+  #endif
+  #ifdef WDT_MODULE_ENABLED
+  #include "at32f423_wdt.h"
+  #endif
+  #ifdef EXINT_MODULE_ENABLED
+  #include "at32f423_exint.h"
+  #endif
+  #ifdef XMC_MODULE_ENABLED
+  #include "at32f423_xmc.h"
+  #endif
+  #ifdef ACC_MODULE_ENABLED
+  #include "at32f423_acc.h"
+  #endif
+  #ifdef MISC_MODULE_ENABLED
+  #include "at32f423_misc.h"
+  #endif
+  #ifdef SCFG_MODULE_ENABLED
+  #include "at32f423_scfg.h"
+  #endif
+  #ifdef USB_MODULE_ENABLED
+  #include "at32f423_usb.h"
+  #endif
+  
+  #ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_crc.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_crc.h
@@ -1,0 +1,199 @@
+/**
+  **************************************************************************
+  * @file     at32f423_crc.h
+  * @brief    at32f423 crc header file
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+/* define to prevent recursive inclusion -------------------------------------*/
+#ifndef __AT32F423_CRC_H
+#define __AT32F423_CRC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* includes ------------------------------------------------------------------*/
+#include "at32f423.h"
+
+/** @addtogroup AT32F423_periph_driver
+  * @{
+  */
+
+/** @addtogroup  CRC
+  * @{
+  */
+
+/** @defgroup CRC_exported_types
+  * @{
+  */
+
+/**
+  * @brief crc reverse input data
+  */
+typedef enum
+{
+  CRC_REVERSE_INPUT_NO_AFFECTE           = 0x00, /*!< input data no reverse */
+  CRC_REVERSE_INPUT_BY_BYTE              = 0x01, /*!< input data reverse by byte */
+  CRC_REVERSE_INPUT_BY_HALFWORD          = 0x02, /*!< input data reverse by half word */
+  CRC_REVERSE_INPUT_BY_WORD              = 0x03  /*!< input data reverse by word */
+} crc_reverse_input_type;
+
+/**
+  * @brief crc reverse output data
+  */
+typedef enum
+{
+  CRC_REVERSE_OUTPUT_NO_AFFECTE          = 0x00, /*!< output data no reverse */
+  CRC_REVERSE_OUTPUT_DATA                = 0x01  /*!< output data reverse by word */
+} crc_reverse_output_type;
+
+/**
+  * @brief crc polynomial size
+  */
+typedef enum
+{
+  CRC_POLY_SIZE_32B                      = 0x00, /*!< polynomial size 32 bits */
+  CRC_POLY_SIZE_16B                      = 0x01, /*!< polynomial size 16 bits */
+  CRC_POLY_SIZE_8B                       = 0x02, /*!< polynomial size 8 bits */
+  CRC_POLY_SIZE_7B                       = 0x03  /*!< polynomial size 7 bits */
+} crc_poly_size_type;
+
+/**
+ * @brief type define crc register all
+ */
+typedef struct
+{
+  /**
+    * @brief crc dt register, offset:0x00
+    */
+  union
+  {
+    __IO uint32_t dt;
+    struct
+    {
+      __IO uint32_t dt                   : 32; /* [31:0] */
+    } dt_bit;
+  };
+
+  /**
+    * @brief crc cdt register, offset:0x04
+    */
+  union
+  {
+    __IO uint32_t cdt;
+    struct
+    {
+      __IO uint32_t cdt                  : 8 ; /* [7:0] */
+      __IO uint32_t reserved1            : 24 ;/* [31:8] */
+    } cdt_bit;
+  };
+
+  /**
+    * @brief crc ctrl register, offset:0x08 
+    */
+  union
+  {
+    __IO uint32_t ctrl;
+    struct
+    {
+      __IO uint32_t rst                  : 1 ; /* [0] */
+      __IO uint32_t reserved1            : 2 ; /* [2:1] */
+      __IO uint32_t poly_size            : 2 ; /* [4:3] */
+      __IO uint32_t revid                : 2 ; /* [6:5] */
+      __IO uint32_t revod                : 1 ; /* [7] */
+      __IO uint32_t reserved2            : 24 ;/* [31:8] */
+    } ctrl_bit;
+  };
+
+  /**
+    * @brief crm reserved1 register, offset:0x0C
+    */
+  __IO uint32_t reserved1;
+
+  /**
+    * @brief crc idt register, offset:0x10
+    */
+  union
+  {
+    __IO uint32_t idt;
+    struct
+    {
+      __IO uint32_t idt                  : 32; /* [31:0] */
+    } idt_bit;
+  };
+
+  /**
+    * @brief crc polynomial register, offset:0x14 
+    */
+  union
+  {
+    __IO uint32_t poly;
+    struct
+    {
+      __IO uint32_t poly                 : 32; /* [31:0] */
+    } poly_bit;
+  };
+
+} crc_type;
+
+/**
+  * @}
+  */
+
+#define CRC                              ((crc_type *) CRC_BASE)
+
+/** @defgroup CRC_exported_functions
+  * @{
+  */
+
+void crc_data_reset(void);
+uint32_t crc_one_word_calculate(uint32_t data);
+uint32_t crc_block_calculate(uint32_t *pbuffer, uint32_t length);
+uint32_t crc_data_get(void);
+void crc_common_data_set(uint8_t cdt_value);
+uint8_t crc_common_data_get(void);
+void crc_init_data_set(uint32_t value);
+void crc_reverse_input_data_set(crc_reverse_input_type value);
+void crc_reverse_output_data_set(crc_reverse_output_type value);
+void crc_poly_value_set(uint32_t value);
+uint32_t crc_poly_value_get(void);
+void crc_poly_size_set(crc_poly_size_type size);
+crc_poly_size_type crc_poly_size_get(void);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_crm.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_crm.h
@@ -1,0 +1,1238 @@
+/**
+  **************************************************************************
+  * @file     at32f423_crm.h
+  * @brief    at32f423 crm header file
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+/* define to prevent recursive inclusion -------------------------------------*/
+#ifndef __AT32F423_CRM_H
+#define __AT32F423_CRM_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* includes ------------------------------------------------------------------*/
+#include "at32f423.h"
+
+/** @addtogroup AT32F423_periph_driver
+  * @{
+  */
+
+/** @addtogroup CRM
+  * @{
+  */
+
+#define CRM_REG(value)                   PERIPH_REG(CRM_BASE, value)
+#define CRM_REG_BIT(value)               PERIPH_REG_BIT(value)
+
+/** @defgroup CRM_flags_definition
+  * @brief crm flag
+  * @{
+  */
+
+#define CRM_HICK_STABLE_FLAG             MAKE_VALUE(0x00, 1)  /*!< high speed internal clock stable flag */
+#define CRM_HEXT_STABLE_FLAG             MAKE_VALUE(0x00, 17) /*!< high speed external crystal stable flag */
+#define CRM_PLL_STABLE_FLAG              MAKE_VALUE(0x00, 25) /*!< phase locking loop stable flag */
+#define CRM_LEXT_STABLE_FLAG             MAKE_VALUE(0x70, 1)  /*!< low speed external crystal stable flag */
+#define CRM_LICK_STABLE_FLAG             MAKE_VALUE(0x74, 1)  /*!< low speed internal clock stable flag */
+#define CRM_ALL_RESET_FLAG               MAKE_VALUE(0x74, 24) /*!< all reset flag */
+#define CRM_NRST_RESET_FLAG              MAKE_VALUE(0x74, 26) /*!< nrst pin reset flag */
+#define CRM_POR_RESET_FLAG               MAKE_VALUE(0x74, 27) /*!< power on reset flag */
+#define CRM_SW_RESET_FLAG                MAKE_VALUE(0x74, 28) /*!< software reset flag */
+#define CRM_WDT_RESET_FLAG               MAKE_VALUE(0x74, 29) /*!< watchdog timer reset flag */
+#define CRM_WWDT_RESET_FLAG              MAKE_VALUE(0x74, 30) /*!< window watchdog timer reset flag */
+#define CRM_LOWPOWER_RESET_FLAG          MAKE_VALUE(0x74, 31) /*!< low-power reset flag */
+#define CRM_LICK_READY_INT_FLAG          MAKE_VALUE(0x0C, 0)  /*!< low speed internal clock stable interrupt ready flag */
+#define CRM_LEXT_READY_INT_FLAG          MAKE_VALUE(0x0C, 1)  /*!< low speed external crystal stable interrupt ready flag */
+#define CRM_HICK_READY_INT_FLAG          MAKE_VALUE(0x0C, 2)  /*!< high speed internal clock stable interrupt ready flag */
+#define CRM_HEXT_READY_INT_FLAG          MAKE_VALUE(0x0C, 3)  /*!< high speed external crystal stable interrupt ready flag */
+#define CRM_PLL_READY_INT_FLAG           MAKE_VALUE(0x0C, 4)  /*!< phase locking loop stable interrupt ready flag */
+#define CRM_CLOCK_FAILURE_INT_FLAG       MAKE_VALUE(0x0C, 7)  /*!< clock failure interrupt ready flag */
+
+/**
+  * @}
+  */
+
+/** @defgroup CRM_interrupts_definition
+  * @brief crm interrupt
+  * @{
+  */
+
+#define CRM_LICK_STABLE_INT              ((uint32_t)0x00000100) /*!< low speed internal clock stable interrupt */
+#define CRM_LEXT_STABLE_INT              ((uint32_t)0x00000200) /*!< low speed external crystal stable interrupt */
+#define CRM_HICK_STABLE_INT              ((uint32_t)0x00000400) /*!< high speed internal clock stable interrupt */
+#define CRM_HEXT_STABLE_INT              ((uint32_t)0x00000800) /*!< high speed external crystal stable interrupt */
+#define CRM_PLL_STABLE_INT               ((uint32_t)0x00001000) /*!< phase locking loop stable interrupt */
+#define CRM_CLOCK_FAILURE_INT            ((uint32_t)0x00800000) /*!< clock failure interrupt */
+
+/**
+  * @}
+  */
+
+/** @defgroup CRM_exported_types
+  * @{
+  */
+
+/**
+  * @brief crm periph clock
+  */
+typedef enum
+{
+  /* ahb periph1 */
+  CRM_GPIOA_PERIPH_CLOCK                 = MAKE_VALUE(0x30, 0),  /*!< gpioa periph clock */
+  CRM_GPIOB_PERIPH_CLOCK                 = MAKE_VALUE(0x30, 1),  /*!< gpiob periph clock */
+  CRM_GPIOC_PERIPH_CLOCK                 = MAKE_VALUE(0x30, 2),  /*!< gpioc periph clock */
+  CRM_GPIOD_PERIPH_CLOCK                 = MAKE_VALUE(0x30, 3),  /*!< gpiod periph clock */
+  CRM_GPIOE_PERIPH_CLOCK                 = MAKE_VALUE(0x30, 4),  /*!< gpioe periph clock */
+  CRM_GPIOF_PERIPH_CLOCK                 = MAKE_VALUE(0x30, 5),  /*!< gpiof periph clock */
+  CRM_CRC_PERIPH_CLOCK                   = MAKE_VALUE(0x30, 12), /*!< crc periph clock */
+  CRM_DMA1_PERIPH_CLOCK                  = MAKE_VALUE(0x30, 22), /*!< dma1 periph clock */
+  CRM_DMA2_PERIPH_CLOCK                  = MAKE_VALUE(0x30, 24), /*!< dma2 periph clock */
+  /* ahb periph2 */
+  CRM_OTGFS1_PERIPH_CLOCK                = MAKE_VALUE(0x34, 7),  /*!< otgfs1 periph clock */
+  /* ahb periph3 */
+  CRM_XMC_PERIPH_CLOCK                   = MAKE_VALUE(0x38, 0),  /*!< xmc periph clock */
+  /* apb1 periph */
+  CRM_TMR2_PERIPH_CLOCK                  = MAKE_VALUE(0x40, 0),  /*!< tmr2 periph clock */
+  CRM_TMR3_PERIPH_CLOCK                  = MAKE_VALUE(0x40, 1),  /*!< tmr3 periph clock */
+  CRM_TMR4_PERIPH_CLOCK                  = MAKE_VALUE(0x40, 2),  /*!< tmr4 periph clock */
+  CRM_TMR6_PERIPH_CLOCK                  = MAKE_VALUE(0x40, 4),  /*!< tmr6 periph clock */
+  CRM_TMR7_PERIPH_CLOCK                  = MAKE_VALUE(0x40, 5),  /*!< tmr7 periph clock */
+  CRM_TMR12_PERIPH_CLOCK                 = MAKE_VALUE(0x40, 6),  /*!< tmr12 periph clock */
+  CRM_TMR13_PERIPH_CLOCK                 = MAKE_VALUE(0x40, 7),  /*!< tmr13 periph clock */
+  CRM_TMR14_PERIPH_CLOCK                 = MAKE_VALUE(0x40, 8),  /*!< tmr14 periph clock */
+  CRM_WWDT_PERIPH_CLOCK                  = MAKE_VALUE(0x40, 11), /*!< wwdt periph clock */
+  CRM_SPI2_PERIPH_CLOCK                  = MAKE_VALUE(0x40, 14), /*!< spi2 periph clock */
+  CRM_SPI3_PERIPH_CLOCK                  = MAKE_VALUE(0x40, 15), /*!< spi3 periph clock */
+  CRM_USART2_PERIPH_CLOCK                = MAKE_VALUE(0x40, 17), /*!< usart2 periph clock */
+  CRM_USART3_PERIPH_CLOCK                = MAKE_VALUE(0x40, 18), /*!< usart3 periph clock */
+  CRM_USART4_PERIPH_CLOCK                = MAKE_VALUE(0x40, 19), /*!< usart4 periph clock */
+  CRM_USART5_PERIPH_CLOCK                = MAKE_VALUE(0x40, 20), /*!< usart5 periph clock */
+  CRM_I2C1_PERIPH_CLOCK                  = MAKE_VALUE(0x40, 21), /*!< i2c1 periph clock */
+  CRM_I2C2_PERIPH_CLOCK                  = MAKE_VALUE(0x40, 22), /*!< i2c2 periph clock */
+  CRM_I2C3_PERIPH_CLOCK                  = MAKE_VALUE(0x40, 23), /*!< i2c3 periph clock */
+  CRM_CAN1_PERIPH_CLOCK                  = MAKE_VALUE(0x40, 25), /*!< can1 periph clock */
+  CRM_CAN2_PERIPH_CLOCK                  = MAKE_VALUE(0x40, 26), /*!< can2 periph clock */
+  CRM_PWC_PERIPH_CLOCK                   = MAKE_VALUE(0x40, 28), /*!< pwc periph clock */
+  CRM_DAC_PERIPH_CLOCK                   = MAKE_VALUE(0x40, 29), /*!< dac periph clock */
+  CRM_USART7_PERIPH_CLOCK                = MAKE_VALUE(0x40, 30), /*!< usart7 periph clock */
+  CRM_USART8_PERIPH_CLOCK                = MAKE_VALUE(0x40, 31), /*!< usart8 periph clock */
+  /* apb2 periph */
+  CRM_TMR1_PERIPH_CLOCK                  = MAKE_VALUE(0x44, 0),  /*!< tmr1 periph clock */
+  CRM_USART1_PERIPH_CLOCK                = MAKE_VALUE(0x44, 4),  /*!< usart1 periph clock */
+  CRM_USART6_PERIPH_CLOCK                = MAKE_VALUE(0x44, 5),  /*!< usart6 periph clock */
+  CRM_ADC1_PERIPH_CLOCK                  = MAKE_VALUE(0x44, 8),  /*!< adc1 periph clock */
+  CRM_SPI1_PERIPH_CLOCK                  = MAKE_VALUE(0x44, 12), /*!< spi1 periph clock */
+  CRM_SCFG_PERIPH_CLOCK                  = MAKE_VALUE(0x44, 14), /*!< scfg periph clock */
+  CRM_TMR9_PERIPH_CLOCK                  = MAKE_VALUE(0x44, 16), /*!< tmr9 periph clock */
+  CRM_TMR10_PERIPH_CLOCK                 = MAKE_VALUE(0x44, 17), /*!< tmr10 periph clock */
+  CRM_TMR11_PERIPH_CLOCK                 = MAKE_VALUE(0x44, 18), /*!< tmr11 periph clock */
+  CRM_ACC_PERIPH_CLOCK                   = MAKE_VALUE(0x44, 29)  /*!< acc periph clock */
+
+} crm_periph_clock_type;
+
+/**
+  * @brief crm periph reset
+  */
+typedef enum
+{
+  /* ahb periph1 */
+  CRM_GPIOA_PERIPH_RESET                 = MAKE_VALUE(0x10, 0),  /*!< gpioa periph reset */
+  CRM_GPIOB_PERIPH_RESET                 = MAKE_VALUE(0x10, 1),  /*!< gpiob periph reset */
+  CRM_GPIOC_PERIPH_RESET                 = MAKE_VALUE(0x10, 2),  /*!< gpioc periph reset */
+  CRM_GPIOD_PERIPH_RESET                 = MAKE_VALUE(0x10, 3),  /*!< gpiod periph reset */
+  CRM_GPIOE_PERIPH_RESET                 = MAKE_VALUE(0x10, 4),  /*!< gpioe periph reset */
+  CRM_GPIOF_PERIPH_RESET                 = MAKE_VALUE(0x10, 5),  /*!< gpiof periph reset */
+  CRM_CRC_PERIPH_RESET                   = MAKE_VALUE(0x10, 12), /*!< crc periph reset */
+  CRM_DMA1_PERIPH_RESET                  = MAKE_VALUE(0x10, 22), /*!< dma1 periph reset */
+  CRM_DMA2_PERIPH_RESET                  = MAKE_VALUE(0x10, 24), /*!< dma2 periph reset */
+  /* ahb periph2 */
+  CRM_OTGFS1_PERIPH_RESET                = MAKE_VALUE(0x14, 7),  /*!< otgfs1 periph reset */
+  /* ahb periph3 */
+  CRM_XMC_PERIPH_RESET                   = MAKE_VALUE(0x18, 0),  /*!< xmc periph reset */
+  /* apb1 periph */
+  CRM_TMR2_PERIPH_RESET                  = MAKE_VALUE(0x20, 0),  /*!< tmr2 periph reset */
+  CRM_TMR3_PERIPH_RESET                  = MAKE_VALUE(0x20, 1),  /*!< tmr3 periph reset */
+  CRM_TMR4_PERIPH_RESET                  = MAKE_VALUE(0x20, 2),  /*!< tmr4 periph reset */
+  CRM_TMR6_PERIPH_RESET                  = MAKE_VALUE(0x20, 4),  /*!< tmr6 periph reset */
+  CRM_TMR7_PERIPH_RESET                  = MAKE_VALUE(0x20, 5),  /*!< tmr7 periph reset */
+  CRM_TMR12_PERIPH_RESET                 = MAKE_VALUE(0x20, 6),  /*!< tmr12 periph reset */
+  CRM_TMR13_PERIPH_RESET                 = MAKE_VALUE(0x20, 7),  /*!< tmr13 periph reset */
+  CRM_TMR14_PERIPH_RESET                 = MAKE_VALUE(0x20, 8),  /*!< tmr14 periph reset */
+  CRM_WWDT_PERIPH_RESET                  = MAKE_VALUE(0x20, 11), /*!< wwdt periph reset */
+  CRM_SPI2_PERIPH_RESET                  = MAKE_VALUE(0x20, 14), /*!< spi2 periph reset */
+  CRM_SPI3_PERIPH_RESET                  = MAKE_VALUE(0x20, 15), /*!< spi3 periph reset */
+  CRM_USART2_PERIPH_RESET                = MAKE_VALUE(0x20, 17), /*!< usart2 periph reset */
+  CRM_USART3_PERIPH_RESET                = MAKE_VALUE(0x20, 18), /*!< usart3 periph reset */
+  CRM_USART4_PERIPH_RESET                = MAKE_VALUE(0x20, 19), /*!< usart4 periph reset */
+  CRM_USART5_PERIPH_RESET                = MAKE_VALUE(0x20, 20), /*!< usart5 periph reset */
+  CRM_I2C1_PERIPH_RESET                  = MAKE_VALUE(0x20, 21), /*!< i2c1 periph reset */
+  CRM_I2C2_PERIPH_RESET                  = MAKE_VALUE(0x20, 22), /*!< i2c2 periph reset */
+  CRM_I2C3_PERIPH_RESET                  = MAKE_VALUE(0x20, 23), /*!< i2c3 periph reset */
+  CRM_CAN1_PERIPH_RESET                  = MAKE_VALUE(0x20, 25), /*!< can1 periph reset */
+  CRM_CAN2_PERIPH_RESET                  = MAKE_VALUE(0x20, 26), /*!< can2 periph reset */
+  CRM_PWC_PERIPH_RESET                   = MAKE_VALUE(0x20, 28), /*!< pwc periph reset */
+  CRM_DAC_PERIPH_RESET                   = MAKE_VALUE(0x20, 29), /*!< dac periph reset */
+  CRM_USART7_PERIPH_RESET                = MAKE_VALUE(0x20, 30), /*!< usart7 periph reset */
+  CRM_USART8_PERIPH_RESET                = MAKE_VALUE(0x20, 31), /*!< usart8 periph reset */
+  /* apb2 periph */
+  CRM_TMR1_PERIPH_RESET                  = MAKE_VALUE(0x24, 0),  /*!< tmr1 periph reset */
+  CRM_USART1_PERIPH_RESET                = MAKE_VALUE(0x24, 4),  /*!< usart1 periph reset */
+  CRM_USART6_PERIPH_RESET                = MAKE_VALUE(0x24, 5),  /*!< usart6 periph reset */
+  CRM_ADC_PERIPH_RESET                   = MAKE_VALUE(0x24, 8),  /*!< adc periph reset */
+  CRM_SPI1_PERIPH_RESET                  = MAKE_VALUE(0x24, 12), /*!< spi1 periph reset */
+  CRM_SCFG_PERIPH_RESET                  = MAKE_VALUE(0x24, 14), /*!< scfg periph reset */
+  CRM_TMR9_PERIPH_RESET                  = MAKE_VALUE(0x24, 16), /*!< tmr9 periph reset */
+  CRM_TMR10_PERIPH_RESET                 = MAKE_VALUE(0x24, 17), /*!< tmr10 periph reset */
+  CRM_TMR11_PERIPH_RESET                 = MAKE_VALUE(0x24, 18), /*!< tmr11 periph reset */
+  CRM_ACC_PERIPH_RESET                   = MAKE_VALUE(0x24, 29)  /*!< acc periph reset */
+
+} crm_periph_reset_type;
+
+/**
+  * @brief crm periph clock in low power mode
+  */
+typedef enum
+{
+  /* ahb periph1 */
+  CRM_GPIOA_PERIPH_LOWPOWER              = MAKE_VALUE(0x50, 0),  /*!< gpioa sleep mode periph clock */
+  CRM_GPIOB_PERIPH_LOWPOWER              = MAKE_VALUE(0x50, 1),  /*!< gpiob sleep mode periph clock */
+  CRM_GPIOC_PERIPH_LOWPOWER              = MAKE_VALUE(0x50, 2),  /*!< gpioc sleep mode periph clock */
+  CRM_GPIOD_PERIPH_LOWPOWER              = MAKE_VALUE(0x50, 3),  /*!< gpiod sleep mode periph clock */
+  CRM_GPIOE_PERIPH_LOWPOWER              = MAKE_VALUE(0x50, 4),  /*!< gpioe sleep mode periph clock */
+  CRM_GPIOF_PERIPH_LOWPOWER              = MAKE_VALUE(0x50, 5),  /*!< gpiof sleep mode periph clock */
+  CRM_CRC_PERIPH_LOWPOWER                = MAKE_VALUE(0x50, 12), /*!< crc sleep mode periph clock */
+  CRM_FLASH_PERIPH_LOWPOWER              = MAKE_VALUE(0x50, 15), /*!< flash sleep mode periph clock */
+  CRM_SRAM_PERIPH_LOWPOWER               = MAKE_VALUE(0x50, 16), /*!< sram sleep mode periph clock */
+  CRM_DMA1_PERIPH_LOWPOWER               = MAKE_VALUE(0x50, 22), /*!< dma1 sleep mode periph clock */
+  CRM_DMA2_PERIPH_LOWPOWER               = MAKE_VALUE(0x50, 24), /*!< dma2 sleep mode periph clock */
+  /* ahb periph2 */
+  CRM_OTGFS1_PERIPH_LOWPOWER             = MAKE_VALUE(0x54, 7),  /*!< otgfs1 sleep mode periph clock */
+  /* ahb periph3 */
+  CRM_XMC_PERIPH_LOWPOWER                = MAKE_VALUE(0x58, 0),  /*!< xmc sleep mode periph clock */
+  /* apb1 periph */
+  CRM_TMR2_PERIPH_LOWPOWER               = MAKE_VALUE(0x60, 0),  /*!< tmr2 sleep mode periph clock */
+  CRM_TMR3_PERIPH_LOWPOWER               = MAKE_VALUE(0x60, 1),  /*!< tmr3 sleep mode periph clock */
+  CRM_TMR4_PERIPH_LOWPOWER               = MAKE_VALUE(0x60, 2),  /*!< tmr4 sleep mode periph clock */
+  CRM_TMR6_PERIPH_LOWPOWER               = MAKE_VALUE(0x60, 4),  /*!< tmr6 sleep mode periph clock */
+  CRM_TMR7_PERIPH_LOWPOWER               = MAKE_VALUE(0x60, 5),  /*!< tmr7 sleep mode periph clock */
+  CRM_TMR12_PERIPH_LOWPOWER              = MAKE_VALUE(0x60, 6),  /*!< tmr12 sleep mode periph clock */
+  CRM_TMR13_PERIPH_LOWPOWER              = MAKE_VALUE(0x60, 7),  /*!< tmr13 sleep mode periph clock */
+  CRM_TMR14_PERIPH_LOWPOWER              = MAKE_VALUE(0x60, 8),  /*!< tmr14 sleep mode periph clock */
+  CRM_WWDT_PERIPH_LOWPOWER               = MAKE_VALUE(0x60, 11), /*!< wwdt sleep mode periph clock */
+  CRM_SPI2_PERIPH_LOWPOWER               = MAKE_VALUE(0x60, 14), /*!< spi2 sleep mode periph clock */
+  CRM_SPI3_PERIPH_LOWPOWER               = MAKE_VALUE(0x60, 15), /*!< spi3 sleep mode periph clock */
+  CRM_USART2_PERIPH_LOWPOWER             = MAKE_VALUE(0x60, 17), /*!< usart2 sleep mode periph clock */
+  CRM_USART3_PERIPH_LOWPOWER             = MAKE_VALUE(0x60, 18), /*!< usart3 sleep mode periph clock */
+  CRM_USART4_PERIPH_LOWPOWER             = MAKE_VALUE(0x60, 19), /*!< usart4 sleep mode periph clock */
+  CRM_USART5_PERIPH_LOWPOWER             = MAKE_VALUE(0x60, 20), /*!< usart5 sleep mode periph clock */
+  CRM_I2C1_PERIPH_LOWPOWER               = MAKE_VALUE(0x60, 21), /*!< i2c1 sleep mode periph clock */
+  CRM_I2C2_PERIPH_LOWPOWER               = MAKE_VALUE(0x60, 22), /*!< i2c2 sleep mode periph clock */
+  CRM_I2C3_PERIPH_LOWPOWER               = MAKE_VALUE(0x60, 23), /*!< i2c3 sleep mode periph clock */
+  CRM_CAN1_PERIPH_LOWPOWER               = MAKE_VALUE(0x60, 25), /*!< can1 sleep mode periph clock */
+  CRM_CAN2_PERIPH_LOWPOWER               = MAKE_VALUE(0x60, 26), /*!< can2 sleep mode periph clock */
+  CRM_PWC_PERIPH_LOWPOWER                = MAKE_VALUE(0x60, 28), /*!< pwc sleep mode periph clock */
+  CRM_DAC_PERIPH_LOWPOWER                = MAKE_VALUE(0x60, 29), /*!< dac sleep mode periph clock */
+  CRM_USART7_PERIPH_LOWPOWER             = MAKE_VALUE(0x60, 30), /*!< usart7 sleep mode periph clock */
+  CRM_USART8_PERIPH_LOWPOWER             = MAKE_VALUE(0x60, 31), /*!< usart8 sleep mode periph clock */
+  /* apb2 periph */
+  CRM_TMR1_PERIPH_LOWPOWER               = MAKE_VALUE(0x64, 0),  /*!< tmr1 sleep mode periph clock */
+  CRM_USART1_PERIPH_LOWPOWER             = MAKE_VALUE(0x64, 4),  /*!< usart1 sleep mode periph clock */
+  CRM_USART6_PERIPH_LOWPOWER             = MAKE_VALUE(0x64, 5),  /*!< usart6 sleep mode periph clock */
+  CRM_ADC_PERIPH_LOWPOWER                = MAKE_VALUE(0x64, 8),  /*!< adc sleep mode periph clock */
+  CRM_SPI1_PERIPH_LOWPOWER               = MAKE_VALUE(0x64, 12), /*!< spi1 sleep mode periph clock */
+  CRM_SCFG_PERIPH_LOWPOWER               = MAKE_VALUE(0x64, 14), /*!< scfg sleep mode periph clock */
+  CRM_TMR9_PERIPH_LOWPOWER               = MAKE_VALUE(0x64, 16), /*!< tmr9 sleep mode periph clock */
+  CRM_TMR10_PERIPH_LOWPOWER              = MAKE_VALUE(0x64, 17), /*!< tmr10 sleep mode periph clock */
+  CRM_TMR11_PERIPH_LOWPOWER              = MAKE_VALUE(0x64, 18), /*!< tmr11 sleep mode periph clock */
+  CRM_ACC_PERIPH_LOWPOWER                = MAKE_VALUE(0x64, 29)  /*!< acc sleep mode periph clock */
+
+} crm_periph_clock_lowpower_type;
+
+/**
+  * @brief crm pll clock source
+  */
+typedef enum
+{
+  CRM_PLL_SOURCE_HICK                    = 0x00, /*!< high speed internal clock as pll reference clock source */
+  CRM_PLL_SOURCE_HEXT                    = 0x01  /*!< high speed external crystal as pll reference clock source */
+} crm_pll_clock_source_type;
+
+/**
+  * @brief crm pll fr
+  */
+typedef enum
+{
+  CRM_PLL_FR_1                           = 0x00, /*!< pll post-division div1 */
+  CRM_PLL_FR_2                           = 0x01, /*!< pll post-division div2 */
+  CRM_PLL_FR_4                           = 0x02, /*!< pll post-division div4 */
+  CRM_PLL_FR_8                           = 0x03, /*!< pll post-division div8 */
+  CRM_PLL_FR_16                          = 0x04, /*!< pll post-division div16 */
+  CRM_PLL_FR_32                          = 0x05  /*!< pll post-division div32 */
+} crm_pll_fr_type;
+
+/**
+  * @brief crm clock source
+  */
+typedef enum
+{
+  CRM_CLOCK_SOURCE_HICK                  = 0x00, /*!< high speed internal clock */
+  CRM_CLOCK_SOURCE_HEXT                  = 0x01, /*!< high speed external crystal */
+  CRM_CLOCK_SOURCE_PLL                   = 0x02, /*!< phase locking loop */
+  CRM_CLOCK_SOURCE_LEXT                  = 0x03, /*!< low speed external crystal */
+  CRM_CLOCK_SOURCE_LICK                  = 0x04  /*!< low speed internal clock */
+} crm_clock_source_type;
+
+/**
+  * @brief crm ahb division
+  */
+typedef enum
+{
+  CRM_AHB_DIV_1                          = 0x00, /*!< sclk div1 to ahbclk */
+  CRM_AHB_DIV_2                          = 0x08, /*!< sclk div2 to ahbclk */
+  CRM_AHB_DIV_4                          = 0x09, /*!< sclk div4 to ahbclk */
+  CRM_AHB_DIV_8                          = 0x0A, /*!< sclk div8 to ahbclk */
+  CRM_AHB_DIV_16                         = 0x0B, /*!< sclk div16 to ahbclk */
+  CRM_AHB_DIV_64                         = 0x0C, /*!< sclk div64 to ahbclk */
+  CRM_AHB_DIV_128                        = 0x0D, /*!< sclk div128 to ahbclk */
+  CRM_AHB_DIV_256                        = 0x0E, /*!< sclk div256 to ahbclk */
+  CRM_AHB_DIV_512                        = 0x0F  /*!< sclk div512 to ahbclk */
+} crm_ahb_div_type;
+
+/**
+  * @brief crm apb1 division
+  */
+typedef enum
+{
+  CRM_APB1_DIV_1                         = 0x00, /*!< ahbclk div1 to apb1clk */
+  CRM_APB1_DIV_2                         = 0x04, /*!< ahbclk div2 to apb1clk */
+  CRM_APB1_DIV_4                         = 0x05, /*!< ahbclk div4 to apb1clk */
+  CRM_APB1_DIV_8                         = 0x06, /*!< ahbclk div8 to apb1clk */
+  CRM_APB1_DIV_16                        = 0x07  /*!< ahbclk div16 to apb1clk */
+} crm_apb1_div_type;
+
+/**
+  * @brief crm apb2 division
+  */
+typedef enum
+{
+  CRM_APB2_DIV_1                         = 0x00, /*!< ahbclk div1 to apb2clk */
+  CRM_APB2_DIV_2                         = 0x04, /*!< ahbclk div2 to apb2clk */
+  CRM_APB2_DIV_4                         = 0x05, /*!< ahbclk div4 to apb2clk */
+  CRM_APB2_DIV_8                         = 0x06, /*!< ahbclk div8 to apb2clk */
+  CRM_APB2_DIV_16                        = 0x07  /*!< ahbclk div16 to apb2clk */
+} crm_apb2_div_type;
+
+/**
+  * @brief crm hext to sysclk division
+  */
+typedef enum
+{
+  CRM_HEXT_SCLK_DIV_1                    = 0x00, /*!< hext div1 to sysclk */
+  CRM_HEXT_SCLK_DIV_2                    = 0x01, /*!< hext div2 to sysclk */
+  CRM_HEXT_SCLK_DIV_4                    = 0x02, /*!< hext div4 to sysclk */
+  CRM_HEXT_SCLK_DIV_8                    = 0x03, /*!< hext div8 to sysclk */
+  CRM_HEXT_SCLK_DIV_16                   = 0x04, /*!< hext div16 to sysclk */
+  CRM_HEXT_SCLK_DIV_32                   = 0x05  /*!< hext div32 to sysclk */
+} crm_hext_sclk_div_type;                
+
+/**
+  * @brief crm hick to sysclk division
+  */
+typedef enum
+{
+  CRM_HICK_SCLK_DIV_1                    = 0x00, /*!< hick div1 to sysclk */
+  CRM_HICK_SCLK_DIV_2                    = 0x01, /*!< hick div2 to sysclk */
+  CRM_HICK_SCLK_DIV_4                    = 0x02, /*!< hick div4 to sysclk */
+  CRM_HICK_SCLK_DIV_8                    = 0x03, /*!< hick div8 to sysclk */
+  CRM_HICK_SCLK_DIV_16                   = 0x04  /*!< hick div16 to sysclk */
+} crm_hick_sclk_div_type;
+
+/**
+  * @brief crm usb division
+  */
+typedef enum
+{
+  CRM_USB_DIV_3                          = 0x00, /*!< pllclk div3 to usbclk */
+  CRM_USB_DIV_2                          = 0x01, /*!< pllclk div2 to usbclk */
+  CRM_USB_DIV_5                          = 0x02, /*!< pllclk div5 to usbclk */
+  CRM_USB_DIV_4                          = 0x03, /*!< pllclk div4 to usbclk */
+  CRM_USB_DIV_7                          = 0x04, /*!< pllclk div7 to usbclk */
+  CRM_USB_DIV_6                          = 0x05, /*!< pllclk div6 to usbclk */
+  CRM_USB_DIV_9                          = 0x06, /*!< pllclk div9 to usbclk */
+  CRM_USB_DIV_8                          = 0x07  /*!< pllclk div8 to usbclk */
+} crm_usb_div_type;
+
+/**
+  * @brief crm ertc clock
+  */
+typedef enum
+{
+  CRM_ERTC_CLOCK_NOCLK                   = 0x000, /*!< no clock as ertc clock source */
+  CRM_ERTC_CLOCK_LEXT                    = 0x001, /*!< low speed external crystal as ertc clock source */
+  CRM_ERTC_CLOCK_LICK                    = 0x002, /*!< low speed internal clock as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_2              = 0x023, /*!< high speed external crystal div2 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_3              = 0x033, /*!< high speed external crystal div3 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_4              = 0x043, /*!< high speed external crystal div4 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_5              = 0x053, /*!< high speed external crystal div5 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_6              = 0x063, /*!< high speed external crystal div6 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_7              = 0x073, /*!< high speed external crystal div7 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_8              = 0x083, /*!< high speed external crystal div8 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_9              = 0x093, /*!< high speed external crystal div9 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_10             = 0x0A3, /*!< high speed external crystal div10 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_11             = 0x0B3, /*!< high speed external crystal div11 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_12             = 0x0C3, /*!< high speed external crystal div12 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_13             = 0x0D3, /*!< high speed external crystal div13 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_14             = 0x0E3, /*!< high speed external crystal div14 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_15             = 0x0F3, /*!< high speed external crystal div15 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_16             = 0x103, /*!< high speed external crystal div16 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_17             = 0x113, /*!< high speed external crystal div17 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_18             = 0x123, /*!< high speed external crystal div18 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_19             = 0x133, /*!< high speed external crystal div19 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_20             = 0x143, /*!< high speed external crystal div20 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_21             = 0x153, /*!< high speed external crystal div21 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_22             = 0x163, /*!< high speed external crystal div22 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_23             = 0x173, /*!< high speed external crystal div23 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_24             = 0x183, /*!< high speed external crystal div24 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_25             = 0x193, /*!< high speed external crystal div25 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_26             = 0x1A3, /*!< high speed external crystal div26 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_27             = 0x1B3, /*!< high speed external crystal div27 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_28             = 0x1C3, /*!< high speed external crystal div28 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_29             = 0x1D3, /*!< high speed external crystal div29 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_30             = 0x1E3, /*!< high speed external crystal div30 as ertc clock source */
+  CRM_ERTC_CLOCK_HEXT_DIV_31             = 0x1F3  /*!< high speed external crystal div31 as ertc clock source */
+} crm_ertc_clock_type;
+
+/**
+  * @brief crm hick 48mhz division
+  */
+typedef enum
+{
+  CRM_HICK48_DIV6                        = 0x00, /*!< fixed 8 mhz when hick is selected as sclk */
+  CRM_HICK48_NODIV                       = 0x01  /*!< 8 mhz or 48 mhz depend on hickdiv when hick is selected as sclk */
+} crm_hick_div_6_type;
+
+/**
+  * @brief crm sclk select
+  */
+typedef enum
+{
+  CRM_SCLK_HICK                          = 0x00, /*!< select high speed internal clock as sclk */
+  CRM_SCLK_HEXT                          = 0x01, /*!< select high speed external crystal as sclk */
+  CRM_SCLK_PLL                           = 0x02  /*!< select phase locking loop clock as sclk */
+} crm_sclk_type;
+
+/**
+  * @brief crm clkout2 select
+  */
+typedef enum
+{
+  CRM_CLKOUT_SCLK                        = 0x00, /*!< output system clock to clkout2 pin */
+  CRM_CLKOUT_HEXT                        = 0x02, /*!< output high speed external crystal to clkout2 pin */
+  CRM_CLKOUT_PLL                         = 0x03, /*!< output phase locking loop clock to clkout2 pin */
+  CRM_CLKOUT_USB                         = 0x10, /*!< output usbclk to clkout2 pin */
+  CRM_CLKOUT_ADC                         = 0x11, /*!< output adcclk to clkout2 pin */
+  CRM_CLKOUT_HICK                        = 0x12, /*!< output high speed internal clock to clkout2 pin */
+  CRM_CLKOUT_LICK                        = 0x13, /*!< output low speed internal clock to clkout2 pin */
+  CRM_CLKOUT_LEXT                        = 0x14  /*!< output low speed external crystal to clkout2 pin */
+} crm_clkout_select_type;
+
+/**
+  * @brief crm clkout division1
+  */
+typedef enum
+{
+  CRM_CLKOUT_DIV1_1                      = 0x00, /*!< clkout division1 div1 */
+  CRM_CLKOUT_DIV1_2                      = 0x04, /*!< clkout division1 div2 */
+  CRM_CLKOUT_DIV1_3                      = 0x05, /*!< clkout division1 div3 */
+  CRM_CLKOUT_DIV1_4                      = 0x06, /*!< clkout division1 div4 */
+  CRM_CLKOUT_DIV1_5                      = 0x07  /*!< clkout division1 div5 */
+} crm_clkout_div1_type;
+
+/**
+  * @brief crm clkout division2
+  */
+typedef enum
+{
+  CRM_CLKOUT_DIV2_1                      = 0x00, /*!< clkout division2 div1 */
+  CRM_CLKOUT_DIV2_2                      = 0x08, /*!< clkout division2 div2 */
+  CRM_CLKOUT_DIV2_4                      = 0x09, /*!< clkout division2 div4 */
+  CRM_CLKOUT_DIV2_8                      = 0x0A, /*!< clkout division2 div8 */
+  CRM_CLKOUT_DIV2_16                     = 0x0B, /*!< clkout division2 div16 */
+  CRM_CLKOUT_DIV2_64                     = 0x0C, /*!< clkout division2 div64 */
+  CRM_CLKOUT_DIV2_128                    = 0x0D, /*!< clkout division2 div128 */
+  CRM_CLKOUT_DIV2_256                    = 0x0E, /*!< clkout division2 div256 */
+  CRM_CLKOUT_DIV2_512                    = 0x0F  /*!< clkout division2 div512 */
+} crm_clkout_div2_type;
+
+/**
+  * @brief crm auto step mode
+  */
+typedef enum
+{
+  CRM_AUTO_STEP_MODE_DISABLE             = 0x00, /*!< disable auto step mode */
+  CRM_AUTO_STEP_MODE_ENABLE              = 0x03  /*!< enable auto step mode */
+} crm_auto_step_mode_type;
+
+/**
+  * @brief crm usart index
+  */
+typedef enum
+{
+  CRM_USART1                             = 0x00, /*!< usart1 */
+  CRM_USART2                             = 0x01, /*!< usart2 */
+  CRM_USART3                             = 0x02  /*!< usart3 */
+} crm_usart_type;
+
+/**
+  * @brief crm i2c index
+  */
+typedef enum
+{
+  CRM_I2C1                               = 0x00  /*!< i2c1 */
+} crm_i2c_type;
+
+/**
+  * @brief crm usart clock source
+  */
+typedef enum
+{
+  CRM_USART_CLOCK_SOURCE_PCLK            = 0x00, /*!< select pclk clock as usart clock source */
+  CRM_USART_CLOCK_SOURCE_SCLK            = 0x01, /*!< select system clock as usart clock source */
+  CRM_USART_CLOCK_SOURCE_HICK            = 0x02, /*!< select high speed internal clock as usart clock source */
+  CRM_USART_CLOCK_SOURCE_LEXT            = 0x03  /*!< select low speed external crystal as usart clock source */
+} crm_usart_clock_source_type;
+
+/**
+  * @brief crm i2c clock source
+  */
+typedef enum
+{
+  CRM_I2C_CLOCK_SOURCE_PCLK              = 0x00, /*!< select pclk clock as usart clock source */
+  CRM_I2C_CLOCK_SOURCE_SCLK              = 0x01, /*!< select system clock as usart clock source */
+  CRM_I2C_CLOCK_SOURCE_HICK              = 0x02  /*!< select high speed internal clock as usart clock source */
+} crm_i2c_clock_source_type;
+
+/**
+  * @brief crm adc clock source
+  */
+typedef enum
+{
+  CRM_ADC_CLOCK_SOURCE_HCLK              = 0x00, /*!< select hclk clock as adc clock source */
+  CRM_ADC_CLOCK_SOURCE_PLLCLK            = 0x01  /*!< select pll clock as adc clock source */
+} crm_adc_clock_source_type;
+
+/**
+  * @brief crm usb 48 mhz clock source select
+  */
+typedef enum
+{
+  CRM_USB_CLOCK_SOURCE_PLL               = 0x00, /*!< select phase locking loop clock as usb clock source */
+  CRM_USB_CLOCK_SOURCE_HICK              = 0x01  /*!< select high speed internal clock as usb clock source */
+} crm_usb_clock_source_type;
+
+/**
+  * @brief crm hick as system clock frequency select
+  */
+typedef enum
+{
+  CRM_HICK_SCLK_8MHZ                     = 0x00, /*!< fixed 8 mhz when hick is selected as sclk */
+  CRM_HICK_SCLK_48MHZ                    = 0x01  /*!< 8 mhz or 48 mhz depend on hickdiv when hick is selected as sclk */
+} crm_hick_sclk_frequency_type;
+
+/**
+  * @brief crm clocks freqency structure
+  */
+typedef struct
+{
+  uint32_t sclk_freq; /*!< system clock frequency */
+  uint32_t ahb_freq;  /*!< ahb bus clock frequency */
+  uint32_t apb2_freq; /*!< apb2 bus clock frequency */
+  uint32_t apb1_freq; /*!< apb1 bus clock frequency */
+} crm_clocks_freq_type;
+
+/**
+  * @brief type define crm register all
+  */
+typedef struct
+{
+  /**
+    * @brief crm ctrl register, offset:0x00
+    */
+  union
+  {
+    __IO uint32_t ctrl;
+    struct
+    {
+      __IO uint32_t hicken               : 1; /* [0] */
+      __IO uint32_t hickstbl             : 1; /* [1] */
+      __IO uint32_t hicktrim             : 6; /* [7:2] */
+      __IO uint32_t hickcal              : 8; /* [15:8] */
+      __IO uint32_t hexten               : 1; /* [16] */
+      __IO uint32_t hextstbl             : 1; /* [17] */
+      __IO uint32_t hextbyps             : 1; /* [18] */
+      __IO uint32_t cfden                : 1; /* [19] */
+      __IO uint32_t reserved1            : 4; /* [23:20] */
+      __IO uint32_t pllen                : 1; /* [24] */
+      __IO uint32_t pllstbl              : 1; /* [25] */
+      __IO uint32_t reserved2            : 6; /* [31:26] */
+    } ctrl_bit;
+  };
+
+  /**
+    * @brief crm pllcfg register, offset:0x04
+    */
+  union
+  {
+    __IO uint32_t pllcfg;
+    struct
+    {
+      __IO uint32_t pllms                : 4; /* [3:0] */
+      __IO uint32_t reserved1            : 2; /* [5:4] */
+      __IO uint32_t pllns                : 9; /* [14:6] */
+      __IO uint32_t reserved2            : 1; /* [15] */
+      __IO uint32_t pllfr                : 3; /* [18:16] */
+      __IO uint32_t reserved3            : 3; /* [21:19] */
+      __IO uint32_t pllrcs               : 1; /* [22] */
+      __IO uint32_t reserved4            : 9; /* [31:23] */
+    } pllcfg_bit;
+  };
+
+  /**
+    * @brief crm cfg register, offset:0x08
+    */
+  union
+  {
+    __IO uint32_t cfg;
+    struct
+    {
+      __IO uint32_t sclksel              : 2; /* [1:0] */
+      __IO uint32_t sclksts              : 2; /* [3:2] */
+      __IO uint32_t ahbdiv               : 4; /* [7:4] */
+      __IO uint32_t reserved1            : 2; /* [9:8] */
+      __IO uint32_t apb1div              : 3; /* [12:10] */
+      __IO uint32_t apb2div              : 3; /* [15:13] */
+      __IO uint32_t ertcdiv              : 5; /* [20:16] */
+      __IO uint32_t reserved2            : 6; /* [26:21] */
+      __IO uint32_t clkoutdiv1           : 3; /* [29:27] */
+      __IO uint32_t clkout_sel1          : 2; /* [31:30] */
+    } cfg_bit;
+  };
+
+  /**
+    * @brief crm clkint register, offset:0x0C
+    */
+  union
+  {
+    __IO uint32_t clkint;
+    struct
+    {
+      __IO uint32_t lickstblf            : 1; /* [0] */
+      __IO uint32_t lextstblf            : 1; /* [1] */
+      __IO uint32_t hickstblf            : 1; /* [2] */
+      __IO uint32_t hextstblf            : 1; /* [3] */
+      __IO uint32_t pllstblf             : 1; /* [4] */
+      __IO uint32_t reserved1            : 2; /* [6:5] */
+      __IO uint32_t cfdf                 : 1; /* [7] */
+      __IO uint32_t lickstblien          : 1; /* [8] */
+      __IO uint32_t lextstblien          : 1; /* [9] */
+      __IO uint32_t hickstblien          : 1; /* [10] */
+      __IO uint32_t hextstblien          : 1; /* [11] */
+      __IO uint32_t pllstblien           : 1; /* [12] */
+      __IO uint32_t reserved2            : 3; /* [15:13] */
+      __IO uint32_t lickstblfc           : 1; /* [16] */
+      __IO uint32_t lextstblfc           : 1; /* [17] */
+      __IO uint32_t hickstblfc           : 1; /* [18] */
+      __IO uint32_t hextstblfc           : 1; /* [19] */
+      __IO uint32_t pllstblfc            : 1; /* [20] */
+      __IO uint32_t reserved3            : 2; /* [22:21] */
+      __IO uint32_t cfdfc                : 1; /* [23] */
+      __IO uint32_t reserved4            : 8; /* [31:24] */
+    } clkint_bit;
+  };
+
+  /**
+    * @brief crm ahbrst1 register, offset:0x10
+    */
+  union
+  {
+    __IO uint32_t ahbrst1;
+    struct
+    {
+      __IO uint32_t gpioarst             : 1; /* [0] */
+      __IO uint32_t gpiobrst             : 1; /* [1] */
+      __IO uint32_t gpiocrst             : 1; /* [2] */
+      __IO uint32_t gpiodrst             : 1; /* [3] */
+      __IO uint32_t gpioerst             : 1; /* [4] */
+      __IO uint32_t gpiofrst             : 1; /* [5] */
+      __IO uint32_t reserved1            : 6; /* [11:6] */
+      __IO uint32_t crcrst               : 1; /* [12] */
+      __IO uint32_t reserved2            : 9; /* [21:13] */
+      __IO uint32_t dma1rst              : 1; /* [22] */
+      __IO uint32_t reserved3            : 1; /* [23] */
+      __IO uint32_t dma2rst              : 1; /* [24] */
+      __IO uint32_t reserved4            : 7; /* [31:25] */
+    } ahbrst1_bit;
+  };
+
+  /**
+    * @brief crm ahbrst2 register, offset:0x14
+    */
+  union
+  {
+    __IO uint32_t ahbrst2;
+    struct
+    {
+      __IO uint32_t reserved1            : 7; /* [6:0] */
+      __IO uint32_t otgfs1rst            : 1; /* [7] */
+      __IO uint32_t reserved2            : 24;/* [31:8] */
+    } ahbrst2_bit;
+  };
+
+  /**
+    * @brief crm ahbrst3 register, offset:0x18
+    */
+  union
+  {
+    __IO uint32_t ahbrst3;
+    struct
+    {
+      __IO uint32_t xmcrst               : 1; /* [0] */
+      __IO uint32_t reserved1            : 31;/* [31:1] */
+    } ahbrst3_bit;
+  };
+
+  /**
+    * @brief crm reserved1 register, offset:0x1C
+    */
+  __IO uint32_t reserved1;
+
+  /**
+    * @brief crm apb1rst register, offset:0x20
+    */
+  union
+  {
+    __IO uint32_t apb1rst;
+    struct
+    {
+      __IO uint32_t tmr2rst              : 1; /* [0] */
+      __IO uint32_t tmr3rst              : 1; /* [1] */
+      __IO uint32_t tmr4rst              : 1; /* [2] */
+      __IO uint32_t reserved1            : 1; /* [3] */
+      __IO uint32_t tmr6rst              : 1; /* [4] */
+      __IO uint32_t tmr7rst              : 1; /* [5] */
+      __IO uint32_t tmr12rst             : 1; /* [6] */
+      __IO uint32_t tmr13rst             : 1; /* [7] */
+      __IO uint32_t tmr14rst             : 1; /* [8] */
+      __IO uint32_t reserved2            : 2; /* [10:9] */
+      __IO uint32_t wwdtrst              : 1; /* [11] */
+      __IO uint32_t reserved3            : 2; /* [13:12] */
+      __IO uint32_t spi2rst              : 1; /* [14] */
+      __IO uint32_t spi3rst              : 1; /* [15] */
+      __IO uint32_t reserved4            : 1; /* [16] */
+      __IO uint32_t usart2rst            : 1; /* [17] */
+      __IO uint32_t usart3rst            : 1; /* [18] */
+      __IO uint32_t usart4rst            : 1; /* [19] */
+      __IO uint32_t usart5rst            : 1; /* [20] */
+      __IO uint32_t i2c1rst              : 1; /* [21] */
+      __IO uint32_t i2c2rst              : 1; /* [22] */
+      __IO uint32_t i2c3rst              : 1; /* [23] */
+      __IO uint32_t reserved5            : 1; /* [24] */
+      __IO uint32_t can1rst              : 1; /* [25] */
+      __IO uint32_t can2rst              : 1; /* [26] */
+      __IO uint32_t reserved6            : 1; /* [27] */
+      __IO uint32_t pwcrst               : 1; /* [28] */
+      __IO uint32_t dacrst               : 1; /* [29] */
+      __IO uint32_t usart7rst            : 1; /* [30] */
+      __IO uint32_t usart8rst            : 1; /* [31] */
+    } apb1rst_bit;
+  };
+
+  /**
+    * @brief crm apb2rst register, offset:0x24
+    */
+  union
+  {
+    __IO uint32_t apb2rst;
+    struct
+    {
+      __IO uint32_t tmr1rst              : 1; /* [0] */
+      __IO uint32_t reserved1            : 3; /* [3:1] */
+      __IO uint32_t usart1rst            : 1; /* [4] */
+      __IO uint32_t usart6rst            : 1; /* [5] */
+      __IO uint32_t reserved2            : 2; /* [7:6] */
+      __IO uint32_t adcrst               : 1; /* [8] */
+      __IO uint32_t reserved3            : 3; /* [11:9] */
+      __IO uint32_t spi1rst              : 1; /* [12] */
+      __IO uint32_t reserved4            : 1; /* [13] */
+      __IO uint32_t scfgrst              : 1; /* [14] */
+      __IO uint32_t reserved5            : 1; /* [15] */
+      __IO uint32_t tmr9rst              : 1; /* [16] */
+      __IO uint32_t tmr10rst             : 1; /* [17] */
+      __IO uint32_t tmr11rst             : 1; /* [18] */
+      __IO uint32_t reserved6            : 10;/* [28:19] */
+      __IO uint32_t accrst               : 1; /* [29] */
+      __IO uint32_t reserved7            : 2; /* [31:30] */
+    } apb2rst_bit;
+  };
+
+  /**
+    * @brief crm reserved2 register, offset:0x28~0x2C
+    */
+  __IO uint32_t reserved2[2];
+
+  /**
+    * @brief crm ahben1 register, offset:0x30
+    */
+  union
+  {
+    __IO uint32_t ahben1;
+    struct
+    {
+      __IO uint32_t gpioaen              : 1; /* [0] */
+      __IO uint32_t gpioben              : 1; /* [1] */
+      __IO uint32_t gpiocen              : 1; /* [2] */
+      __IO uint32_t gpioden              : 1; /* [3] */
+      __IO uint32_t gpioeen              : 1; /* [4] */
+      __IO uint32_t gpiofen              : 1; /* [5] */
+      __IO uint32_t reserved1            : 6; /* [11:6] */
+      __IO uint32_t crcen                : 1; /* [12] */
+      __IO uint32_t reserved2            : 9; /* [21:13] */
+      __IO uint32_t dma1en               : 1; /* [22] */
+      __IO uint32_t reserved3            : 1; /* [23] */
+      __IO uint32_t dma2en               : 1; /* [24] */
+      __IO uint32_t reserved4            : 7; /* [31:25] */
+    } ahben1_bit;
+  };
+
+  /**
+    * @brief crm ahben2 register, offset:0x34
+    */
+  union
+  {
+    __IO uint32_t ahben2;
+    struct
+    {
+      __IO uint32_t reserved1            : 7; /* [6:0] */
+      __IO uint32_t otgfs1en             : 1; /* [7] */
+      __IO uint32_t reserved2            : 24;/* [31:8] */
+    } ahben2_bit;
+  };
+
+  /**
+    * @brief crm ahben3 register, offset:0x38
+    */
+  union
+  {
+    __IO uint32_t ahben3;
+    struct
+    {
+      __IO uint32_t xmcen                : 1; /* [0] */
+      __IO uint32_t reserved1            : 31;/* [31:1] */
+    } ahben3_bit;
+  };
+
+  /**
+    * @brief crm reserved3 register, offset:0x3C
+    */
+  __IO uint32_t reserved3;
+
+  /**
+    * @brief crm apb1en register, offset:0x40
+    */
+  union
+  {
+    __IO uint32_t apb1en;
+    struct
+    {
+      __IO uint32_t tmr2en               : 1; /* [0] */
+      __IO uint32_t tmr3en               : 1; /* [1] */
+      __IO uint32_t tmr4en               : 1; /* [2] */
+      __IO uint32_t reserved1            : 1; /* [3] */
+      __IO uint32_t tmr6en               : 1; /* [4] */
+      __IO uint32_t tmr7en               : 1; /* [5] */
+      __IO uint32_t tmr12en              : 1; /* [6] */
+      __IO uint32_t tmr13en              : 1; /* [7] */
+      __IO uint32_t tmr14en              : 1; /* [8] */
+      __IO uint32_t reserved2            : 2; /* [10:9] */
+      __IO uint32_t wwdten               : 1; /* [11] */
+      __IO uint32_t reserved3            : 2; /* [13:12] */
+      __IO uint32_t spi2en               : 1; /* [14] */
+      __IO uint32_t spi3en               : 1; /* [15] */
+      __IO uint32_t reserved4            : 1; /* [16] */
+      __IO uint32_t usart2en             : 1; /* [17] */
+      __IO uint32_t usart3en             : 1; /* [18] */
+      __IO uint32_t usart4en             : 1; /* [19] */
+      __IO uint32_t usart5en             : 1; /* [20] */
+      __IO uint32_t i2c1en               : 1; /* [21] */
+      __IO uint32_t i2c2en               : 1; /* [22] */
+      __IO uint32_t i2c3en               : 1; /* [23] */
+      __IO uint32_t reserved5            : 1; /* [24] */
+      __IO uint32_t can1en               : 1; /* [25] */
+      __IO uint32_t can2en               : 1; /* [26] */
+      __IO uint32_t reserved6            : 1; /* [27] */
+      __IO uint32_t pwcen                : 1; /* [28] */
+      __IO uint32_t dacen                : 1; /* [29] */
+      __IO uint32_t usart7en             : 1; /* [30] */
+      __IO uint32_t usart8en             : 1; /* [31] */
+    } apb1en_bit;
+  };
+
+  /**
+    * @brief crm apb2en register, offset:0x44
+    */
+  union
+  {
+    __IO uint32_t apb2en;
+    struct
+    {
+      __IO uint32_t tmr1en               : 1; /* [0] */
+      __IO uint32_t reserved1            : 3; /* [3:1] */
+      __IO uint32_t usart1en             : 1; /* [4] */
+      __IO uint32_t usart6en             : 1; /* [5] */
+      __IO uint32_t reserved2            : 2; /* [7:6] */
+      __IO uint32_t adc1en               : 1; /* [8] */
+      __IO uint32_t reserved3            : 3; /* [11:9] */
+      __IO uint32_t spi1en               : 1; /* [12] */
+      __IO uint32_t reserved4               : 1; /* [13] */
+      __IO uint32_t scfgen               : 1; /* [14] */
+      __IO uint32_t reserved5            : 1; /* [15] */
+      __IO uint32_t tmr9en               : 1; /* [16] */
+      __IO uint32_t tmr10en              : 1; /* [17] */
+      __IO uint32_t tmr11en              : 1; /* [18] */
+      __IO uint32_t reserved6            : 10;/* [28:19] */
+      __IO uint32_t accen                : 1; /* [29] */
+      __IO uint32_t reserved7            : 2; /* [31:30] */
+    } apb2en_bit;
+  };
+
+  /**
+    * @brief crm reserved4 register, offset:0x48~0x4C
+    */
+  __IO uint32_t reserved4[2];
+
+  /**
+    * @brief crm ahblpen1 register, offset:0x50
+    */
+  union
+  {
+    __IO uint32_t ahblpen1;
+    struct
+    {
+      __IO uint32_t gpioalpen            : 1; /* [0] */
+      __IO uint32_t gpioblpen            : 1; /* [1] */
+      __IO uint32_t gpioclpen            : 1; /* [2] */
+      __IO uint32_t gpiodlpen            : 1; /* [3] */
+      __IO uint32_t gpioelpen            : 1; /* [4] */
+      __IO uint32_t gpioflpen            : 1; /* [5] */
+      __IO uint32_t reserved1            : 6; /* [11:6] */
+      __IO uint32_t crclpen              : 1; /* [12] */
+      __IO uint32_t reserved2            : 9; /* [21:13] */
+      __IO uint32_t dma1lpen             : 1; /* [22] */
+      __IO uint32_t reserved3            : 1; /* [23] */
+      __IO uint32_t dma2lpen             : 1; /* [24] */
+      __IO uint32_t reserved4            : 7; /* [31:25] */
+    } ahblpen1_bit;
+  };
+
+  /**
+    * @brief crm ahblpen2 register, offset:0x54
+    */
+  union
+  {
+    __IO uint32_t ahblpen2;
+    struct
+    {
+      __IO uint32_t reserved1            : 7; /* [6:0] */
+      __IO uint32_t otgfs1lpen           : 1; /* [7] */
+      __IO uint32_t reserved2            : 24;/* [31:8] */
+    } ahblpen2_bit;
+  };
+
+  /**
+    * @brief crm ahblpen3 register, offset:0x58
+    */
+  union
+  {
+    __IO uint32_t ahblpen3;
+    struct
+    {
+      __IO uint32_t xmclpen              : 1; /* [0] */
+      __IO uint32_t reserved1            : 31;/* [31:1] */
+    } ahblpen3_bit;
+  };
+
+  /**
+    * @brief crm reserved5 register, offset:0x5C
+    */
+  __IO uint32_t reserved5;
+
+  /**
+    * @brief crm apb1lpen register, offset:0x60
+    */
+  union
+  {
+    __IO uint32_t apb1lpen;
+    struct
+    {
+      __IO uint32_t tmr2lpen             : 1; /* [0] */
+      __IO uint32_t tmr3lpen             : 1; /* [1] */
+      __IO uint32_t tmr4lpen             : 1; /* [2] */
+      __IO uint32_t reserved1            : 1; /* [3] */
+      __IO uint32_t tmr6lpen             : 1; /* [4] */
+      __IO uint32_t tmr7lpen             : 1; /* [5] */
+      __IO uint32_t tmr12lpen            : 1; /* [6] */
+      __IO uint32_t tmr13lpen            : 1; /* [7] */
+      __IO uint32_t tmr14lpen            : 1; /* [8] */
+      __IO uint32_t reserved2            : 2; /* [10:9] */
+      __IO uint32_t wwdtlpen             : 1; /* [11] */
+      __IO uint32_t reserved3            : 2; /* [13:12] */
+      __IO uint32_t spi2lpen             : 1; /* [14] */
+      __IO uint32_t spi3lpen             : 1; /* [15] */
+      __IO uint32_t reserved4            : 1; /* [16] */
+      __IO uint32_t usart2lpen           : 1; /* [17] */
+      __IO uint32_t usart3lpen           : 1; /* [18] */
+      __IO uint32_t usart4lpen           : 1; /* [19] */
+      __IO uint32_t usart5lpen           : 1; /* [20] */
+      __IO uint32_t i2c1lpen             : 1; /* [21] */
+      __IO uint32_t i2c2lpen             : 1; /* [22] */
+      __IO uint32_t i2c3lpen             : 1; /* [23] */
+      __IO uint32_t reserved5            : 1; /* [24] */
+      __IO uint32_t can1lpen             : 1; /* [25] */
+      __IO uint32_t can2lpen             : 1; /* [26] */
+      __IO uint32_t reserved6            : 1; /* [27] */
+      __IO uint32_t pwclpen              : 1; /* [28] */
+      __IO uint32_t daclpen              : 1; /* [29] */
+      __IO uint32_t usart7lpen           : 1; /* [30] */
+      __IO uint32_t usart8lpen           : 1; /* [31] */
+    } apb1lpen_bit;
+  };
+
+  /**
+    * @brief crm apb2lpen register, offset:0x64
+    */
+  union
+  {
+    __IO uint32_t apb2lpen;
+    struct
+    {
+      __IO uint32_t tmr1lpen             : 1; /* [0] */
+      __IO uint32_t reserved1            : 3; /* [3:1] */
+      __IO uint32_t usart1lpen           : 1; /* [4] */
+      __IO uint32_t usart6lpen           : 1; /* [5] */
+      __IO uint32_t reserved2            : 2; /* [7:6] */
+      __IO uint32_t adc1lpen             : 1; /* [8] */
+      __IO uint32_t reserved3            : 3; /* [11:9] */
+      __IO uint32_t spi1lpen             : 1; /* [12] */
+      __IO uint32_t reserved4            : 1; /* [13] */
+      __IO uint32_t scfglpen             : 1; /* [14] */
+      __IO uint32_t reserved5            : 1; /* [15] */
+      __IO uint32_t tmr9lpen             : 1; /* [16] */
+      __IO uint32_t tmr10lpen            : 1; /* [17] */
+      __IO uint32_t tmr11lpen            : 1; /* [18] */
+      __IO uint32_t reserved6            : 10;/* [28:19] */
+      __IO uint32_t acclpen              : 1; /* [29] */
+      __IO uint32_t reserved7            : 2; /* [31:30] */
+    } apb2lpen_bit;
+  };
+
+  /**
+    * @brief crm piclks register, offset:0x68
+    */
+  union
+  {
+    __IO uint32_t piclks;
+    struct
+    {
+      __IO uint32_t usart1sel            : 2; /* [1:0] */
+      __IO uint32_t usart2sel            : 2; /* [3:2] */
+      __IO uint32_t usart3sel            : 2; /* [5:4] */
+      __IO uint32_t reserved1            : 6; /* [11:6] */
+      __IO uint32_t i2c1sel              : 2; /* [13:12] */
+      __IO uint32_t reserved2            : 18;/* [31:14] */
+    } piclks_bit;
+  };
+
+  /**
+    * @brief crm reserved6 register, offset:0x6C
+    */
+  __IO uint32_t reserved6;
+
+  /**
+    * @brief crm bpdc register, offset:0x70
+    */
+  union
+  {
+    __IO uint32_t bpdc;
+    struct
+    {
+      __IO uint32_t lexten               : 1; /* [0] */
+      __IO uint32_t lextstbl             : 1; /* [1] */
+      __IO uint32_t lextbyps             : 1; /* [2] */
+      __IO uint32_t reserved1            : 5; /* [7:3] */
+      __IO uint32_t ertcsel              : 2; /* [9:8] */
+      __IO uint32_t reserved2            : 5; /* [14:10] */
+      __IO uint32_t ertcen               : 1; /* [15] */
+      __IO uint32_t bpdrst               : 1; /* [16] */
+      __IO uint32_t reserved3            : 15;/* [31:17] */
+    } bpdc_bit;
+  };
+
+  /**
+    * @brief crm ctrlsts register, offset:0x74
+    */
+  union
+  {
+    __IO uint32_t ctrlsts;
+    struct
+    {
+      __IO uint32_t licken               : 1; /* [0] */
+      __IO uint32_t lickstbl             : 1; /* [1] */
+      __IO uint32_t reserved1            : 22;/* [23:2] */
+      __IO uint32_t rstfc                : 1; /* [24] */
+      __IO uint32_t reserved2            : 1; /* [25] */
+      __IO uint32_t nrstf                : 1; /* [26] */
+      __IO uint32_t porrstf              : 1; /* [27] */
+      __IO uint32_t swrstf               : 1; /* [28] */
+      __IO uint32_t wdtrstf              : 1; /* [29] */
+      __IO uint32_t wwdtrstf             : 1; /* [30] */
+      __IO uint32_t lprstf               : 1; /* [31] */
+    } ctrlsts_bit;
+  };
+
+  /**
+    * @brief crm reserved7 register, offset:0x78~0x9C
+    */
+  __IO uint32_t reserved7[10];
+
+  /**
+    * @brief crm misc1 register, offset:0xA0
+    */
+  union
+  {
+    __IO uint32_t misc1;
+    struct
+    {
+      __IO uint32_t hickcal_key          : 8; /* [7:0] */
+      __IO uint32_t reserved1            : 4; /* [11:8] */
+      __IO uint32_t hickdiv              : 1; /* [12] */
+      __IO uint32_t hick_to_usb          : 1; /* [13] */
+      __IO uint32_t hick_to_sclk         : 1; /* [14] */
+      __IO uint32_t pllclk_to_adc        : 1; /* [15] */
+      __IO uint32_t clkout_sel2          : 4; /* [19:16] */
+      __IO uint32_t reserved2            : 8; /* [27:20] */
+      __IO uint32_t clkoutdiv2           : 4; /* [31:28] */
+    } misc1_bit;
+  };
+
+  /**
+    * @brief crm misc2 register, offset:0xA4
+    */
+  union
+  {
+    __IO uint32_t misc2;
+    struct
+    {
+      __IO uint32_t reserved1            : 4; /* [3:0] */
+      __IO uint32_t auto_step_en         : 2; /* [5:4] */
+      __IO uint32_t reserved2            : 6; /* [11:6] */
+      __IO uint32_t usbdiv               : 4; /* [15:12] */
+      __IO uint32_t hick_to_sclk_div     : 3; /* [18:16] */
+      __IO uint32_t hext_to_sclk_div     : 3; /* [21:19] */
+      __IO uint32_t reserved3            : 10;/* [31:22] */
+    } misc2_bit;
+  };
+
+} crm_type;
+
+/**
+  * @}
+  */
+
+#define CRM                              ((crm_type *) CRM_BASE)
+
+/** @defgroup CRM_exported_functions
+  * @{
+  */
+
+void crm_reset(void);
+void crm_lext_bypass(confirm_state new_state);
+void crm_hext_bypass(confirm_state new_state);
+flag_status crm_flag_get(uint32_t flag);
+flag_status crm_interrupt_flag_get(uint32_t flag);
+error_status crm_hext_stable_wait(void);
+void crm_hick_clock_trimming_set(uint8_t trim_value);
+void crm_hick_clock_calibration_set(uint8_t cali_value);
+void crm_periph_clock_enable(crm_periph_clock_type value, confirm_state new_state);
+void crm_periph_reset(crm_periph_reset_type value, confirm_state new_state);
+void crm_periph_lowpower_mode_enable(crm_periph_clock_lowpower_type value, confirm_state new_state);
+void crm_clock_source_enable(crm_clock_source_type source, confirm_state new_state);
+void crm_flag_clear(uint32_t flag);
+void crm_ertc_clock_select(crm_ertc_clock_type value);
+void crm_ertc_clock_enable(confirm_state new_state);
+void crm_ahb_div_set(crm_ahb_div_type value);
+void crm_apb1_div_set(crm_apb1_div_type value);
+void crm_apb2_div_set(crm_apb2_div_type value);
+void crm_hext_sclk_div_set(crm_hext_sclk_div_type value);
+void crm_hick_sclk_div_set(crm_hick_sclk_div_type value);
+void crm_usb_clock_div_set(crm_usb_div_type value);
+void crm_clock_failure_detection_enable(confirm_state new_state);
+void crm_battery_powered_domain_reset(confirm_state new_state);
+void crm_auto_step_mode_enable(confirm_state new_state);
+void crm_hick_divider_select(crm_hick_div_6_type value);
+void crm_hick_sclk_frequency_select(crm_hick_sclk_frequency_type value);
+void crm_usb_clock_source_select(crm_usb_clock_source_type value);
+void crm_usart_clock_select(crm_usart_type usart_index, crm_usart_clock_source_type value);
+crm_usart_clock_source_type crm_usart_clock_get(crm_usart_type usart_index);
+void crm_i2c_clock_select(crm_i2c_type i2c_index, crm_i2c_clock_source_type value);
+crm_i2c_clock_source_type crm_i2c_clock_get(crm_i2c_type i2c_index);
+void crm_adc_clock_select(crm_adc_clock_source_type value);
+void crm_pll_config(crm_pll_clock_source_type clock_source, uint16_t pll_ns, \
+                    uint16_t pll_ms, crm_pll_fr_type pll_fr);
+void crm_sysclk_switch(crm_sclk_type value);
+crm_sclk_type crm_sysclk_switch_status_get(void);
+void crm_clocks_freq_get(crm_clocks_freq_type *clocks_struct);
+void crm_clock_out_set(crm_clkout_select_type clkout);
+void crm_clkout_div_set(crm_clkout_div1_type div1, crm_clkout_div2_type div2);
+void crm_interrupt_enable(uint32_t crm_int, confirm_state new_state);
+error_status crm_pll_parameter_calculate(crm_pll_clock_source_type pll_rcs, uint32_t target_sclk_freq, \
+                                         uint16_t *ret_ms, uint16_t *ret_ns, uint16_t *ret_fr);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_dac.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_dac.h
@@ -1,0 +1,394 @@
+/**
+  **************************************************************************
+  * @file     at32f423_dac.h
+  * @brief    at32f423 dac header file
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __AT32F423_DAC_H
+#define __AT32F423_DAC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "at32f423.h"
+
+/** @addtogroup AT32F423_periph_driver
+  * @{
+  */
+
+/** @addtogroup DAC
+  * @{
+  */
+
+#define DAC1_D1DMAUDRF                   ((uint32_t)(0x00002000))
+#define DAC2_D2DMAUDRF                   ((uint32_t)(0x20000000))
+
+/** @defgroup DAC_exported_types
+  * @{
+  */
+
+/**
+  * @brief dac select type
+  */
+typedef enum
+{
+  DAC1_SELECT                            = 0x01, /*!< dac1 select */
+  DAC2_SELECT                            = 0x02  /*!< dac2 select */
+} dac_select_type;
+
+/**
+  * @brief dac trigger type
+  */
+typedef enum
+{
+  DAC_TMR6_TRGOUT_EVENT                  = 0x00, /*!< dac trigger selection:timer6 trgout event */
+  DAC_TMR3_TRGOUT_EVENT                  = 0x01, /*!< dac trigger selection:timer3 trgout event */
+  DAC_TMR7_TRGOUT_EVENT                  = 0x02, /*!< dac trigger selection:timer7 trgout event */
+  DAC_TMR9_TRGOUT_EVENT                  = 0x03, /*!< dac trigger selection:timer9 trgout event */
+  DAC_TMR2_TRGOUT_EVENT                  = 0x04, /*!< dac trigger selection:timer2 trgout event */
+  DAC_TMR4_TRGOUT_EVENT                  = 0x05, /*!< dac trigger selection:timer4 trgout event */
+  DAC_EXTERNAL_INTERRUPT_LINE_9          = 0x06, /*!< dac trigger selection:external line9 */
+  DAC_SOFTWARE_TRIGGER                   = 0x07  /*!< dac trigger selection:software trigger */
+} dac_trigger_type;
+
+/**
+  * @brief dac wave type
+  */
+typedef enum
+{
+  DAC_WAVE_GENERATE_NONE                 = 0x00, /*!< dac wave generation disabled */
+  DAC_WAVE_GENERATE_NOISE                = 0x01, /*!< dac noise wave generation enabled */
+  DAC_WAVE_GENERATE_TRIANGLE             = 0x02  /*!< dac triangle wave generation enabled */
+} dac_wave_type;
+
+/**
+  * @brief dac mask amplitude type
+  */
+typedef enum
+{
+  DAC_LSFR_BIT0_AMPLITUDE_1              = 0x00, /*!< unmask bit0/ triangle amplitude equal to 1 */
+  DAC_LSFR_BIT10_AMPLITUDE_3             = 0x01, /*!< unmask bit[1:0]/ triangle amplitude equal to 3 */
+  DAC_LSFR_BIT20_AMPLITUDE_7             = 0x02, /*!< unmask bit[2:0]/ triangle amplitude equal to 7 */
+  DAC_LSFR_BIT30_AMPLITUDE_15            = 0x03, /*!< unmask bit[3:0]/ triangle amplitude equal to 15 */
+  DAC_LSFR_BIT40_AMPLITUDE_31            = 0x04, /*!< unmask bit[4:0]/ triangle amplitude equal to 31 */
+  DAC_LSFR_BIT50_AMPLITUDE_63            = 0x05, /*!< unmask bit[5:0]/ triangle amplitude equal to 63 */
+  DAC_LSFR_BIT60_AMPLITUDE_127           = 0x06, /*!< unmask bit[6:0]/ triangle amplitude equal to 127 */
+  DAC_LSFR_BIT70_AMPLITUDE_255           = 0x07, /*!< unmask bit[7:0]/ triangle amplitude equal to 255 */
+  DAC_LSFR_BIT80_AMPLITUDE_511           = 0x08, /*!< unmask bit[8:0]/ triangle amplitude equal to 511 */
+  DAC_LSFR_BIT90_AMPLITUDE_1023          = 0x09, /*!< unmask bit[9:0]/ triangle amplitude equal to 1023 */
+  DAC_LSFR_BITA0_AMPLITUDE_2047          = 0x0A, /*!< unmask bit[10:0]/ triangle amplitude equal to 2047 */
+  DAC_LSFR_BITB0_AMPLITUDE_4095          = 0x0B  /*!< unmask bit[11:0]/ triangle amplitude equal to 4095 */
+} dac_mask_amplitude_type;
+
+/**
+  * @brief  dac1 aligned data type
+  */
+typedef enum
+{
+  DAC1_12BIT_RIGHT                       = 0x40007408, /*!< dac1 12-bit data right-aligned */
+  DAC1_12BIT_LEFT                        = 0x4000740C, /*!< dac1 12-bit data left-aligned */
+  DAC1_8BIT_RIGHT                        = 0x40007410  /*!< dac1 8-bit data right-aligned */
+} dac1_aligned_data_type;
+
+/**
+  * @brief  dac2 aligned data type
+  */
+typedef enum
+{
+  DAC2_12BIT_RIGHT                       = 0x40007414, /*!< dac2 12-bit data right-aligned */
+  DAC2_12BIT_LEFT                        = 0x40007418, /*!< dac2 12-bit data left-aligned */
+  DAC2_8BIT_RIGHT                        = 0x4000741C  /*!< dac2 8-bit data right-aligned */
+} dac2_aligned_data_type;
+
+/**
+  * @brief  dac dual data type
+  */
+typedef enum
+{
+  DAC_DUAL_12BIT_RIGHT                   = 0x40007420, /*!<double dac 12-bit data right-aligned */
+  DAC_DUAL_12BIT_LEFT                    = 0x40007424, /*!<double dac 12-bit data left-aligned */
+  DAC_DUAL_8BIT_RIGHT                    = 0x40007428  /*!<double dac 8-bit data right-aligned */
+} dac_dual_data_type;
+
+/**
+  * @brief type define dac register all
+  */
+typedef struct
+{
+  /**
+    * @brief dac ctrl register, offset:0x00
+    */
+  union
+  {
+    __IO uint32_t ctrl;
+    struct
+    {
+      __IO uint32_t d1en                 : 1; /* [0] */
+      __IO uint32_t d1obdis              : 1; /* [1] */
+      __IO uint32_t d1trgen              : 1; /* [2] */
+      __IO uint32_t d1trgsel             : 3; /* [5:3] */
+      __IO uint32_t d1nm                 : 2; /* [7:6] */
+      __IO uint32_t d1nbsel              : 4; /* [11:8] */
+      __IO uint32_t d1dmaen              : 1; /* [12] */
+      __IO uint32_t d1dmaudrien          : 1; /* [13] */
+      __IO uint32_t reserved1            : 2; /* [15:14] */
+      __IO uint32_t d2en                 : 1; /* [16] */
+      __IO uint32_t d2obdis              : 1; /* [17] */
+      __IO uint32_t d2trgen              : 1; /* [18] */
+      __IO uint32_t d2trgsel             : 3; /* [21:19] */
+      __IO uint32_t d2nm                 : 2; /* [23:22] */
+      __IO uint32_t d2nbsel              : 4; /* [27:24] */
+      __IO uint32_t d2dmaen              : 1; /* [28] */
+      __IO uint32_t d2dmaudrien          : 1; /* [29] */
+      __IO uint32_t reserved2            : 2; /* [31:30] */
+    } ctrl_bit;
+  };
+
+ /**
+    * @brief dac swtrg register, offset:0x04
+    */
+  union
+  {
+    __IO uint32_t swtrg;
+    struct
+    {
+      __IO uint32_t d1swtrg              : 1; /* [0] */
+      __IO uint32_t d2swtrg              : 1; /* [1] */
+      __IO uint32_t reserved1            : 30;/* [31:2] */
+    } swtrg_bit;
+  };
+
+ /**
+    * @brief dac d1dth12r register, offset:0x08
+    */
+  union
+  {
+    __IO uint32_t d1dth12r;
+    struct
+    {
+      __IO uint32_t d1dt12r              : 12;/* [11:0] */
+      __IO uint32_t reserved1            : 20;/* [31:2] */
+    } d1dth12r_bit;
+  };
+
+ /**
+    * @brief dac d1dth12l register, offset:0x0C
+    */
+  union
+  {
+    __IO uint32_t d1dth12l;
+    struct
+    {
+      __IO uint32_t d1dt12l              : 12;/* [11:0] */
+      __IO uint32_t reserved1            : 20;/* [31:2] */
+    } d1dth12l_bit;
+  };
+
+ /**
+    * @brief dac d1dth8r register, offset:0x10
+    */
+  union
+  {
+    __IO uint32_t d1dth8r;
+    struct
+    {
+      __IO uint32_t d1dt8r               : 8; /* [7:0] */
+      __IO uint32_t reserved1            : 24;/* [31:8] */
+    } d1dth8r_bit;
+  };
+
+ /**
+    * @brief dac d2dth12r register, offset:0x14
+    */
+  union
+  {
+    __IO uint32_t d2dth12r;
+    struct
+    {
+      __IO uint32_t d2dt12r              : 12;/* [11:0] */
+      __IO uint32_t reserved1            : 20;/* [31:2] */
+    } d2dth12r_bit;
+  };
+
+ /**
+    * @brief dac d2dth12l register, offset:0x18
+    */
+  union
+  {
+    __IO uint32_t d2dth12l;
+    struct
+    {
+      __IO uint32_t d2dt12l              : 12;/* [11:0] */
+      __IO uint32_t reserved1            : 20;/* [31:2] */
+    } d2dth12l_bit;
+  };
+
+ /**
+    * @brief dac d2dth8r register, offset:0x1C
+    */
+  union
+  {
+    __IO uint32_t d2dth8r;
+    struct
+    {
+      __IO uint32_t d2dt8r               : 8; /* [7:0] */
+      __IO uint32_t reserved1            : 24;/* [31:8] */
+    } d2dth8r_bit;
+  };
+
+ /**
+    * @brief dac ddth12r register, offset:0x20
+    */
+  union
+  {
+    __IO uint32_t ddth12r;
+    struct
+    {
+      __IO uint32_t dd1dt12r             : 12;/* [11:0] */
+      __IO uint32_t reserved1            : 4; /* [15:12] */
+      __IO uint32_t dd2dt12r             : 12;/* [27:16] */
+      __IO uint32_t reserved2            : 4; /* [31:28] */
+    } ddth12r_bit;
+  };
+
+ /**
+    * @brief dac ddth12l register, offset:0x24
+    */
+  union
+  {
+    __IO uint32_t ddth12l;
+    struct
+    {
+      __IO uint32_t reserved1            : 4; /* [3:0] */
+      __IO uint32_t dd1dt12l             : 12;/* [15:4] */
+      __IO uint32_t reserved2            : 4; /* [19:16] */
+      __IO uint32_t dd2dt12l             : 12;/* [31:20] */
+    } ddth12l_bit;
+  };
+
+ /**
+    * @brief dac ddth8r register, offset:0x28
+    */
+  union
+  {
+    __IO uint32_t ddth8r;
+    struct
+    {
+      __IO uint32_t dd1dt8r              : 8; /* [7:0] */
+      __IO uint32_t dd2dt8r              : 8; /* [15:8] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } ddth8r_bit;
+  };
+
+ /**
+    * @brief dac d1odt register, offset:0x2c
+    */
+  union
+  {
+    __IO uint32_t d1odt;
+    struct
+    {
+      __IO uint32_t d1odt                : 12;/* [11:0] */
+      __IO uint32_t reserved1            : 20;/* [31:12] */
+    } d1odt_bit;
+  };
+
+ /**
+    * @brief dac d2odt register, offset:0x30
+    */
+  union
+  {
+    __IO uint32_t d2odt;
+    struct
+    {
+      __IO uint32_t d2odt                : 12;/* [11:0] */
+      __IO uint32_t reserved1            : 20;/* [31:12] */
+    } d2odt_bit;
+  };
+
+ /**
+    * @brief dac sr register, offset:0x34
+    */
+  union
+  {
+    __IO uint32_t sts;
+    struct
+    {
+      __IO uint32_t reserved1            : 13;/* [12:0] */
+      __IO uint32_t d1dmaudrf            : 1; /* [13] */
+      __IO uint32_t reserved2            : 15;/* [28:14] */
+      __IO uint32_t d2dmaudrf            : 1; /* [29] */
+      __IO uint32_t reserved3            : 2;/* [31:30] */
+    } sts_bit;
+  };
+} dac_type;
+
+/**
+  * @}
+  */
+
+#define DAC                              ((dac_type *) DAC_BASE)
+
+/** @defgroup DAC_exported_functions
+  * @{
+  */
+
+void dac_reset(void);
+void dac_enable(dac_select_type dac_select, confirm_state new_state);
+void dac_output_buffer_enable(dac_select_type dac_select, confirm_state new_state);
+void dac_trigger_enable(dac_select_type dac_select, confirm_state new_state);
+void dac_trigger_select(dac_select_type dac_select, dac_trigger_type dac_trigger_source);
+void dac_software_trigger_generate(dac_select_type dac_select);
+void dac_dual_software_trigger_generate(void);
+void dac_wave_generate(dac_select_type dac_select, dac_wave_type dac_wave);
+void dac_mask_amplitude_select(dac_select_type dac_select, dac_mask_amplitude_type dac_mask_amplitude);
+void dac_dma_enable(dac_select_type dac_select, confirm_state new_state);
+uint16_t dac_data_output_get(dac_select_type dac_select);
+void dac_1_data_set(dac1_aligned_data_type dac1_aligned, uint16_t dac1_data);
+void dac_2_data_set(dac2_aligned_data_type dac2_aligned, uint16_t dac2_data);
+void dac_dual_data_set(dac_dual_data_type dac_dual, uint16_t data1, uint16_t data2);
+void dac_udr_enable(dac_select_type dac_select, confirm_state new_state);
+flag_status dac_udr_flag_get(dac_select_type dac_select);
+flag_status dac_udr_interrupt_flag_get(dac_select_type dac_select);
+void dac_udr_flag_clear(dac_select_type dac_select);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_debug.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_debug.h
@@ -1,0 +1,226 @@
+/**
+  **************************************************************************
+  * @file     at32f423_debug.h
+  * @brief    at32f423 debug header file
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __AT32F423_DEBUG_H
+#define __AT32F423_DEBUG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "at32f423.h"
+
+/** @addtogroup AT32F423_periph_driver
+  * @{
+  */
+
+/** @addtogroup DEBUG
+  * @{
+  */
+
+/** @defgroup DEBUG_mode_definition
+  * @{
+  */
+
+/* debug ctrl register bit */
+#define DEBUG_SLEEP                      0x00000001 /*!< debug sleep mode */
+#define DEBUG_DEEPSLEEP                  0x00000002 /*!< debug deepsleep mode */
+#define DEBUG_STANDBY                    0x00000004 /*!< debug standby mode */
+
+/* debug apb1 frz register bit */
+#define DEBUG_TMR2_PAUSE                 0x00000001 /*!< debug timer2 pause */
+#define DEBUG_TMR3_PAUSE                 0x00000002 /*!< debug timer3 pause */
+#define DEBUG_TMR4_PAUSE                 0x00000004 /*!< debug timer4 pause */
+#define DEBUG_TMR6_PAUSE                 0x00000010 /*!< debug timer6 pause */
+#define DEBUG_TMR7_PAUSE                 0x00000020 /*!< debug timer7 pause */
+#define DEBUG_TMR12_PAUSE                0x00000040 /*!< debug timer12 pause */
+#define DEBUG_TMR13_PAUSE                0x00000080 /*!< debug timer13 pause */
+#define DEBUG_TMR14_PAUSE                0x00000100 /*!< debug timer14 pause */
+#define DEBUG_ERTC_PAUSE                 0x00000400 /*!< debug ertc pause */
+#define DEBUG_WWDT_PAUSE                 0x00000800 /*!< debug window watchdog timer pause */
+#define DEBUG_WDT_PAUSE                  0x00001000 /*!< debug watchdog timer pause */
+#define DEBUG_ERTC_512_PAUSE             0x00008000 /*!< debug ertc_512 pause */
+#define DEBUG_I2C1_SMBUS_TIMEOUT         0x01000000 /*!< debug i2c1 smbus timeout */
+#define DEBUG_I2C2_SMBUS_TIMEOUT         0x08000000 /*!< debug i2c2 smbus timeout */
+#define DEBUG_I2C3_SMBUS_TIMEOUT         0x10000000 /*!< debug i2c3 smbus timeout */
+#define DEBUG_CAN1_PAUSE                 0x02000000 /*!< debug can1 pause */
+#define DEBUG_CAN2_PAUSE                 0x04000000 /*!< debug can2 pause */
+
+/* debug apb2 frz register bit */
+#define DEBUG_TMR1_PAUSE                 0x00000001 /*!< debug timer1 pause */
+#define DEBUG_TMR9_PAUSE                 0x00010000 /*!< debug timer9 pause */
+#define DEBUG_TMR10_PAUSE                0x00020000 /*!< debug timer10 pause */
+#define DEBUG_TMR11_PAUSE                0x00040000 /*!< debug timer11 pause */
+
+/**
+  * @}
+  */
+
+/** @defgroup DEBUG_exported_types
+  * @{
+  */
+
+/**
+  * @brief type define debug register all
+  */
+typedef struct
+{
+  /**
+    * @brief debug idcode register, offset:0x00
+    */
+  union
+  {
+    __IO uint32_t pid;
+    struct
+    {
+      __IO uint32_t pid                  : 32;/* [31:0] */
+    } idcode_bit;
+  };
+
+  /**
+    * @brief debug ctrl register, offset:0x04
+    */
+  union
+  {
+    __IO uint32_t ctrl;
+    struct
+    {
+      __IO uint32_t sleep_debug          : 1;/* [0] */
+      __IO uint32_t deepsleep_debug      : 1;/* [1] */
+      __IO uint32_t standby_debug        : 1;/* [2] */
+      __IO uint32_t reserved1            : 29;/* [31:3] */
+    } ctrl_bit;
+  };
+
+  /**
+    * @brief debug apb1 frz register, offset:0x08
+    */
+  union
+  {
+    __IO uint32_t apb1_frz;
+    struct
+    {
+      __IO uint32_t tmr2_pause           : 1;/* [0] */
+      __IO uint32_t tmr3_pause           : 1;/* [1] */
+      __IO uint32_t tmr4_pause           : 1;/* [2] */
+      __IO uint32_t reserved1            : 1;/* [3] */
+      __IO uint32_t tmr6_pause           : 1;/* [4] */
+      __IO uint32_t tmr7_pause           : 1;/* [5] */
+      __IO uint32_t tmr12_pause          : 1;/* [6] */
+      __IO uint32_t tmr13_pause          : 1;/* [7] */
+      __IO uint32_t tmr14_pause          : 1;/* [8] */
+      __IO uint32_t reserved2            : 1;/* [9] */
+      __IO uint32_t ertc_pause           : 1;/* [10] */
+      __IO uint32_t wwdt_pause           : 1;/* [11] */
+      __IO uint32_t wdt_pause            : 1;/* [12] */
+      __IO uint32_t reserved3            : 2;/* [14:13] */
+      __IO uint32_t ertc_512_pause       : 1;/* [15] */
+      __IO uint32_t reserved4            : 8;/* [23:16] */
+      __IO uint32_t i2c1_smbus_timeout   : 1;/* [24] */
+      __IO uint32_t can1_pause           : 1;/* [25] */
+      __IO uint32_t can2_pause           : 1;/* [26] */
+      __IO uint32_t i2c2_smbus_timeout   : 1;/* [27] */
+      __IO uint32_t i2c3_smbus_timeout   : 1;/* [28] */
+      __IO uint32_t reserved5            : 3;/* [31:29] */
+    } apb1_frz_bit;
+  };
+
+  /**
+    * @brief debug apb2 frz register, offset:0x0C
+    */
+  union
+  {
+    __IO uint32_t apb2_frz;
+    struct
+    {
+      __IO uint32_t tmr1_pause           : 1;/* [0] */
+      __IO uint32_t reserved1            : 1;/* [1] */
+      __IO uint32_t reserved2            : 4;/* [5:2] */
+      __IO uint32_t reserved3            : 1;/* [6] */
+      __IO uint32_t reserved4            : 9;/* [15:7] */
+      __IO uint32_t tmr9_pause           : 1;/* [16] */
+      __IO uint32_t tmr10_pause          : 1;/* [17] */
+      __IO uint32_t tmr11_pause          : 1;/* [18] */
+      __IO uint32_t reserved5            : 13;/* [31:19] */
+    } apb2_frz_bit;
+  };
+
+  /**
+    * @brief debug reserved1 register, offset:0x10~0x1C
+    */
+  __IO uint32_t reserved1[4];
+
+  /**
+    * @brief debug ser id register, offset:0x20
+    */
+  union
+  {
+    __IO uint32_t ser_id;
+    struct
+    {
+      __IO uint32_t rev_id               : 3;/* [2:0] */
+      __IO uint32_t reserved1            : 5;/* [7:3] */
+      __IO uint32_t ser_id               : 8;/* [15:8] */
+      __IO uint32_t reserved2            : 16;/* [31:16] */
+    } ser_id_bit;
+  };
+
+} debug_type;
+
+/**
+  * @}
+  */
+
+#define DEBUGMCU                         ((debug_type *) DEBUG_BASE)
+
+/** @defgroup DEBUG_exported_functions
+  * @{
+  */
+
+uint32_t debug_device_id_get(void);
+void debug_low_power_mode_set(uint32_t low_power_mode, confirm_state new_state);
+void debug_apb1_periph_mode_set(uint32_t apb1_periph, confirm_state new_state);
+void debug_apb2_periph_mode_set(uint32_t apb2_periph, confirm_state new_state);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_def.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_def.h
@@ -1,0 +1,70 @@
+/**
+  **************************************************************************
+  * @file     at32f423_def.h
+  * @brief    at32f423 macros header file
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __AT32F423_DEF_H
+#define __AT32F423_DEF_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* gnu compiler */
+#if defined (__GNUC__)
+  #ifndef ALIGNED_HEAD
+    #define ALIGNED_HEAD
+  #endif
+  #ifndef ALIGNED_TAIL
+    #define ALIGNED_TAIL                 __attribute__ ((aligned (4)))
+  #endif
+#endif
+
+/* arm compiler */
+#if defined (__CC_ARM)
+  #ifndef ALIGNED_HEAD
+    #define ALIGNED_HEAD                 __align(4)
+  #endif
+  #ifndef ALIGNED_TAIL
+    #define ALIGNED_TAIL
+  #endif
+#endif
+
+/* iar compiler */
+#if defined (__ICCARM__)
+  #ifndef ALIGNED_HEAD
+    #define ALIGNED_HEAD
+  #endif
+  #ifndef ALIGNED_TAIL
+    #define ALIGNED_TAIL
+  #endif
+#endif
+
+#define UNUSED(x)                        (void)x /* to avoid gcc/g++ warnings */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_dma.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_dma.h
@@ -1,0 +1,773 @@
+/**
+  **************************************************************************
+  * @file     at32f423_dma.h
+  * @brief    at32f423 dma header file
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __AT32F423_DMA_H
+#define __AT32F423_DMA_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "at32f423.h"
+
+/** @addtogroup AT32F423_periph_driver
+  * @{
+  */
+
+/** @addtogroup DMA
+  * @{
+  */
+
+/** @defgroup DMA_interrupts_definition
+  * @brief dma interrupt
+  * @{
+  */
+
+#define DMA_FDT_INT                      ((uint32_t)0x00000002) /*!< dma full data transfer interrupt */
+#define DMA_HDT_INT                      ((uint32_t)0x00000004) /*!< dma half data transfer interrupt */
+#define DMA_DTERR_INT                    ((uint32_t)0x00000008) /*!< dma errorr interrupt */
+
+/**
+  * @}
+  */
+
+/** @defgroup DMA_flags_definition
+  * @brief dma flag
+  * @{
+  */
+
+#define DMA1_GL1_FLAG                    ((uint32_t)0x00000001) /*!< dma1 channel1 global flag */
+#define DMA1_FDT1_FLAG                   ((uint32_t)0x00000002) /*!< dma1 channel1 full data transfer flag */
+#define DMA1_HDT1_FLAG                   ((uint32_t)0x00000004) /*!< dma1 channel1 half data transfer flag */
+#define DMA1_DTERR1_FLAG                 ((uint32_t)0x00000008) /*!< dma1 channel1 error flag */
+#define DMA1_GL2_FLAG                    ((uint32_t)0x00000010) /*!< dma1 channel2 global flag */
+#define DMA1_FDT2_FLAG                   ((uint32_t)0x00000020) /*!< dma1 channel2 full data transfer flag */
+#define DMA1_HDT2_FLAG                   ((uint32_t)0x00000040) /*!< dma1 channel2 half data transfer flag */
+#define DMA1_DTERR2_FLAG                 ((uint32_t)0x00000080) /*!< dma1 channel2 error flag */
+#define DMA1_GL3_FLAG                    ((uint32_t)0x00000100) /*!< dma1 channel3 global flag */
+#define DMA1_FDT3_FLAG                   ((uint32_t)0x00000200) /*!< dma1 channel3 full data transfer flag */
+#define DMA1_HDT3_FLAG                   ((uint32_t)0x00000400) /*!< dma1 channel3 half data transfer flag */
+#define DMA1_DTERR3_FLAG                 ((uint32_t)0x00000800) /*!< dma1 channel3 error flag */
+#define DMA1_GL4_FLAG                    ((uint32_t)0x00001000) /*!< dma1 channel4 global flag */
+#define DMA1_FDT4_FLAG                   ((uint32_t)0x00002000) /*!< dma1 channel4 full data transfer flag */
+#define DMA1_HDT4_FLAG                   ((uint32_t)0x00004000) /*!< dma1 channel4 half data transfer flag */
+#define DMA1_DTERR4_FLAG                 ((uint32_t)0x00008000) /*!< dma1 channel4 error flag */
+#define DMA1_GL5_FLAG                    ((uint32_t)0x00010000) /*!< dma1 channel5 global flag */
+#define DMA1_FDT5_FLAG                   ((uint32_t)0x00020000) /*!< dma1 channel5 full data transfer flag */
+#define DMA1_HDT5_FLAG                   ((uint32_t)0x00040000) /*!< dma1 channel5 half data transfer flag */
+#define DMA1_DTERR5_FLAG                 ((uint32_t)0x00080000) /*!< dma1 channel5 error flag */
+#define DMA1_GL6_FLAG                    ((uint32_t)0x00100000) /*!< dma1 channel6 global flag */
+#define DMA1_FDT6_FLAG                   ((uint32_t)0x00200000) /*!< dma1 channel6 full data transfer flag */
+#define DMA1_HDT6_FLAG                   ((uint32_t)0x00400000) /*!< dma1 channel6 half data transfer flag */
+#define DMA1_DTERR6_FLAG                 ((uint32_t)0x00800000) /*!< dma1 channel6 error flag */
+#define DMA1_GL7_FLAG                    ((uint32_t)0x01000000) /*!< dma1 channel7 global flag */
+#define DMA1_FDT7_FLAG                   ((uint32_t)0x02000000) /*!< dma1 channel7 full data transfer flag */
+#define DMA1_HDT7_FLAG                   ((uint32_t)0x04000000) /*!< dma1 channel7 half data transfer flag */
+#define DMA1_DTERR7_FLAG                 ((uint32_t)0x08000000) /*!< dma1 channel7 error flag */
+
+#define DMA2_GL1_FLAG                    ((uint32_t)0x10000001) /*!< dma2 channel1 global flag */
+#define DMA2_FDT1_FLAG                   ((uint32_t)0x10000002) /*!< dma2 channel1 full data transfer flag */
+#define DMA2_HDT1_FLAG                   ((uint32_t)0x10000004) /*!< dma2 channel1 half data transfer flag */
+#define DMA2_DTERR1_FLAG                 ((uint32_t)0x10000008) /*!< dma2 channel1 error flag */
+#define DMA2_GL2_FLAG                    ((uint32_t)0x10000010) /*!< dma2 channel2 global flag */
+#define DMA2_FDT2_FLAG                   ((uint32_t)0x10000020) /*!< dma2 channel2 full data transfer flag */
+#define DMA2_HDT2_FLAG                   ((uint32_t)0x10000040) /*!< dma2 channel2 half data transfer flag */
+#define DMA2_DTERR2_FLAG                 ((uint32_t)0x10000080) /*!< dma2 channel2 error flag */
+#define DMA2_GL3_FLAG                    ((uint32_t)0x10000100) /*!< dma2 channel3 global flag */
+#define DMA2_FDT3_FLAG                   ((uint32_t)0x10000200) /*!< dma2 channel3 full data transfer flag */
+#define DMA2_HDT3_FLAG                   ((uint32_t)0x10000400) /*!< dma2 channel3 half data transfer flag */
+#define DMA2_DTERR3_FLAG                 ((uint32_t)0x10000800) /*!< dma2 channel3 error flag */
+#define DMA2_GL4_FLAG                    ((uint32_t)0x10001000) /*!< dma2 channel4 global flag */
+#define DMA2_FDT4_FLAG                   ((uint32_t)0x10002000) /*!< dma2 channel4 full data transfer flag */
+#define DMA2_HDT4_FLAG                   ((uint32_t)0x10004000) /*!< dma2 channel4 half data transfer flag */
+#define DMA2_DTERR4_FLAG                 ((uint32_t)0x10008000) /*!< dma2 channel4 error flag */
+#define DMA2_GL5_FLAG                    ((uint32_t)0x10010000) /*!< dma2 channel5 global flag */
+#define DMA2_FDT5_FLAG                   ((uint32_t)0x10020000) /*!< dma2 channel5 full data transfer flag */
+#define DMA2_HDT5_FLAG                   ((uint32_t)0x10040000) /*!< dma2 channel5 half data transfer flag */
+#define DMA2_DTERR5_FLAG                 ((uint32_t)0x10080000) /*!< dma2 channel5 error flag */
+#define DMA2_GL6_FLAG                    ((uint32_t)0x10100000) /*!< dma2 channel6 global flag */
+#define DMA2_FDT6_FLAG                   ((uint32_t)0x10200000) /*!< dma2 channel6 full data transfer flag */
+#define DMA2_HDT6_FLAG                   ((uint32_t)0x10400000) /*!< dma2 channel6 half data transfer flag */
+#define DMA2_DTERR6_FLAG                 ((uint32_t)0x10800000) /*!< dma2 channel6 error flag */
+#define DMA2_GL7_FLAG                    ((uint32_t)0x11000000) /*!< dma2 channel7 global flag */
+#define DMA2_FDT7_FLAG                   ((uint32_t)0x12000000) /*!< dma2 channel7 full data transfer flag */
+#define DMA2_HDT7_FLAG                   ((uint32_t)0x14000000) /*!< dma2 channel7 half data transfer flag */
+#define DMA2_DTERR7_FLAG                 ((uint32_t)0x18000000) /*!< dma2 channel7 error flag */
+
+/**
+  * @brief dmamux flag
+  */
+#define DMAMUX_SYNC_OV1_FLAG             ((uint32_t)0x00000001) /*!< dmamux channel1 synchronization overrun event flag */
+#define DMAMUX_SYNC_OV2_FLAG             ((uint32_t)0x00000002) /*!< dmamux channel2 synchronization overrun event flag */
+#define DMAMUX_SYNC_OV3_FLAG             ((uint32_t)0x00000004) /*!< dmamux channel3 synchronization overrun event flag */
+#define DMAMUX_SYNC_OV4_FLAG             ((uint32_t)0x00000008) /*!< dmamux channel4 synchronization overrun event flag */
+#define DMAMUX_SYNC_OV5_FLAG             ((uint32_t)0x00000010) /*!< dmamux channel5 synchronization overrun event flag */
+#define DMAMUX_SYNC_OV6_FLAG             ((uint32_t)0x00000020) /*!< dmamux channel6 synchronization overrun event flag */
+#define DMAMUX_SYNC_OV7_FLAG             ((uint32_t)0x00000040) /*!< dmamux channel7 synchronization overrun event flag */
+
+#define DMAMUX_GEN_TRIG_OV1_FLAG         ((uint32_t)0x00000001) /*!< dmamux generator channel1 overrun event flag */
+#define DMAMUX_GEN_TRIG_OV2_FLAG         ((uint32_t)0x00000002) /*!< dmamux generator channel2 overrun event flag */
+#define DMAMUX_GEN_TRIG_OV3_FLAG         ((uint32_t)0x00000004) /*!< dmamux generator channel3 overrun event flag */
+#define DMAMUX_GEN_TRIG_OV4_FLAG         ((uint32_t)0x00000008) /*!< dmamux generator channel4 overrun event flag */
+
+/**
+  * @}
+  */
+
+/** @defgroup DMA_exported_types
+  * @{
+  */
+
+/**
+  * @brief dma direction type
+  */
+typedef enum
+{
+  DMA_DIR_PERIPHERAL_TO_MEMORY           = 0x0000, /*!< dma data transfer direction: peripheral to memory */
+  DMA_DIR_MEMORY_TO_PERIPHERAL           = 0x0010, /*!< dma data transfer direction: memory to peripheral */
+  DMA_DIR_MEMORY_TO_MEMORY               = 0x4000  /*!< dma data transfer direction: memory to memory,
+                                                        note:if the direction is memory to memory,peripheral_base_addr as source and memory_base_addr as destnation */
+} dma_dir_type;
+
+/**
+  * @brief dma peripheral data size type
+  */
+typedef enum
+{
+  DMA_PERIPHERAL_DATA_WIDTH_BYTE         = 0x00, /*!< dma peripheral databus width 8bit */
+  DMA_PERIPHERAL_DATA_WIDTH_HALFWORD     = 0x01, /*!< dma peripheral databus width 16bit */
+  DMA_PERIPHERAL_DATA_WIDTH_WORD         = 0x02  /*!< dma peripheral databus width 32bit */
+} dma_peripheral_data_size_type;
+
+/**
+  * @brief dma memory data size type
+  */
+typedef enum
+{
+  DMA_MEMORY_DATA_WIDTH_BYTE             = 0x00, /*!< dma memory databus width 8bit */
+  DMA_MEMORY_DATA_WIDTH_HALFWORD         = 0x01, /*!< dma memory databus width 16bit */
+  DMA_MEMORY_DATA_WIDTH_WORD             = 0x02  /*!< dma memory databus width 32bit */
+} dma_memory_data_size_type;
+
+/**
+  * @brief dma priority level type
+  */
+typedef enum
+{
+  DMA_PRIORITY_LOW                       = 0x00, /*!< dma channel priority: low */
+  DMA_PRIORITY_MEDIUM                    = 0x01, /*!< dma channel priority: medium */
+  DMA_PRIORITY_HIGH                      = 0x02, /*!< dma channel priority: high */
+  DMA_PRIORITY_VERY_HIGH                 = 0x03  /*!< dma channel priority: very high */
+} dma_priority_level_type;
+
+/**
+  * @brief dmamux request type
+  */
+typedef enum
+{
+  DMAMUX_DMAREQ_ID_REQ_G1                = 0x01, /*!< dmamux channel dma request inputs resources: generator channel1 */
+  DMAMUX_DMAREQ_ID_REQ_G2                = 0x02, /*!< dmamux channel dma request inputs resources: generator channel2 */
+  DMAMUX_DMAREQ_ID_REQ_G3                = 0x03, /*!< dmamux channel dma request inputs resources: generator channel3 */
+  DMAMUX_DMAREQ_ID_REQ_G4                = 0x04, /*!< dmamux channel dma request inputs resources: generator channel4 */
+  DMAMUX_DMAREQ_ID_ADC1                  = 0x05, /*!< dmamux channel dma request inputs resources: adc1 */
+  DMAMUX_DMAREQ_ID_DAC1                  = 0x06, /*!< dmamux channel dma request inputs resources: dac1 */
+  DMAMUX_DMAREQ_ID_DAC2                  = 0x29, /*!< dmamux channel dma request inputs resources: dac2 */
+  DMAMUX_DMAREQ_ID_TMR6_OVERFLOW         = 0x08, /*!< dmamux channel dma request inputs resources: timer6 overflow */
+  DMAMUX_DMAREQ_ID_TMR7_OVERFLOW         = 0x09, /*!< dmamux channel dma request inputs resources: timer7 overflow */
+  DMAMUX_DMAREQ_ID_SPI1_RX               = 0x0A, /*!< dmamux channel dma request inputs resources: spi1 rx */
+  DMAMUX_DMAREQ_ID_SPI1_TX               = 0x0B, /*!< dmamux channel dma request inputs resources: spi1 tx */
+  DMAMUX_DMAREQ_ID_SPI2_RX               = 0x0C, /*!< dmamux channel dma request inputs resources: spi2 rx */
+  DMAMUX_DMAREQ_ID_SPI2_TX               = 0x0D, /*!< dmamux channel dma request inputs resources: spi2 tx */
+  DMAMUX_DMAREQ_ID_SPI3_RX               = 0x0E, /*!< dmamux channel dma request inputs resources: spi3 rx */
+  DMAMUX_DMAREQ_ID_SPI3_TX               = 0x0F, /*!< dmamux channel dma request inputs resources: spi3 tx */
+  DMAMUX_DMAREQ_ID_I2C1_RX               = 0x10, /*!< dmamux channel dma request inputs resources: i2c1_rx */
+  DMAMUX_DMAREQ_ID_I2C1_TX               = 0x11, /*!< dmamux channel dma request inputs resources: i2c1_tx */
+  DMAMUX_DMAREQ_ID_I2C2_RX               = 0x12, /*!< dmamux channel dma request inputs resources: i2c2_rx */
+  DMAMUX_DMAREQ_ID_I2C2_TX               = 0x13, /*!< dmamux channel dma request inputs resources: i2c2_tx */
+  DMAMUX_DMAREQ_ID_I2C3_RX               = 0x14, /*!< dmamux channel dma request inputs resources: i2c3_rx */
+  DMAMUX_DMAREQ_ID_I2C3_TX               = 0x15, /*!< dmamux channel dma request inputs resources: i2c3_tx */
+  DMAMUX_DMAREQ_ID_USART1_RX             = 0x18, /*!< dmamux channel dma request inputs resources: usart1_rx */
+  DMAMUX_DMAREQ_ID_USART1_TX             = 0x19, /*!< dmamux channel dma request inputs resources: usart1_tx */
+  DMAMUX_DMAREQ_ID_USART2_RX             = 0x1A, /*!< dmamux channel dma request inputs resources: usart2_rx */
+  DMAMUX_DMAREQ_ID_USART2_TX             = 0x1B, /*!< dmamux channel dma request inputs resources: usart2_tx */
+  DMAMUX_DMAREQ_ID_USART3_RX             = 0x1C, /*!< dmamux channel dma request inputs resources: usart3_rx */
+  DMAMUX_DMAREQ_ID_USART3_TX             = 0x1D, /*!< dmamux channel dma request inputs resources: usart3_tx */
+  DMAMUX_DMAREQ_ID_USART4_RX             = 0x1E, /*!< dmamux channel dma request inputs resources: uart4_rx */
+  DMAMUX_DMAREQ_ID_USART4_TX             = 0x1F, /*!< dmamux channel dma request inputs resources: uart4_tx */
+  DMAMUX_DMAREQ_ID_USART5_RX             = 0x20, /*!< dmamux channel dma request inputs resources: uart5_rx */
+  DMAMUX_DMAREQ_ID_USART5_TX             = 0x21, /*!< dmamux channel dma request inputs resources: uart5_tx */
+  DMAMUX_DMAREQ_ID_USART6_RX             = 0x72, /*!< dmamux channel dma request inputs resources: usart6_rx */
+  DMAMUX_DMAREQ_ID_USART6_TX             = 0x73, /*!< dmamux channel dma request inputs resources: usart6_tx */
+  DMAMUX_DMAREQ_ID_USART7_RX             = 0x74, /*!< dmamux channel dma request inputs resources: uart7_rx */
+  DMAMUX_DMAREQ_ID_USART7_TX             = 0x75, /*!< dmamux channel dma request inputs resources: uart7_tx */
+  DMAMUX_DMAREQ_ID_USART8_RX             = 0x76, /*!< dmamux channel dma request inputs resources: uart8_rx */
+  DMAMUX_DMAREQ_ID_USART8_TX             = 0x77, /*!< dmamux channel dma request inputs resources: uart8_tx */
+  DMAMUX_DMAREQ_ID_TMR1_CH1              = 0x2A, /*!< dmamux channel dma request inputs resources: timer1 ch1 */
+  DMAMUX_DMAREQ_ID_TMR1_CH2              = 0x2B, /*!< dmamux channel dma request inputs resources: timer1 ch2 */
+  DMAMUX_DMAREQ_ID_TMR1_CH3              = 0x2C, /*!< dmamux channel dma request inputs resources: timer1 ch3 */
+  DMAMUX_DMAREQ_ID_TMR1_CH4              = 0x2D, /*!< dmamux channel dma request inputs resources: timer1 ch4 */
+  DMAMUX_DMAREQ_ID_TMR1_OVERFLOW         = 0x2E, /*!< dmamux channel dma request inputs resources: timer1 overflow */
+  DMAMUX_DMAREQ_ID_TMR1_TRIG             = 0x2F, /*!< dmamux channel dma request inputs resources: timer1 trigger */
+  DMAMUX_DMAREQ_ID_TMR1_HALL             = 0x30, /*!< dmamux channel dma request inputs resources: timer1 hall */
+  DMAMUX_DMAREQ_ID_TMR2_CH1              = 0x38, /*!< dmamux channel dma request inputs resources: timer2 ch1 */
+  DMAMUX_DMAREQ_ID_TMR2_CH2              = 0x39, /*!< dmamux channel dma request inputs resources: timer2 ch2 */
+  DMAMUX_DMAREQ_ID_TMR2_CH3              = 0x3A, /*!< dmamux channel dma request inputs resources: timer2 ch3 */
+  DMAMUX_DMAREQ_ID_TMR2_CH4              = 0x3B, /*!< dmamux channel dma request inputs resources: timer2 ch4 */
+  DMAMUX_DMAREQ_ID_TMR2_OVERFLOW         = 0x3C, /*!< dmamux channel dma request inputs resources: timer2 overflow */
+  DMAMUX_DMAREQ_ID_TMR2_TRIG             = 0x7E, /*!< dmamux channel dma request inputs resources: timer2 trigger */
+  DMAMUX_DMAREQ_ID_TMR3_CH1              = 0x3D, /*!< dmamux channel dma request inputs resources: timer3 ch1 */
+  DMAMUX_DMAREQ_ID_TMR3_CH2              = 0x3E, /*!< dmamux channel dma request inputs resources: timer3 ch2 */
+  DMAMUX_DMAREQ_ID_TMR3_CH3              = 0x3F, /*!< dmamux channel dma request inputs resources: timer3 ch3 */
+  DMAMUX_DMAREQ_ID_TMR3_CH4              = 0x40, /*!< dmamux channel dma request inputs resources: timer3 ch4 */
+  DMAMUX_DMAREQ_ID_TMR3_OVERFLOW         = 0x41, /*!< dmamux channel dma request inputs resources: timer3 overflow */
+  DMAMUX_DMAREQ_ID_TMR3_TRIG             = 0x42, /*!< dmamux channel dma request inputs resources: timer3 trigger */
+  DMAMUX_DMAREQ_ID_TMR4_CH1              = 0x43, /*!< dmamux channel dma request inputs resources: timer4 ch1 */
+  DMAMUX_DMAREQ_ID_TMR4_CH2              = 0x44, /*!< dmamux channel dma request inputs resources: timer4 ch2 */
+  DMAMUX_DMAREQ_ID_TMR4_CH3              = 0x45, /*!< dmamux channel dma request inputs resources: timer4 ch3 */
+  DMAMUX_DMAREQ_ID_TMR4_CH4              = 0x46, /*!< dmamux channel dma request inputs resources: timer4 ch4 */
+  DMAMUX_DMAREQ_ID_TMR4_OVERFLOW         = 0x47, /*!< dmamux channel dma request inputs resources: timer4 overflow */
+  DMAMUX_DMAREQ_ID_TMR4_TRIG             = 0x7F, /*!< dmamux channel dma request inputs resources: timer4 trigger */
+  DMAMUX_DMAREQ_ID_TMR9_CH1              = 0x4E, /*!< dmamux channel dma request inputs resources: timer9 ch1 */
+  DMAMUX_DMAREQ_ID_TMR9_CH2              = 0x7C, /*!< dmamux channel dma request inputs resources: timer9 ch2 */
+  DMAMUX_DMAREQ_ID_TMR9_OVERFLOW         = 0x4F, /*!< dmamux channel dma request inputs resources: timer9 overflow */
+  DMAMUX_DMAREQ_ID_TMR9_TRIG             = 0x50, /*!< dmamux channel dma request inputs resources: timer9 trigger */
+  DMAMUX_DMAREQ_ID_TMR9_HALL             = 0x51, /*!< dmamux channel dma request inputs resources: timer9 trigger */
+  DMAMUX_DMAREQ_ID_TMR10_CH1             = 0x52, /*!< dmamux channel dma request inputs resources: timer10 ch1 */
+  DMAMUX_DMAREQ_ID_TMR10_OVERFLOW        = 0x53, /*!< dmamux channel dma request inputs resources: timer10 overflow */
+  DMAMUX_DMAREQ_ID_TMR11_CH1             = 0x54, /*!< dmamux channel dma request inputs resources: timer11 ch1 */
+  DMAMUX_DMAREQ_ID_TMR11_OVERFLOW        = 0x55, /*!< dmamux channel dma request inputs resources: timer11 overflow */
+  DMAMUX_DMAREQ_ID_TMR12_CH1             = 0x5F, /*!< dmamux channel dma request inputs resources: timer12 ch1 */
+  DMAMUX_DMAREQ_ID_TMR12_CH2             = 0x7D, /*!< dmamux channel dma request inputs resources: timer12 ch2 */
+  DMAMUX_DMAREQ_ID_TMR12_OVERFLOW        = 0x60, /*!< dmamux channel dma request inputs resources: timer12 overflow */
+  DMAMUX_DMAREQ_ID_TMR12_TRIG            = 0x61, /*!< dmamux channel dma request inputs resources: timer12 trigger */
+  DMAMUX_DMAREQ_ID_TMR12_HALL            = 0x62, /*!< dmamux channel dma request inputs resources: timer12 trigger */
+  DMAMUX_DMAREQ_ID_TMR13_CH1             = 0x78, /*!< dmamux channel dma request inputs resources: timer13 ch1 */
+  DMAMUX_DMAREQ_ID_TMR13_OVERFLOW        = 0x79, /*!< dmamux channel dma request inputs resources: timer13 overflow */
+  DMAMUX_DMAREQ_ID_TMR14_CH1             = 0x7A, /*!< dmamux channel dma request inputs resources: timer14 ch1 */
+  DMAMUX_DMAREQ_ID_TMR14_OVERFLOW        = 0x7B, /*!< dmamux channel dma request inputs resources: timer14 overflow */
+} dmamux_requst_id_sel_type;
+
+/**
+  * @brief dmamux sync id type
+  */
+typedef enum
+{
+  DMAMUX_SYNC_ID_EXINT0                  = 0x00, /*!< dmamux channel synchronization inputs resources: exint line0 */
+  DMAMUX_SYNC_ID_EXINT1                  = 0x01, /*!< dmamux channel synchronization inputs resources: exint line1 */
+  DMAMUX_SYNC_ID_EXINT2                  = 0x02, /*!< dmamux channel synchronization inputs resources: exint line2 */
+  DMAMUX_SYNC_ID_EXINT3                  = 0x03, /*!< dmamux channel synchronization inputs resources: exint line3 */
+  DMAMUX_SYNC_ID_EXINT4                  = 0x04, /*!< dmamux channel synchronization inputs resources: exint line4 */
+  DMAMUX_SYNC_ID_EXINT5                  = 0x05, /*!< dmamux channel synchronization inputs resources: exint line5 */
+  DMAMUX_SYNC_ID_EXINT6                  = 0x06, /*!< dmamux channel synchronization inputs resources: exint line6 */
+  DMAMUX_SYNC_ID_EXINT7                  = 0x07, /*!< dmamux channel synchronization inputs resources: exint line7 */
+  DMAMUX_SYNC_ID_EXINT8                  = 0x08, /*!< dmamux channel synchronization inputs resources: exint line8 */
+  DMAMUX_SYNC_ID_EXINT9                  = 0x09, /*!< dmamux channel synchronization inputs resources: exint line9 */
+  DMAMUX_SYNC_ID_EXINT10                 = 0x0A, /*!< dmamux channel synchronization inputs resources: exint line10 */
+  DMAMUX_SYNC_ID_EXINT11                 = 0x0B, /*!< dmamux channel synchronization inputs resources: exint line11 */
+  DMAMUX_SYNC_ID_EXINT12                 = 0x0C, /*!< dmamux channel synchronization inputs resources: exint line12 */
+  DMAMUX_SYNC_ID_EXINT13                 = 0x0D, /*!< dmamux channel synchronization inputs resources: exint line13 */
+  DMAMUX_SYNC_ID_EXINT14                 = 0x0E, /*!< dmamux channel synchronization inputs resources: exint line14 */
+  DMAMUX_SYNC_ID_EXINT15                 = 0x0F, /*!< dmamux channel synchronization inputs resources: exint line15 */
+  DMAMUX_SYNC_ID_DMAMUX_CH1_EVT          = 0x10, /*!< dmamux channel synchronization inputs resources: dmamux channel1 event */
+  DMAMUX_SYNC_ID_DMAMUX_CH2_EVT          = 0x11, /*!< dmamux channel synchronization inputs resources: dmamux channel2 event */
+  DMAMUX_SYNC_ID_DMAMUX_CH3_EVT          = 0x12, /*!< dmamux channel synchronization inputs resources: dmamux channel3 event */
+  DMAMUX_SYNC_ID_DMAMUX_CH4_EVT          = 0x13, /*!< dmamux channel synchronization inputs resources: dmamux channel4 event */
+  DMAMUX_SYNC_ID_DMAMUX_CH5_EVT          = 0x14, /*!< dmamux channel synchronization inputs resources: dmamux channel5 event */
+  DMAMUX_SYNC_ID_DMAMUX_CH6_EVT          = 0x15, /*!< dmamux channel synchronization inputs resources: dmamux channel6 event */
+  DMAMUX_SYNC_ID_DMAMUX_CH7_EVT          = 0x16  /*!< dmamux channel synchronization inputs resources: dmamux channel7 event */
+} dmamux_sync_id_sel_type;
+
+/**
+  * @brief dmamux sync polarity type
+  */
+typedef enum
+{
+  DMAMUX_SYNC_POLARITY_DISABLE           = 0x00, /*!< dmamux channel synchronization inputs resources polarity default value */
+  DMAMUX_SYNC_POLARITY_RISING            = 0x01, /*!< dmamux channel synchronization inputs resources polarity: rising */
+  DMAMUX_SYNC_POLARITY_FALLING           = 0x02, /*!< dmamux channel synchronization inputs resources polarity: falling */
+  DMAMUX_SYNC_POLARITY_RISING_FALLING    = 0x03  /*!< dmamux channel synchronization inputs resources polarity: rising_falling */
+} dmamux_sync_pol_type;
+
+/**
+  * @brief dmamux generator id type
+  */
+typedef enum
+{
+  DMAMUX_GEN_ID_EXINT0                   = 0x00, /*!< dmamux generator channel inputs resources: exint line0 */
+  DMAMUX_GEN_ID_EXINT1                   = 0x01, /*!< dmamux generator channel inputs resources: exint line1 */
+  DMAMUX_GEN_ID_EXINT2                   = 0x02, /*!< dmamux generator channel inputs resources: exint line2 */
+  DMAMUX_GEN_ID_EXINT3                   = 0x03, /*!< dmamux generator channel inputs resources: exint line3 */
+  DMAMUX_GEN_ID_EXINT4                   = 0x04, /*!< dmamux generator channel inputs resources: exint line4 */
+  DMAMUX_GEN_ID_EXINT5                   = 0x05, /*!< dmamux generator channel inputs resources: exint line5 */
+  DMAMUX_GEN_ID_EXINT6                   = 0x06, /*!< dmamux generator channel inputs resources: exint line6 */
+  DMAMUX_GEN_ID_EXINT7                   = 0x07, /*!< dmamux generator channel inputs resources: exint line7 */
+  DMAMUX_GEN_ID_EXINT8                   = 0x08, /*!< dmamux generator channel inputs resources: exint line8 */
+  DMAMUX_GEN_ID_EXINT9                   = 0x09, /*!< dmamux generator channel inputs resources: exint line9 */
+  DMAMUX_GEN_ID_EXINT10                  = 0x0A, /*!< dmamux generator channel inputs resources: exint line10 */
+  DMAMUX_GEN_ID_EXINT11                  = 0x0B, /*!< dmamux generator channel inputs resources: exint line11 */
+  DMAMUX_GEN_ID_EXINT12                  = 0x0C, /*!< dmamux generator channel inputs resources: exint line12 */
+  DMAMUX_GEN_ID_EXINT13                  = 0x0D, /*!< dmamux generator channel inputs resources: exint line13 */
+  DMAMUX_GEN_ID_EXINT14                  = 0x0E, /*!< dmamux generator channel inputs resources: exint line14 */
+  DMAMUX_GEN_ID_EXINT15                  = 0x0F, /*!< dmamux generator channel inputs resources: exint line15 */
+  DMAMUX_GEN_ID_DMAMUX_CH1_EVT           = 0x10, /*!< dmamux generator channel inputs resources: dmamux channel1 event */
+  DMAMUX_GEN_ID_DMAMUX_CH2_EVT           = 0x11, /*!< dmamux generator channel inputs resources: dmamux channel2 event */
+  DMAMUX_GEN_ID_DMAMUX_CH3_EVT           = 0x12, /*!< dmamux generator channel inputs resources: dmamux channel3 event */
+  DMAMUX_GEN_ID_DMAMUX_CH4_EVT           = 0x13, /*!< dmamux generator channel inputs resources: dmamux channel4 event */
+  DMAMUX_GEN_ID_DMAMUX_CH5_EVT           = 0x14, /*!< dmamux generator channel inputs resources: dmamux channel5 event */
+  DMAMUX_GEN_ID_DMAMUX_CH6_EVT           = 0x15, /*!< dmamux generator channel inputs resources: dmamux channel6 event */
+  DMAMUX_GEN_ID_DMAMUX_CH7_EVT           = 0x16  /*!< dmamux generator channel inputs resources: dmamux channel7 event */
+} dmamux_gen_id_sel_type;
+
+/**
+  * @brief dmamux generator polarity type
+  */
+typedef enum
+{
+  DMAMUX_GEN_POLARITY_DISABLE            = 0x00, /*!< dmamux generator channel inputs resources polarity default value */
+  DMAMUX_GEN_POLARITY_RISING             = 0x01, /*!< dmamux generator channel inputs resources polarity: rising */
+  DMAMUX_GEN_POLARITY_FALLING            = 0x02, /*!< dmamux generator channel inputs resources polarity: falling */
+  DMAMUX_GEN_POLARITY_RISING_FALLING     = 0x03  /*!< dmamux generator channel inputs resources polarity: rising_falling */
+} dmamux_gen_pol_type;
+
+/**
+  * @brief dma init type
+  */
+typedef struct
+{
+  uint32_t                               peripheral_base_addr;    /*!< base addrress for peripheral */
+  uint32_t                               memory_base_addr;        /*!< base addrress for memory */
+  dma_dir_type                           direction;               /*!< dma transmit direction, peripheral as source or as destnation  */
+  uint16_t                               buffer_size;             /*!< counter to transfer (0~0xFFFF) */
+  confirm_state                          peripheral_inc_enable;   /*!< periphera address increment after one transmit */
+  confirm_state                          memory_inc_enable;       /*!< memory address increment after one transmit */
+  dma_peripheral_data_size_type          peripheral_data_width;   /*!< peripheral data width for transmit */
+  dma_memory_data_size_type              memory_data_width;       /*!< memory data width for transmit */
+  confirm_state                          loop_mode_enable;        /*!< when loop mode enable, buffer size will reload if count to 0*/
+  dma_priority_level_type                priority;                /*!< dma priority can choose from very high,high,dedium or low */
+} dma_init_type;
+
+/**
+  * @brief dmamux sync init type
+  */
+typedef struct
+{
+  dmamux_sync_id_sel_type                sync_signal_sel;     /*!< dma dmamux synchronization input select */
+  uint32_t                               sync_polarity;       /*!< dma dmamux synchronization polarity */
+  uint32_t                               sync_request_number; /*!< dma dmamux number of dma requests before an output event is generated  */
+  confirm_state                          sync_event_enable;   /*!< dma dmamux event generation disabled */
+  confirm_state                          sync_enable;         /*!< dma dmamux synchronization enable */
+} dmamux_sync_init_type;
+
+/**
+  * @brief dmamux generator init type
+  */
+typedef struct
+{
+  dmamux_gen_id_sel_type                 gen_signal_sel;     /*!< dma dmamux generator dma request trigger input select */
+  dmamux_gen_pol_type                    gen_polarity;       /*!< dma dmamux generator trigger polarity */
+  uint32_t                               gen_request_number; /*!< dma dmamux the number of dma requests to be generated after a trigger event  */
+  confirm_state                          gen_enable;         /*!< dma dmamux generator enable */
+} dmamux_gen_init_type;
+
+/**
+  * @brief type define dma1 register
+  */
+typedef struct
+{
+  /**
+    * @brief dma sts register, offset:0x00
+    */
+  union
+  {
+    __IO uint32_t sts;
+    struct
+    {
+      __IO uint32_t gf1                  : 1; /* [0] */
+      __IO uint32_t fdtf1                : 1; /* [1] */
+      __IO uint32_t hdtf1                : 1; /* [2] */
+      __IO uint32_t dterrf1              : 1; /* [3] */
+      __IO uint32_t gf2                  : 1; /* [4] */
+      __IO uint32_t fdtf2                : 1; /* [5] */
+      __IO uint32_t hdtf2                : 1; /* [6] */
+      __IO uint32_t dterrf2              : 1; /* [7] */
+      __IO uint32_t gf3                  : 1; /* [8] */
+      __IO uint32_t fdtf3                : 1; /* [9] */
+      __IO uint32_t hdtf3                : 1; /* [10] */
+      __IO uint32_t dterrf3              : 1; /* [11] */
+      __IO uint32_t gf4                  : 1; /* [12] */
+      __IO uint32_t fdtf4                : 1; /* [13] */
+      __IO uint32_t hdtf4                : 1; /* [14] */
+      __IO uint32_t dterrf4              : 1; /* [15] */
+      __IO uint32_t gf5                  : 1; /* [16] */
+      __IO uint32_t fdtf5                : 1; /* [17] */
+      __IO uint32_t hdtf5                : 1; /* [18] */
+      __IO uint32_t dterrf5              : 1; /* [19] */
+      __IO uint32_t gf6                  : 1; /* [20] */
+      __IO uint32_t fdtf6                : 1; /* [21] */
+      __IO uint32_t hdtf6                : 1; /* [22] */
+      __IO uint32_t dterrf6              : 1; /* [23] */
+      __IO uint32_t gf7                  : 1; /* [24] */
+      __IO uint32_t fdtf7                : 1; /* [25] */
+      __IO uint32_t hdtf7                : 1; /* [26] */
+      __IO uint32_t dterrf7              : 1; /* [27] */
+      __IO uint32_t reserved1            : 4; /* [31:28] */
+    } sts_bit;
+  };
+
+  /**
+    * @brief dma clr register, offset:0x04
+    */
+  union
+  {
+    __IO uint32_t clr;
+    struct
+    {
+      __IO uint32_t gfc1                 : 1; /* [0] */
+      __IO uint32_t fdtfc1               : 1; /* [1] */
+      __IO uint32_t hdtfc1               : 1; /* [2] */
+      __IO uint32_t dterrfc1             : 1; /* [3] */
+      __IO uint32_t gfc2                 : 1; /* [4] */
+      __IO uint32_t fdtfc2               : 1; /* [5] */
+      __IO uint32_t hdtfc2               : 1; /* [6] */
+      __IO uint32_t dterrfc2             : 1; /* [7] */
+      __IO uint32_t gfc3                 : 1; /* [8] */
+      __IO uint32_t fdtfc3               : 1; /* [9] */
+      __IO uint32_t hdtfc3               : 1; /* [10] */
+      __IO uint32_t dterrfc3             : 1; /* [11] */
+      __IO uint32_t gfc4                 : 1; /* [12] */
+      __IO uint32_t fdtfc4               : 1; /* [13] */
+      __IO uint32_t hdtfc4               : 1; /* [14] */
+      __IO uint32_t dterrfc4             : 1; /* [15] */
+      __IO uint32_t gfc5                 : 1; /* [16] */
+      __IO uint32_t fdtfc5               : 1; /* [17] */
+      __IO uint32_t hdtfc5               : 1; /* [18] */
+      __IO uint32_t dterrfc5             : 1; /* [19] */
+      __IO uint32_t gfc6                 : 1; /* [20] */
+      __IO uint32_t fdtfc6               : 1; /* [21] */
+      __IO uint32_t hdtfc6               : 1; /* [22] */
+      __IO uint32_t dterrfc6             : 1; /* [23] */
+      __IO uint32_t gfc7                 : 1; /* [24] */
+      __IO uint32_t fdtfc7               : 1; /* [25] */
+      __IO uint32_t hdtfc7               : 1; /* [26] */
+      __IO uint32_t dterrfc7             : 1; /* [27] */
+      __IO uint32_t reserved1            : 4; /* [31:28] */
+    } clr_bit;
+  };
+
+  /**
+    * @brief reserved, offset:0x08~0xFC
+    */
+  __IO uint32_t reserved1[62];
+
+  /**
+    * @brief dmamux sel register, offset:0x100
+    */
+  union
+  {
+    __IO uint32_t muxsel;
+    struct
+    {
+      __IO uint32_t tblsel               : 1; /* [0] */
+      __IO uint32_t reserved1            : 31;/* [31:1] */
+    }muxsel_bit;
+  };
+
+  /**
+    * @brief reserved, offset:0x104~0x12C
+    */
+  __IO uint32_t reserved2[11];
+
+  /**
+    * @brief dmamux syncsts register, offset:0x130
+    */
+  union
+  {
+    __IO uint32_t muxsyncsts;
+    struct
+    {
+      __IO uint32_t syncovf              : 7; /* [6:0] */
+      __IO uint32_t reserved1            : 25;/* [31:7] */
+    }muxsyncsts_bit;
+  };
+
+  /**
+    * @brief dmamux syncclr register, offset:0x134
+    */
+  union
+  {
+    __IO uint32_t muxsyncclr;
+    struct
+    {
+      __IO uint32_t syncovfc             : 7; /* [6:0] */
+      __IO uint32_t reserved1            : 25;/* [31:7] */
+    }muxsyncclr_bit;
+  };
+
+  /**
+    * @brief dmamux request generator status register, offset:0x138
+    */
+  union
+  {
+    __IO uint32_t muxgsts;
+    struct
+    {
+      __IO uint32_t trgovf               : 4; /* [3:0] */
+      __IO uint32_t reserved1            : 28;/* [31:4] */
+    }muxgsts_bit;
+  };
+  /**
+    * @brief dmamux request generator status clear register, offset:0x13C
+    */
+  union
+  {
+    __IO uint32_t muxgclr;
+    struct
+    {
+      __IO uint32_t trgovfc              : 4; /* [3:0] */
+      __IO uint32_t reserved1            : 28;/* [31:4] */
+    }muxgclr_bit;
+  };
+} dma_type;
+
+/**
+  * @brief type define dma channel register all
+  */
+typedef struct
+{
+  /**
+    * @brief dma ch ctrl0 register, offset:0x08+20*(x-1) x=1...7
+    */
+  union
+  {
+    __IO uint32_t ctrl;
+    struct
+    {
+      __IO uint32_t chen                 : 1; /* [0] */
+      __IO uint32_t fdtien               : 1; /* [1] */
+      __IO uint32_t hdtien               : 1; /* [2] */
+      __IO uint32_t dterrien             : 1; /* [3] */
+      __IO uint32_t dtd                  : 1; /* [4] */
+      __IO uint32_t lm                   : 1; /* [5] */
+      __IO uint32_t pincm                : 1; /* [6] */
+      __IO uint32_t mincm                : 1; /* [7] */
+      __IO uint32_t pwidth               : 2; /* [9:8] */
+      __IO uint32_t mwidth               : 2; /* [11:10] */
+      __IO uint32_t chpl                 : 2; /* [13:12] */
+      __IO uint32_t m2m                  : 1; /* [14] */
+      __IO uint32_t reserved1            : 17;/* [31:15] */
+    } ctrl_bit;
+  };
+
+  /**
+    * @brief dma tcnt register, offset:0x0C+20*(x-1) x=1...7
+    */
+  union
+  {
+    __IO uint32_t dtcnt;
+    struct
+    {
+      __IO uint32_t cnt                  : 16;/* [15:0] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } dtcnt_bit;
+  };
+
+  /**
+    * @brief dma cpba register, offset:0x10+20*(x-1) x=1...7
+    */
+  union
+  {
+    __IO uint32_t paddr;
+    struct
+    {
+      __IO uint32_t paddr                : 32;/* [31:0] */
+    } paddr_bit;
+  };
+
+  /**
+    * @brief dma cmba register, offset:0x14+20*(x-1) x=1...7
+    */
+  union
+  {
+    __IO uint32_t maddr;
+    struct
+    {
+      __IO uint32_t maddr                : 32;/* [31:0] */
+    } maddr_bit;
+  };
+} dma_channel_type;
+
+/**
+  * @brief type define dmamux muxsctrl register
+  */
+typedef struct
+{
+  /**
+    * @brief dma muxsctrl register
+    */
+  union
+  {
+    __IO uint32_t muxctrl;
+    struct
+    {
+      __IO uint32_t reqsel               : 7; /* [6:0] */
+      __IO uint32_t reserved1            : 1; /* [7] */
+      __IO uint32_t syncovien            : 1; /* [8] */
+      __IO uint32_t evtgen               : 1; /* [9] */
+      __IO uint32_t reserved2            : 6; /* [15:10] */
+      __IO uint32_t syncen               : 1; /* [16] */
+      __IO uint32_t syncpol              : 2; /* [18:17] */
+      __IO uint32_t reqcnt               : 5; /* [23:19] */
+      __IO uint32_t syncsel              : 5; /* [28:24] */
+      __IO uint32_t reserved3            : 3; /* [31:29] */
+    }muxctrl_bit;
+  };
+} dmamux_channel_type;
+
+/**
+  * @brief type define dmamux request generator register all
+  */
+typedef struct
+{
+  /**
+    * @brief dmamux request generator register, offset:0x120+4*(x-1) x=1...4
+    */
+  union
+  {
+    __IO uint32_t gctrl;
+    struct
+    {
+      __IO uint32_t sigsel               : 5; /* [4:0] */
+      __IO uint32_t reserved1            : 3; /* [7:5] */
+      __IO uint32_t trgovien             : 1; /* [8] */
+      __IO uint32_t reserved2            : 7; /* [15:9] */
+      __IO uint32_t gen                  : 1; /* [16] */
+      __IO uint32_t gpol                 : 2; /* [18:17] */
+      __IO uint32_t greqcnt              : 5; /* [23:19] */
+      __IO uint32_t reserved3            : 8; /* [31:24] */
+    }gctrl_bit;
+  };
+} dmamux_generator_type;
+
+/**
+  * @}
+  */
+
+#define DMA1                             ((dma_type *) DMA1_BASE)
+#define DMA1_CHANNEL1                    ((dma_channel_type *) DMA1_CHANNEL1_BASE)
+#define DMA1_CHANNEL2                    ((dma_channel_type *) DMA1_CHANNEL2_BASE)
+#define DMA1_CHANNEL3                    ((dma_channel_type *) DMA1_CHANNEL3_BASE)
+#define DMA1_CHANNEL4                    ((dma_channel_type *) DMA1_CHANNEL4_BASE)
+#define DMA1_CHANNEL5                    ((dma_channel_type *) DMA1_CHANNEL5_BASE)
+#define DMA1_CHANNEL6                    ((dma_channel_type *) DMA1_CHANNEL6_BASE)
+#define DMA1_CHANNEL7                    ((dma_channel_type *) DMA1_CHANNEL7_BASE)
+
+#define DMA1MUX_CHANNEL1                 ((dmamux_channel_type *) DMA1MUX_CHANNEL1_BASE)
+#define DMA1MUX_CHANNEL2                 ((dmamux_channel_type *) DMA1MUX_CHANNEL2_BASE)
+#define DMA1MUX_CHANNEL3                 ((dmamux_channel_type *) DMA1MUX_CHANNEL3_BASE)
+#define DMA1MUX_CHANNEL4                 ((dmamux_channel_type *) DMA1MUX_CHANNEL4_BASE)
+#define DMA1MUX_CHANNEL5                 ((dmamux_channel_type *) DMA1MUX_CHANNEL5_BASE)
+#define DMA1MUX_CHANNEL6                 ((dmamux_channel_type *) DMA1MUX_CHANNEL6_BASE)
+#define DMA1MUX_CHANNEL7                 ((dmamux_channel_type *) DMA1MUX_CHANNEL7_BASE)
+
+#define DMA1MUX_GENERATOR1               ((dmamux_generator_type *) DMA1MUX_GENERATOR1_BASE)
+#define DMA1MUX_GENERATOR2               ((dmamux_generator_type *) DMA1MUX_GENERATOR2_BASE)
+#define DMA1MUX_GENERATOR3               ((dmamux_generator_type *) DMA1MUX_GENERATOR3_BASE)
+#define DMA1MUX_GENERATOR4               ((dmamux_generator_type *) DMA1MUX_GENERATOR4_BASE)
+
+#define DMA2                             ((dma_type *) DMA2_BASE)
+#define DMA2_CHANNEL1                    ((dma_channel_type *) DMA2_CHANNEL1_BASE)
+#define DMA2_CHANNEL2                    ((dma_channel_type *) DMA2_CHANNEL2_BASE)
+#define DMA2_CHANNEL3                    ((dma_channel_type *) DMA2_CHANNEL3_BASE)
+#define DMA2_CHANNEL4                    ((dma_channel_type *) DMA2_CHANNEL4_BASE)
+#define DMA2_CHANNEL5                    ((dma_channel_type *) DMA2_CHANNEL5_BASE)
+#define DMA2_CHANNEL6                    ((dma_channel_type *) DMA2_CHANNEL6_BASE)
+#define DMA2_CHANNEL7                    ((dma_channel_type *) DMA2_CHANNEL7_BASE)
+
+#define DMA2MUX_CHANNEL1                 ((dmamux_channel_type *) DMA2MUX_CHANNEL1_BASE)
+#define DMA2MUX_CHANNEL2                 ((dmamux_channel_type *) DMA2MUX_CHANNEL2_BASE)
+#define DMA2MUX_CHANNEL3                 ((dmamux_channel_type *) DMA2MUX_CHANNEL3_BASE)
+#define DMA2MUX_CHANNEL4                 ((dmamux_channel_type *) DMA2MUX_CHANNEL4_BASE)
+#define DMA2MUX_CHANNEL5                 ((dmamux_channel_type *) DMA2MUX_CHANNEL5_BASE)
+#define DMA2MUX_CHANNEL6                 ((dmamux_channel_type *) DMA2MUX_CHANNEL6_BASE)
+#define DMA2MUX_CHANNEL7                 ((dmamux_channel_type *) DMA2MUX_CHANNEL7_BASE)
+
+#define DMA2MUX_GENERATOR1               ((dmamux_generator_type *) DMA2MUX_GENERATOR1_BASE)
+#define DMA2MUX_GENERATOR2               ((dmamux_generator_type *) DMA2MUX_GENERATOR2_BASE)
+#define DMA2MUX_GENERATOR3               ((dmamux_generator_type *) DMA2MUX_GENERATOR3_BASE)
+#define DMA2MUX_GENERATOR4               ((dmamux_generator_type *) DMA2MUX_GENERATOR4_BASE)
+
+/** @defgroup DMA_exported_functions
+  * @{
+  */
+
+/* dma controller function */
+void dma_reset(dma_channel_type *dmax_channely);
+void dma_data_number_set(dma_channel_type *dmax_channely, uint16_t data_number);
+uint16_t dma_data_number_get(dma_channel_type *dmax_channely);
+void dma_interrupt_enable(dma_channel_type *dmax_channely, uint32_t dma_int, confirm_state new_state);
+void dma_channel_enable(dma_channel_type *dmax_channely, confirm_state new_state);
+flag_status dma_flag_get(uint32_t dmax_flag);
+flag_status dma_interrupt_flag_get(uint32_t dmax_flag);
+void dma_flag_clear(uint32_t dmax_flag);
+void dma_default_para_init(dma_init_type *dma_init_struct);
+void dma_init(dma_channel_type *dmax_channely, dma_init_type *dma_init_struct);
+
+/* dma requst multiplexer function */
+void dma_flexible_config(dma_type* dma_x, dmamux_channel_type *dmamux_channelx, dmamux_requst_id_sel_type dmamux_req_sel);
+void dmamux_enable(dma_type *dma_x, confirm_state new_state);
+void dmamux_init(dmamux_channel_type *dmamux_channelx, dmamux_requst_id_sel_type dmamux_req_sel);
+void dmamux_sync_default_para_init(dmamux_sync_init_type *dmamux_sync_init_struct);
+void dmamux_sync_config(dmamux_channel_type *dmamux_channelx, dmamux_sync_init_type *dmamux_sync_init_struct);
+void dmamux_generator_default_para_init(dmamux_gen_init_type *dmamux_gen_init_struct);
+void dmamux_generator_config(dmamux_generator_type *dmamux_gen_x, dmamux_gen_init_type *dmamux_gen_init_struct);
+void dmamux_sync_interrupt_enable(dmamux_channel_type *dmamux_channelx, confirm_state new_state);
+void dmamux_generator_interrupt_enable(dmamux_generator_type *dmamux_gen_x, confirm_state new_state);
+flag_status dmamux_sync_flag_get(dma_type *dma_x, uint32_t flag);
+flag_status dmamux_sync_interrupt_flag_get(dma_type *dma_x, uint32_t flag);
+void dmamux_sync_flag_clear(dma_type *dma_x, uint32_t flag);
+flag_status dmamux_generator_flag_get(dma_type *dma_x, uint32_t flag);
+flag_status dmamux_generator_interrupt_flag_get(dma_type *dma_x, uint32_t flag);
+void dmamux_generator_flag_clear(dma_type *dma_x, uint32_t flag);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_ertc.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_ertc.h
@@ -1,0 +1,1187 @@
+/**
+  **************************************************************************
+  * @file     at32f423_ertc.h
+  * @brief    at32f423 ertc header file
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __AT32F423_ERTC_H
+#define __AT32F423_ERTC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "at32f423.h"
+
+/** @addtogroup AT32F423_periph_driver
+  * @{
+  */
+
+/** @addtogroup ERTC
+  * @{
+  */
+
+/** @defgroup ERTC_interrupts_definition
+  * @brief ertc interrupt
+  * @{
+  */
+
+#define ERTC_TP_INT                      ((uint32_t)0x00000004) /*!< ertc tamper interrupt */
+#define ERTC_ALA_INT                     ((uint32_t)0x00001000) /*!< ertc alarm a interrupt */
+#define ERTC_ALB_INT                     ((uint32_t)0x00002000) /*!< ertc alarm b interrupt */
+#define ERTC_WAT_INT                     ((uint32_t)0x00004000) /*!< ertc wakeup timer interrupt */
+#define ERTC_TS_INT                      ((uint32_t)0x00008000) /*!< ertc timestamp interrupt */
+
+/**
+  * @}
+  */
+
+/** @defgroup ERTC_flags_definition
+  * @brief ertc flag
+  * @{
+  */
+
+#define ERTC_ALAWF_FLAG                  ((uint32_t)0x00000001) /*!< ertc alarm a register allows write flag */
+#define ERTC_ALBWF_FLAG                  ((uint32_t)0x00000002) /*!< ertc alarm b register allows write flag */
+#define ERTC_WATWF_FLAG                  ((uint32_t)0x00000004) /*!< ertc wakeup timer register allows write flag */
+#define ERTC_TADJF_FLAG                  ((uint32_t)0x00000008) /*!< ertc time adjustment flag */
+#define ERTC_INITF_FLAG                  ((uint32_t)0x00000010) /*!< ertc calendar initialization flag */
+#define ERTC_UPDF_FLAG                   ((uint32_t)0x00000020) /*!< ertc calendar update flag */
+#define ERTC_IMF_FLAG                    ((uint32_t)0x00000040) /*!< ertc enter initialization mode flag */
+#define ERTC_ALAF_FLAG                   ((uint32_t)0x00000100) /*!< ertc alarm clock a flag */
+#define ERTC_ALBF_FLAG                   ((uint32_t)0x00000200) /*!< ertc alarm clock b flag */
+#define ERTC_WATF_FLAG                   ((uint32_t)0x00000400) /*!< ertc wakeup timer flag */
+#define ERTC_TSF_FLAG                    ((uint32_t)0x00000800) /*!< ertc timestamp flag */
+#define ERTC_TSOF_FLAG                   ((uint32_t)0x00001000) /*!< ertc timestamp overflow flag */
+#define ERTC_TP1F_FLAG                   ((uint32_t)0x00002000) /*!< ertc tamper detection 1 flag */
+#define ERTC_TP2F_FLAG                   ((uint32_t)0x00004000) /*!< ertc tamper detection 2 flag */
+#define ERTC_CALUPDF_FLAG                ((uint32_t)0x00010000) /*!< ertc calibration value update completed flag */
+
+/**
+  * @brief ertc alarm mask
+  */
+#define ERTC_ALARM_MASK_NONE             ((uint32_t)0x00000000) /*!< ertc alarm match all */
+#define ERTC_ALARM_MASK_SEC              ((uint32_t)0x00000080) /*!< ertc alarm don't match seconds */
+#define ERTC_ALARM_MASK_MIN              ((uint32_t)0x00008000) /*!< ertc alarm don't match minute */
+#define ERTC_ALARM_MASK_HOUR             ((uint32_t)0x00800000) /*!< ertc alarm don't match hour */
+#define ERTC_ALARM_MASK_DATE_WEEK        ((uint32_t)0x80000000) /*!< ertc alarm don't match date or week */
+#define ERTC_ALARM_MASK_ALL              ((uint32_t)0x80808080) /*!< ertc alarm don't match all */
+
+/**
+  * @}
+  */
+
+/** @defgroup ERTC_exported_types
+  * @{
+  */
+
+/**
+  * @brief ertc hour mode
+  */
+typedef enum
+{
+  ERTC_HOUR_MODE_24                      = 0x00, /*!< 24-hour format */
+  ERTC_HOUR_MODE_12                      = 0x01  /*!< 12-hour format */
+} ertc_hour_mode_set_type;
+
+/**
+  * @brief ertc 12-hour format am/pm
+  */
+typedef enum
+{
+  ERTC_24H                               = 0x00, /*!< 24-hour format */
+  ERTC_AM                                = 0x00, /*!< 12-hour format, ante meridiem */
+  ERTC_PM                                = 0x01  /*!< 12-hour format, meridiem */
+} ertc_am_pm_type;
+
+/**
+  * @brief ertc week or date select
+  */
+typedef enum
+{
+  ERTC_SLECT_DATE                        = 0x00, /*!< slect date mode */
+  ERTC_SLECT_WEEK                        = 0x01  /*!< slect week mode */
+} ertc_week_date_select_type;
+
+/**
+  * @brief ertc alarm x select
+  */
+typedef enum
+{
+  ERTC_ALA                               = 0x00, /*!< select alarm a */
+  ERTC_ALB                               = 0x01  /*!< select alarm b */
+} ertc_alarm_type;
+
+/**
+  * @brief ertc alarm sub second mask
+  */
+typedef enum
+{
+  ERTC_ALARM_SBS_MASK_ALL                = 0x00, /*!< do not match the sub-second */
+  ERTC_ALARM_SBS_MASK_14_1               = 0x01, /*!< only compare bit [0] */
+  ERTC_ALARM_SBS_MASK_14_2               = 0x02, /*!< only compare bit [1:0] */
+  ERTC_ALARM_SBS_MASK_14_3               = 0x03, /*!< only compare bit [2:0] */
+  ERTC_ALARM_SBS_MASK_14_4               = 0x04, /*!< only compare bit [3:0] */
+  ERTC_ALARM_SBS_MASK_14_5               = 0x05, /*!< only compare bit [4:0] */
+  ERTC_ALARM_SBS_MASK_14_6               = 0x06, /*!< only compare bit [5:0] */
+  ERTC_ALARM_SBS_MASK_14_7               = 0x07, /*!< only compare bit [6:0] */
+  ERTC_ALARM_SBS_MASK_14_8               = 0x08, /*!< only compare bit [7:0] */
+  ERTC_ALARM_SBS_MASK_14_9               = 0x09, /*!< only compare bit [8:0] */
+  ERTC_ALARM_SBS_MASK_14_10              = 0x0A, /*!< only compare bit [9:0] */
+  ERTC_ALARM_SBS_MASK_14_11              = 0x0B, /*!< only compare bit [10:0] */
+  ERTC_ALARM_SBS_MASK_14_12              = 0x0C, /*!< only compare bit [11:0] */
+  ERTC_ALARM_SBS_MASK_14_13              = 0x0D, /*!< only compare bit [12:0] */
+  ERTC_ALARM_SBS_MASK_14                 = 0x0E, /*!< only compare bit [13:0] */
+  ERTC_ALARM_SBS_MASK_NONE               = 0x0F  /*!< compare bit [14:0] */
+} ertc_alarm_sbs_mask_type;
+
+/**
+  * @brief ertc wakeup timer clock select
+  */
+typedef enum
+{
+  ERTC_WAT_CLK_ERTCCLK_DIV16             = 0x00, /*!< the wake up timer clock is ERTC_CLK / 16 */
+  ERTC_WAT_CLK_ERTCCLK_DIV8              = 0x01, /*!< the wake up timer clock is ERTC_CLK / 8 */
+  ERTC_WAT_CLK_ERTCCLK_DIV4              = 0x02, /*!< the wake up timer clock is ERTC_CLK / 4 */
+  ERTC_WAT_CLK_ERTCCLK_DIV2              = 0x03, /*!< the wake up timer clock is ERTC_CLK / 2 */
+  ERTC_WAT_CLK_CK_B_16BITS               = 0x04, /*!< the wake up timer clock is CK_B, wakeup counter = ERTC_WAT */
+  ERTC_WAT_CLK_CK_B_17BITS               = 0x06  /*!< the wake up timer clock is CK_B, wakeup counter = ERTC_WAT + 65535 */
+} ertc_wakeup_clock_type;
+
+/**
+  * @brief ertc smooth calibration period
+  */
+typedef enum
+{
+  ERTC_SMOOTH_CAL_PERIOD_32              = 0x00, /*!< 32 second calibration period */
+  ERTC_SMOOTH_CAL_PERIOD_16              = 0x01, /*!< 16 second calibration period */
+  ERTC_SMOOTH_CAL_PERIOD_8               = 0x02  /*!< 8 second calibration period */
+} ertc_smooth_cal_period_type;
+
+/**
+  * @brief ertc smooth calibration clock add mode
+  */
+typedef enum
+{
+  ERTC_SMOOTH_CAL_CLK_ADD_0              = 0x00, /*!< do not increase clock */
+  ERTC_SMOOTH_CAL_CLK_ADD_512            = 0x01  /*!< add 512 clocks */
+} ertc_smooth_cal_clk_add_type;
+
+/**
+  * @brief ertc calibration direction mode
+  */
+typedef enum
+{
+  ERTC_CAL_DIR_POSITIVE                  = 0x00, /*!< positive calibration */
+  ERTC_CAL_DIR_NEGATIVE                  = 0x01  /*!< negative calibration */
+} ertc_cal_direction_type;
+
+/**
+  * @brief ertc calibration output mode
+  */
+typedef enum
+{
+  ERTC_CAL_OUTPUT_512HZ                  = 0x00, /*!< output 512 hz */
+  ERTC_CAL_OUTPUT_1HZ                    = 0x01  /*!< output 1 hz */
+} ertc_cal_output_select_type;
+
+/**
+  * @brief time adjust add mode
+  */
+typedef enum
+{
+  ERTC_TIME_ADD_NONE                     = 0x00, /*!< none operation */
+  ERTC_TIME_ADD_1S                       = 0x01  /*!< add 1 second */
+} ertc_time_adjust_type;
+
+/**
+  * @brief ertc daylight saving time hour adjustment mode
+  */
+typedef enum
+{
+  ERTC_DST_ADD_1H                        = 0x00, /*!< add 1 hour */
+  ERTC_DST_DEC_1H                        = 0x01  /*!< dec 1 hour */
+} ertc_dst_operation_type;
+
+/**
+  * @brief ertc daylight saving time store operation mode
+  */
+typedef enum
+{
+  ERTC_DST_SAVE_0                        = 0x00, /*!< set the bpr register value to 0 */
+  ERTC_DST_SAVE_1                        = 0x01  /*!< set the bpr register value to 1 */
+} ertc_dst_save_type;
+
+/**
+  * @brief output source
+  */
+typedef enum
+{
+  ERTC_OUTPUT_DISABLE                    = 0x00, /*!< diable output */
+  ERTC_OUTPUT_ALARM_A                    = 0x01, /*!< output alarm a event */
+  ERTC_OUTPUT_ALARM_B                    = 0x02, /*!< output alarm b event */
+  ERTC_OUTPUT_WAKEUP                     = 0x03  /*!< output wakeup event */
+} ertc_output_source_type;
+
+/**
+  * @brief output polarity
+  */
+typedef enum
+{
+  ERTC_OUTPUT_POLARITY_HIGH              = 0x00, /*!< when the event occurs, the output is high */
+  ERTC_OUTPUT_POLARITY_LOW               = 0x01  /*!< when the event occurs, the output is low */
+} ertc_output_polarity_type;
+
+/**
+  * @brief output type
+  */
+typedef enum
+{
+  ERTC_OUTPUT_TYPE_OPEN_DRAIN            = 0x00, /*!< open drain output */
+  ERTC_OUTPUT_TYPE_PUSH_PULL             = 0x01  /*!< push pull output */
+} ertc_output_type;
+
+/**
+  * @brief timestamp/ tamper detection pin selection
+  */
+typedef enum
+{
+  ERTC_PIN_PC13                          = 0x00, /*!< pc13 is used as timestamp detection pin */
+  ERTC_PIN_PA0                           = 0x01  /*!< pa0 is used as timestamp detection pin */
+} ertc_pin_select_type;
+
+/**
+  * @brief ertc timestamp valid edge
+  */
+typedef enum
+{
+  ERTC_TIMESTAMP_EDGE_RISING             = 0x00, /*!< rising edge trigger */
+  ERTC_TIMESTAMP_EDGE_FALLING            = 0x01  /*!< falling edge trigger */
+} ertc_timestamp_valid_edge_type;
+
+/**
+  * @brief ertc tamper x select
+  */
+typedef enum
+{
+  ERTC_TAMPER_1                          = 0x00, /*!< tamper 1 */
+  ERTC_TAMPER_2                          = 0x01  /*!< tamper 2 */
+} ertc_tamper_select_type;
+
+/**
+  * @brief tamper detection pre-charge time
+  */
+typedef enum
+{
+  ERTC_TAMPER_PR_1_ERTCCLK               = 0x00, /*!< pre-charge time is 1 ERTC_CLK */
+  ERTC_TAMPER_PR_2_ERTCCLK               = 0x01, /*!< pre-charge time is 2 ERTC_CLK */
+  ERTC_TAMPER_PR_4_ERTCCLK               = 0x02, /*!< pre-charge time is 4 ERTC_CLK */
+  ERTC_TAMPER_PR_8_ERTCCLK               = 0x03  /*!< pre-charge time is 8 ERTC_CLK */
+} ertc_tamper_precharge_type;
+
+/**
+  * @brief ertc tamper filter
+  */
+typedef enum
+{
+  ERTC_TAMPER_FILTER_DISABLE             = 0x00, /*!< disable filter function */
+  ERTC_TAMPER_FILTER_2                   = 0x01, /*!< 2 consecutive samples arw valid, effective tamper event */
+  ERTC_TAMPER_FILTER_4                   = 0x02, /*!< 4 consecutive samples arw valid, effective tamper event */
+  ERTC_TAMPER_FILTER_8                   = 0x03  /*!< 8 consecutive samples arw valid, effective tamper event */
+} ertc_tamper_filter_type;
+
+/**
+  * @brief ertc tamper detection frequency
+  */
+typedef enum
+{
+  ERTC_TAMPER_FREQ_DIV_32768             = 0x00, /*!< ERTC_CLK / 32768 */
+  ERTC_TAMPER_FREQ_DIV_16384             = 0x01, /*!< ERTC_CLK / 16384 */
+  ERTC_TAMPER_FREQ_DIV_8192              = 0x02, /*!< ERTC_CLK / 8192 */
+  ERTC_TAMPER_FREQ_DIV_4096              = 0x03, /*!< ERTC_CLK / 4096 */
+  ERTC_TAMPER_FREQ_DIV_2048              = 0x04, /*!< ERTC_CLK / 2048 */
+  ERTC_TAMPER_FREQ_DIV_1024              = 0x05, /*!< ERTC_CLK / 1024 */
+  ERTC_TAMPER_FREQ_DIV_512               = 0x06, /*!< ERTC_CLK / 512 */
+  ERTC_TAMPER_FREQ_DIV_256               = 0x07  /*!< ERTC_CLK / 256 */
+} ertc_tamper_detect_freq_type;
+
+/**
+  * @brief ertc tamper valid edge
+  */
+typedef enum
+{
+  ERTC_TAMPER_EDGE_RISING                = 0x00, /*!< rising gedge */
+  ERTC_TAMPER_EDGE_FALLING               = 0x01, /*!< falling gedge */
+  ERTC_TAMPER_EDGE_LOW                   = 0x00, /*!< low level */
+  ERTC_TAMPER_EDGE_HIGH                  = 0x01  /*!< high level */
+} ertc_tamper_valid_edge_type;
+
+/**
+  * @brief ertc bpr register
+  */
+typedef enum
+{
+  ERTC_DT1                               = 0,  /*!< bpr data register 0 */
+  ERTC_DT2                               = 1,  /*!< bpr data register 1 */
+  ERTC_DT3                               = 2,  /*!< bpr data register 2 */
+  ERTC_DT4                               = 3,  /*!< bpr data register 3 */
+  ERTC_DT5                               = 4,  /*!< bpr data register 4 */
+  ERTC_DT6                               = 5,  /*!< bpr data register 5 */
+  ERTC_DT7                               = 6,  /*!< bpr data register 6 */
+  ERTC_DT8                               = 7,  /*!< bpr data register 7 */
+  ERTC_DT9                               = 8,  /*!< bpr data register 8 */
+  ERTC_DT10                              = 9,  /*!< bpr data register 9 */
+  ERTC_DT11                              = 10, /*!< bpr data register 10 */
+  ERTC_DT12                              = 11, /*!< bpr data register 11 */
+  ERTC_DT13                              = 12, /*!< bpr data register 12 */
+  ERTC_DT14                              = 13, /*!< bpr data register 13 */
+  ERTC_DT15                              = 14, /*!< bpr data register 14 */
+  ERTC_DT16                              = 15, /*!< bpr data register 15 */
+  ERTC_DT17                              = 16, /*!< bpr data register 16 */
+  ERTC_DT18                              = 17, /*!< bpr data register 17 */
+  ERTC_DT19                              = 18, /*!< bpr data register 18 */
+  ERTC_DT20                              = 19  /*!< bpr data register 19 */
+} ertc_dt_type;
+
+/**
+  * @brief ertc time
+  */
+typedef struct
+{
+  uint8_t year;                          /*!< year */
+  uint8_t month;                         /*!< month */
+  uint8_t day;                           /*!< date */
+  uint8_t hour;                          /*!< hour */
+  uint8_t min;                           /*!< minute */
+  uint8_t sec;                           /*!< second */
+  uint8_t week;                          /*!< week */
+  ertc_am_pm_type ampm;                  /*!< ante meridiem / post meridiem */
+} ertc_time_type;
+
+/**
+  * @brief ertc alarm
+  */
+typedef struct
+{
+  uint8_t day;                           /*!< date */
+  uint8_t hour;                          /*!< hour */
+  uint8_t min;                           /*!< minute */
+  uint8_t sec;                           /*!< second */
+  ertc_am_pm_type ampm;                  /*!< ante meridiem / post meridiem */
+  uint32_t mask;                         /*!< alarm mask*/
+  uint8_t week_date_sel;                 /*!< week or date mode */
+  uint8_t week;                          /*!< week */
+} ertc_alarm_value_type;
+
+/**
+  * @brief ertc time reg union
+  */
+typedef union
+{
+  __IO uint32_t time;
+  struct
+  {
+    __IO uint32_t s                      : 7; /* [6:0] */
+    __IO uint32_t reserved1              : 1; /* [7] */
+    __IO uint32_t m                      : 7; /* [14:8] */
+    __IO uint32_t reserved2              : 1; /* [15] */
+    __IO uint32_t h                      : 6; /* [21:16] */
+    __IO uint32_t ampm                   : 1; /* [22] */
+    __IO uint32_t reserved3              : 9; /* [31:23] */
+  } time_bit;
+} ertc_reg_time_type;
+
+/**
+  * @brief ertc date reg union
+  */
+typedef union
+{
+  __IO uint32_t date;
+  struct
+  {
+    __IO uint32_t d                      :6; /* [5:0] */
+    __IO uint32_t reserved1              :2; /* [7:6] */
+    __IO uint32_t m                      :5; /* [12:8] */
+    __IO uint32_t wk                     :3; /* [15:13] */
+    __IO uint32_t y                      :8; /* [23:16] */
+    __IO uint32_t reserved2              :8; /* [31:24] */
+  } date_bit;
+} ertc_reg_date_type;
+
+/**
+  * @brief ertc alarm reg union
+  */
+typedef union
+{
+  __IO uint32_t ala;
+  struct
+  {
+    __IO uint32_t s                      :7; /* [6:0] */
+    __IO uint32_t mask1                  :1; /* [7] */
+    __IO uint32_t m                      :7; /* [14:8] */
+    __IO uint32_t mask2                  :1; /* [15] */
+    __IO uint32_t h                      :6; /* [21:16] */
+    __IO uint32_t ampm                   :1; /* [22] */
+    __IO uint32_t mask3                  :1; /* [23] */
+    __IO uint32_t d                      :6; /* [29:24] */
+    __IO uint32_t wksel                  :1; /* [30] */
+    __IO uint32_t mask4                  :1; /* [31] */
+  } ala_bit;
+} ertc_reg_alarm_type;
+
+/**
+  * @brief ertc scal reg union
+  */
+typedef union
+{
+  __IO uint32_t scal;
+  struct
+  {
+    __IO uint32_t dec                    :9; /* [8:0] */
+    __IO uint32_t reserved1              :4; /* [12:9] */
+    __IO uint32_t cal16                  :1; /* [13] */
+    __IO uint32_t cal8                   :1; /* [14] */
+    __IO uint32_t add                    :1; /* [15] */
+    __IO uint32_t reserved2              :16;/* [31:16] */
+  } scal_bit;
+} ertc_reg_scal_type;
+
+/**
+  * @brief ertc tadj reg union
+  */
+typedef union
+{
+  __IO uint32_t tadj;
+  struct
+  {
+    __IO uint32_t decsbs                 :15;/* [14:0] */
+    __IO uint32_t reserved1              :16;/* [30:15] */
+    __IO uint32_t add1s                  :1; /* [31] */
+  } tadj_bit;
+} ertc_reg_tadj_type;
+
+/**
+  * @brief ertc tstm reg union
+  */
+typedef union
+{
+  __IO uint32_t tstm;
+  struct
+  {
+    __IO uint32_t s                      :7; /* [6:0] */
+    __IO uint32_t reserved1              :1; /* [7] */
+    __IO uint32_t m                      :7; /* [14:8] */
+    __IO uint32_t reserved2              :1; /* [15] */
+    __IO uint32_t h                      :6; /* [21:16] */
+    __IO uint32_t ampm                   :1; /* [22] */
+    __IO uint32_t reserved3              :9; /* [31:23] */
+  } tstm_bit;
+} ertc_reg_tstm_type;
+
+/**
+  * @brief ertc tsdt register, offset:0x34
+  */
+typedef union
+{
+  __IO uint32_t tsdt;
+  struct
+  {
+    __IO uint32_t d                      :6; /* [5:0] */
+    __IO uint32_t reserved1              :2; /* [7:6] */
+    __IO uint32_t m                      :5; /* [12:8] */
+    __IO uint32_t wk                     :3; /* [15:13] */
+    __IO uint32_t reserved2              :16;/* [31:16] */
+  } tsdt_bit;
+} ertc_reg_tsdt_type;
+
+/**
+  * @brief type define ertc register all
+  */
+typedef struct
+{
+
+  /**
+    * @brief ertc time register, offset:0x00
+    */
+  union
+  {
+    __IO uint32_t time;
+    struct
+    {
+      __IO uint32_t s                    : 7; /* [6:0] */
+      __IO uint32_t reserved1            : 1; /* [7] */
+      __IO uint32_t m                    : 7; /* [14:8] */
+      __IO uint32_t reserved2            : 1; /* [15] */
+      __IO uint32_t h                    : 6; /* [21:16] */
+      __IO uint32_t ampm                 : 1; /* [22] */
+      __IO uint32_t reserved3            : 9; /* [31:23] */
+    } time_bit;
+  };
+
+  /**
+    * @brief ertc date register, offset:0x04
+    */
+  union
+  {
+    __IO uint32_t date;
+    struct
+    {
+      __IO uint32_t d                    :6; /* [5:0] */
+      __IO uint32_t reserved1            :2; /* [7:6] */
+      __IO uint32_t m                    :5; /* [12:8] */
+      __IO uint32_t wk                   :3; /* [15:13] */
+      __IO uint32_t y                    :8; /* [23:16] */
+      __IO uint32_t reserved2            :8; /* [31:24] */
+    } date_bit;
+  };
+
+  /**
+    * @brief ertc ctrl register, offset:0x08
+    */
+  union
+  {
+    __IO uint32_t ctrl;
+    struct
+    {
+      __IO uint32_t watclk               :3; /* [2:0] */
+      __IO uint32_t tsedg                :1; /* [3] */
+      __IO uint32_t rcden                :1; /* [4] */
+      __IO uint32_t dren                 :1; /* [5] */
+      __IO uint32_t hm                   :1; /* [6] */
+      __IO uint32_t reserved1            :1; /* [7] */
+      __IO uint32_t alaen                :1; /* [8] */
+      __IO uint32_t alben                :1; /* [9] */
+      __IO uint32_t waten                :1; /* [10] */
+      __IO uint32_t tsen                 :1; /* [11] */
+      __IO uint32_t alaien               :1; /* [12] */
+      __IO uint32_t albien               :1; /* [13] */
+      __IO uint32_t watien               :1; /* [14] */
+      __IO uint32_t tsien                :1; /* [15] */
+      __IO uint32_t add1h                :1; /* [16] */
+      __IO uint32_t dec1h                :1; /* [17] */
+      __IO uint32_t bpr                  :1; /* [18] */
+      __IO uint32_t calosel              :1; /* [19] */
+      __IO uint32_t outp                 :1; /* [20] */
+      __IO uint32_t outsel               :2; /* [22:21] */
+      __IO uint32_t caloen               :1; /* [23] */
+      __IO uint32_t reserved2            :8; /* [31:24] */
+    } ctrl_bit;
+  };
+
+  /**
+    * @brief ertc sts register, offset:0x0C
+    */
+  union
+  {
+    __IO uint32_t sts;
+    struct
+    {
+      __IO uint32_t alawf                :1; /* [0] */
+      __IO uint32_t albwf                :1; /* [1] */
+      __IO uint32_t watwf                :1; /* [2] */
+      __IO uint32_t tadjf                :1; /* [3] */
+      __IO uint32_t initf                :1; /* [4] */
+      __IO uint32_t updf                 :1; /* [5] */
+      __IO uint32_t imf                  :1; /* [6] */
+      __IO uint32_t imen                 :1; /* [7] */
+      __IO uint32_t alaf                 :1; /* [8] */
+      __IO uint32_t albf                 :1; /* [9] */
+      __IO uint32_t watf                 :1; /* [10] */
+      __IO uint32_t tsf                  :1; /* [11] */
+      __IO uint32_t tsof                 :1; /* [12] */
+      __IO uint32_t tp1f                 :1; /* [13] */
+      __IO uint32_t tp2f                 :1; /* [14] */
+      __IO uint32_t reserved1            :1; /* [15] */
+      __IO uint32_t calupdf              :1; /* [16] */
+      __IO uint32_t reserved2            :15;/* [31:17] */
+    } sts_bit;
+  };
+
+  /**
+    * @brief ertc div register, offset:0x10
+    */
+  union
+  {
+    __IO uint32_t div;
+    struct
+    {
+      __IO uint32_t divb                 :15;/* [14:0] */
+      __IO uint32_t reserved1            :1; /* [15] */
+      __IO uint32_t diva                 :7; /* [22:16] */
+      __IO uint32_t reserved2            :9; /* [31:23] */
+    } div_bit;
+  };
+
+  /**
+    * @brief ertc wat register, offset:0x14
+    */
+  union
+  {
+    __IO uint32_t wat;
+    struct
+    {
+      __IO uint32_t val                  :16;/* [15:0] */
+      __IO uint32_t reserved1            :16;/* [31:16] */
+    } wat_bit;
+  };
+
+  /**
+    * @brief ertc reserved register, offset:0x18
+    */
+  __IO uint32_t reserved1;
+
+  /**
+    * @brief ertc ala register, offset:0x1C
+    */
+  union
+  {
+    __IO uint32_t ala;
+    struct
+    {
+      __IO uint32_t s                    :7; /* [6:0] */
+      __IO uint32_t mask1                :1; /* [7] */
+      __IO uint32_t m                    :7; /* [14:8] */
+      __IO uint32_t mask2                :1; /* [15] */
+      __IO uint32_t h                    :6; /* [21:16] */
+      __IO uint32_t ampm                 :1; /* [22] */
+      __IO uint32_t mask3                :1; /* [23] */
+      __IO uint32_t d                    :6; /* [29:24] */
+      __IO uint32_t wksel                :1; /* [30] */
+      __IO uint32_t mask4                :1; /* [31] */
+    } ala_bit;
+  };
+
+  /**
+    * @brief ertc alb register, offset:0x20
+    */
+  union
+  {
+    __IO uint32_t alb;
+    struct
+    {
+      __IO uint32_t s                    :7; /* [6:0] */
+      __IO uint32_t mask1                :1; /* [7] */
+      __IO uint32_t m                    :7; /* [14:8] */
+      __IO uint32_t mask2                :1; /* [15] */
+      __IO uint32_t h                    :6; /* [21:16] */
+      __IO uint32_t ampm                 :1; /* [22] */
+      __IO uint32_t mask3                :1; /* [23] */
+      __IO uint32_t d                    :6; /* [29:24] */
+      __IO uint32_t wksel                :1; /* [30] */
+      __IO uint32_t mask4                :1; /* [31] */
+    } alb_bit;
+  };
+
+  /**
+    * @brief ertc wp register, offset:0x24
+    */
+  union
+  {
+    __IO uint32_t wp;
+    struct
+    {
+      __IO uint32_t cmd                  :8; /* [7:0] */
+      __IO uint32_t reserved1            :24;/* [31:8] */
+    } wp_bit;
+  };
+
+  /**
+    * @brief ertc sbs register, offset:0x28
+    */
+  union
+  {
+    __IO uint32_t sbs;
+    struct
+    {
+      __IO uint32_t sbs                  :16;/* [15:0] */
+      __IO uint32_t reserved1            :16;/* [31:16] */
+    } sbs_bit;
+  };
+
+  /**
+    * @brief ertc tadj register, offset:0x2C
+    */
+  union
+  {
+    __IO uint32_t tadj;
+    struct
+    {
+      __IO uint32_t decsbs               :15;/* [14:0] */
+      __IO uint32_t reserved1            :16;/* [30:15] */
+      __IO uint32_t add1s                :1; /* [31] */
+    } tadj_bit;
+  };
+
+  /**
+    * @brief ertc tstm register, offset:0x30
+    */
+  union
+  {
+    __IO uint32_t tstm;
+    struct
+    {
+      __IO uint32_t s                    :7; /* [6:0] */
+      __IO uint32_t reserved1            :1; /* [7] */
+      __IO uint32_t m                    :7; /* [14:8] */
+      __IO uint32_t reserved2            :1; /* [15] */
+      __IO uint32_t h                    :6; /* [21:16] */
+      __IO uint32_t ampm                 :1; /* [22] */
+      __IO uint32_t reserved3            :9; /* [31:23] */
+    } tstm_bit;
+  };
+
+  /**
+    * @brief ertc tsdt register, offset:0x34
+    */
+  union
+  {
+    __IO uint32_t tsdt;
+    struct
+    {
+      __IO uint32_t d                    :6; /* [5:0] */
+      __IO uint32_t reserved1            :2; /* [7:6] */
+      __IO uint32_t m                    :5; /* [12:8] */
+      __IO uint32_t wk                   :3; /* [15:13] */
+      __IO uint32_t reserved2            :16;/* [31:16] */
+    } tsdt_bit;
+  };
+
+  /**
+    * @brief ertc tssbs register, offset:0x38
+    */
+  union
+  {
+    __IO uint32_t tssbs;
+    struct
+    {
+      __IO uint32_t sbs                  :16;/* [15:0] */
+      __IO uint32_t reserved1            :16;/* [31:16] */
+    } tssbs_bit;
+  };
+
+  /**
+    * @brief ertc scal register, offset:0x3C
+    */
+  union
+  {
+    __IO uint32_t scal;
+    struct
+    {
+      __IO uint32_t dec                  :9; /* [8:0] */
+      __IO uint32_t reserved1            :4; /* [12:9] */
+      __IO uint32_t cal16                :1; /* [13] */
+      __IO uint32_t cal8                 :1; /* [14] */
+      __IO uint32_t add                  :1; /* [15] */
+      __IO uint32_t reserved2            :16;/* [31:16] */
+    } scal_bit;
+  };
+
+  /**
+    * @brief ertc tamp register, offset:0x40
+    */
+  union
+  {
+    __IO uint32_t tamp;
+    struct
+    {
+      __IO uint32_t tp1en                :1; /* [0] */
+      __IO uint32_t tp1edg               :1; /* [1] */
+      __IO uint32_t tpien                :1; /* [2] */
+      __IO uint32_t tp2en                :1; /* [3] */
+      __IO uint32_t tp2edg               :1; /* [4] */
+      __IO uint32_t reserved1            :2; /* [6:5] */
+      __IO uint32_t tptsen               :1; /* [7] */
+      __IO uint32_t tpfreq               :3; /* [10:8] */
+      __IO uint32_t tpflt                :2; /* [12:11] */
+      __IO uint32_t tppr                 :2; /* [14:13] */
+      __IO uint32_t tppu                 :1; /* [15] */
+      __IO uint32_t tp1pin               :1; /* [16] */
+      __IO uint32_t tspin                :1; /* [17] */
+      __IO uint32_t outtype              :1; /* [18] */
+      __IO uint32_t reserved2            :13;/* [31:19] */
+    } tamp_bit;
+  };
+
+  /**
+    * @brief ertc alasbs register, offset:0x44
+    */
+  union
+  {
+    __IO uint32_t alasbs;
+    struct
+    {
+      __IO uint32_t sbs                  :15;/* [14:0] */
+      __IO uint32_t reserved1            :9; /* [23:15] */
+      __IO uint32_t sbsmsk               :4; /* [27:24] */
+      __IO uint32_t reserved2            :4; /* [31:28] */
+    } alasbs_bit;
+  };
+
+  /**
+    * @brief ertc albsbs register, offset:0x48
+    */
+  union
+  {
+    __IO uint32_t albsbs;
+    struct
+    {
+      __IO uint32_t sbs                  :15;/* [14:0] */
+      __IO uint32_t reserved1            :9; /* [23:15] */
+      __IO uint32_t sbsmsk               :4; /* [27:24] */
+      __IO uint32_t reserved2            :4; /* [31:28] */
+    } albsbs_bit;
+  };
+
+  /**
+    * @brief reserved register, offset:0x4c
+    */
+  __IO uint32_t reserved2;
+
+  /**
+    * @brief ertc dt1 register, offset:0x50
+    */
+  union
+  {
+    __IO uint32_t dt1;
+    struct
+    {
+      __IO uint32_t dt                   :32;/* [31:0] */
+    } dt1_bit;
+  };
+
+  /**
+    * @brief ertc dt2 register, offset:0x54
+    */
+  union
+  {
+    __IO uint32_t dt2;
+    struct
+    {
+      __IO uint32_t dt                   :32;/* [31:0] */
+    } dt2_bit;
+  };
+
+  /**
+    * @brief ertc dt3 register, offset:0x58
+    */
+  union
+  {
+    __IO uint32_t dt3;
+    struct
+    {
+      __IO uint32_t dt                   :32;/* [31:0] */
+    } dt3_bit;
+  };
+
+  /**
+    * @brief ertc dt4 register, offset:0x5C
+    */
+  union
+  {
+    __IO uint32_t dt4;
+    struct
+    {
+      __IO uint32_t dt                   :32;/* [31:0] */
+    } dt4_bit;
+  };
+
+  /**
+    * @brief ertc dt5 register, offset:0x60
+    */
+  union
+  {
+    __IO uint32_t dt5;
+    struct
+    {
+      __IO uint32_t dt                   :32;/* [31:0] */
+    } dt5_bit;
+  };
+
+  /**
+    * @brief ertc dt6 register, offset:0x64
+    */
+  union
+  {
+    __IO uint32_t dt6;
+    struct
+    {
+      __IO uint32_t dt                   :32;/* [31:0] */
+    } dt6_bit;
+  };
+
+  /**
+    * @brief ertc dt7 register, offset:0x68
+    */
+  union
+  {
+    __IO uint32_t dt7;
+    struct
+    {
+      __IO uint32_t dt                   :32;/* [31:0] */
+    } dt7_bit;
+  };
+
+  /**
+    * @brief ertc dt8 register, offset:0x6C
+    */
+  union
+  {
+    __IO uint32_t dt8;
+    struct
+    {
+      __IO uint32_t dt                   :32;/* [31:0] */
+    } dt8_bit;
+  };
+
+  /**
+    * @brief ertc dt9 register, offset:0x70
+    */
+  union
+  {
+    __IO uint32_t dt9;
+    struct
+    {
+      __IO uint32_t dt                   :32;/* [31:0] */
+    } dt9_bit;
+  };
+
+  /**
+    * @brief ertc dt10 register, offset:0x74
+    */
+  union
+  {
+    __IO uint32_t dt10;
+    struct
+    {
+      __IO uint32_t dt                   :32;/* [31:0] */
+    } dt10_bit;
+  };
+
+  /**
+    * @brief ertc dt11 register, offset:0x78
+    */
+  union
+  {
+    __IO uint32_t dt11;
+    struct
+    {
+      __IO uint32_t dt                   :32;/* [31:0] */
+    } dt11_bit;
+  };
+
+  /**
+    * @brief ertc dt12 register, offset:0x7C
+    */
+  union
+  {
+    __IO uint32_t dt12;
+    struct
+    {
+      __IO uint32_t dt                   :32;/* [31:0] */
+    } dt12_bit;
+  };
+
+  /**
+    * @brief ertc dt13 register, offset:0x80
+    */
+  union
+  {
+    __IO uint32_t dt13;
+    struct
+    {
+      __IO uint32_t dt                   :32;/* [31:0] */
+    } dt13_bit;
+  };
+
+  /**
+    * @brief ertc dt14 register, offset:0x84
+    */
+  union
+  {
+    __IO uint32_t dt14;
+    struct
+    {
+      __IO uint32_t dt                   :32;/* [31:0] */
+    } dt14_bit;
+  };
+
+  /**
+    * @brief ertc dt15 register, offset:0x88
+    */
+  union
+  {
+    __IO uint32_t dt15;
+    struct
+    {
+      __IO uint32_t dt                   :32;/* [31:0] */
+    } dt15_bit;
+  };
+
+  /**
+    * @brief ertc dt16 register, offset:0x8C
+    */
+  union
+  {
+    __IO uint32_t dt16;
+    struct
+    {
+      __IO uint32_t dt                   :32;/* [31:0] */
+    } dt16_bit;
+  };
+
+  /**
+    * @brief ertc dt17 register, offset:0x90
+    */
+  union
+  {
+    __IO uint32_t dt17;
+    struct
+    {
+      __IO uint32_t dt                   :32;/* [31:0] */
+    } dt17_bit;
+  };
+
+  /**
+    * @brief ertc dt18 register, offset:0x94
+    */
+  union
+  {
+    __IO uint32_t dt18;
+    struct
+    {
+      __IO uint32_t dt                   :32;/* [31:0] */
+    } dt18_bit;
+  };
+
+  /**
+    * @brief ertc dt19 register, offset:0x98
+    */
+  union
+  {
+    __IO uint32_t dt19;
+    struct
+    {
+      __IO uint32_t dt                   :32;/* [31:0] */
+    } dt19_bit;
+  };
+
+  /**
+    * @brief ertc dt20 register, offset:0x9C
+    */
+  union
+  {
+    __IO uint32_t dt20;
+    struct
+    {
+      __IO uint32_t dt                   :32;/* [31:0] */
+    } dt20_bit;
+  };
+
+
+} ertc_type;
+
+/**
+  * @}
+  */
+
+#define ERTC                              ((ertc_type *) ERTC_BASE)
+
+/** @defgroup ERTC_exported_functions
+  * @{
+  */
+
+uint8_t ertc_num_to_bcd(uint8_t num);
+uint8_t ertc_bcd_to_num(uint8_t bcd);
+void ertc_write_protect_enable(void);
+void ertc_write_protect_disable(void);
+error_status ertc_wait_update(void);
+error_status ertc_wait_flag(uint32_t flag, flag_status status);
+error_status ertc_init_mode_enter(void);
+void ertc_init_mode_exit(void);
+error_status ertc_reset(void);
+error_status ertc_divider_set(uint16_t div_a, uint16_t div_b);
+error_status ertc_hour_mode_set(ertc_hour_mode_set_type mode);
+error_status ertc_date_set(uint8_t year, uint8_t month, uint8_t date, uint8_t week);
+error_status ertc_time_set(uint8_t hour, uint8_t min, uint8_t sec, ertc_am_pm_type ampm);
+void ertc_calendar_get(ertc_time_type* time);
+uint32_t ertc_sub_second_get(void);
+void ertc_alarm_mask_set(ertc_alarm_type alarm_x, uint32_t mask);
+void ertc_alarm_week_date_select(ertc_alarm_type alarm_x, ertc_week_date_select_type wk);
+void ertc_alarm_set(ertc_alarm_type alarm_x, uint8_t week_date, uint8_t hour, uint8_t min, uint8_t sec, ertc_am_pm_type ampm);
+void ertc_alarm_sub_second_set(ertc_alarm_type alarm_x, uint32_t value, ertc_alarm_sbs_mask_type mask);
+error_status ertc_alarm_enable(ertc_alarm_type alarm_x, confirm_state new_state);
+void ertc_alarm_get(ertc_alarm_type alarm_x, ertc_alarm_value_type* alarm);
+uint32_t ertc_alarm_sub_second_get(ertc_alarm_type alarm_x);
+void ertc_wakeup_clock_set(ertc_wakeup_clock_type clock);
+void ertc_wakeup_counter_set(uint32_t counter);
+uint16_t ertc_wakeup_counter_get(void);
+error_status ertc_wakeup_enable(confirm_state new_state);
+error_status ertc_smooth_calibration_config(ertc_smooth_cal_period_type period, ertc_smooth_cal_clk_add_type clk_add, uint32_t clk_dec);
+void ertc_cal_output_select(ertc_cal_output_select_type output);
+void ertc_cal_output_enable(confirm_state new_state);
+error_status ertc_time_adjust(ertc_time_adjust_type add1s, uint32_t decsbs);
+void ertc_daylight_set(ertc_dst_operation_type operation, ertc_dst_save_type save);
+uint8_t ertc_daylight_bpr_get(void);
+error_status ertc_refer_clock_detect_enable(confirm_state new_state);
+void ertc_direct_read_enable(confirm_state new_state);
+void ertc_output_set(ertc_output_source_type source, ertc_output_polarity_type polarity, ertc_output_type type);
+void ertc_timestamp_pin_select(ertc_pin_select_type pin);
+void ertc_timestamp_valid_edge_set(ertc_timestamp_valid_edge_type edge);
+void ertc_timestamp_enable(confirm_state new_state);
+void ertc_timestamp_get(ertc_time_type* time);
+uint32_t ertc_timestamp_sub_second_get(void);
+void ertc_tamper_1_pin_select(ertc_pin_select_type pin);
+void ertc_tamper_pull_up_enable(confirm_state new_state);
+void ertc_tamper_precharge_set(ertc_tamper_precharge_type precharge);
+void ertc_tamper_filter_set(ertc_tamper_filter_type filter);
+void ertc_tamper_detect_freq_set(ertc_tamper_detect_freq_type freq);
+void ertc_tamper_valid_edge_set(ertc_tamper_select_type tamper_x, ertc_tamper_valid_edge_type trigger);
+void ertc_tamper_timestamp_enable(confirm_state new_state);
+void ertc_tamper_enable(ertc_tamper_select_type tamper_x, confirm_state new_state);
+void ertc_interrupt_enable(uint32_t source, confirm_state new_state);
+flag_status ertc_interrupt_get(uint32_t source);
+flag_status ertc_flag_get(uint32_t flag);
+flag_status ertc_interrupt_flag_get(uint32_t flag);
+void ertc_flag_clear(uint32_t flag);
+void ertc_bpr_data_write(ertc_dt_type dt, uint32_t data);
+uint32_t ertc_bpr_data_read(ertc_dt_type dt);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_exint.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_exint.h
@@ -1,0 +1,236 @@
+/**
+  **************************************************************************
+  * @file     at32f423_exint.h
+  * @brief    at32f423 exint header file
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __AT32F423_EXINT_H
+#define __AT32F423_EXINT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "at32f423.h"
+
+/** @addtogroup AT32F423_periph_driver
+  * @{
+  */
+
+/** @addtogroup EXINT
+  * @{
+  */
+
+/** @defgroup EXINT_lines
+  * @{
+  */
+
+#define EXINT_LINE_NONE                  ((uint32_t)0x00000000)
+#define EXINT_LINE_0                     ((uint32_t)0x00000001) /*!< external interrupt line 0 */
+#define EXINT_LINE_1                     ((uint32_t)0x00000002) /*!< external interrupt line 1 */
+#define EXINT_LINE_2                     ((uint32_t)0x00000004) /*!< external interrupt line 2 */
+#define EXINT_LINE_3                     ((uint32_t)0x00000008) /*!< external interrupt line 3 */
+#define EXINT_LINE_4                     ((uint32_t)0x00000010) /*!< external interrupt line 4 */
+#define EXINT_LINE_5                     ((uint32_t)0x00000020) /*!< external interrupt line 5 */
+#define EXINT_LINE_6                     ((uint32_t)0x00000040) /*!< external interrupt line 6 */
+#define EXINT_LINE_7                     ((uint32_t)0x00000080) /*!< external interrupt line 7 */
+#define EXINT_LINE_8                     ((uint32_t)0x00000100) /*!< external interrupt line 8 */
+#define EXINT_LINE_9                     ((uint32_t)0x00000200) /*!< external interrupt line 9 */
+#define EXINT_LINE_10                    ((uint32_t)0x00000400) /*!< external interrupt line 10 */
+#define EXINT_LINE_11                    ((uint32_t)0x00000800) /*!< external interrupt line 11 */
+#define EXINT_LINE_12                    ((uint32_t)0x00001000) /*!< external interrupt line 12 */
+#define EXINT_LINE_13                    ((uint32_t)0x00002000) /*!< external interrupt line 13 */
+#define EXINT_LINE_14                    ((uint32_t)0x00004000) /*!< external interrupt line 14 */
+#define EXINT_LINE_15                    ((uint32_t)0x00008000) /*!< external interrupt line 15 */
+#define EXINT_LINE_16                    ((uint32_t)0x00010000) /*!< external interrupt line 16 */
+#define EXINT_LINE_17                    ((uint32_t)0x00020000) /*!< external interrupt line 17 */
+#define EXINT_LINE_18                    ((uint32_t)0x00040000) /*!< external interrupt line 18 */
+#define EXINT_LINE_21                    ((uint32_t)0x00200000) /*!< external interrupt line 21 */
+#define EXINT_LINE_22                    ((uint32_t)0x00400000) /*!< external interrupt line 22 */
+#define EXINT_LINE_23                    ((uint32_t)0x00800000) /*!< external interrupt line 23 */
+#define EXINT_LINE_25                    ((uint32_t)0x02000000) /*!< external interrupt line 25 */
+#define EXINT_LINE_26                    ((uint32_t)0x04000000) /*!< external interrupt line 26 */
+#define EXINT_LINE_28                    ((uint32_t)0x10000000) /*!< external interrupt line 28 */
+/**
+  * @}
+  */
+
+/** @defgroup EXINT_exported_types
+  * @{
+  */
+
+/**
+  * @brief exint line mode type
+  */
+typedef enum
+{
+  EXINT_LINE_INTERRUPUT                  = 0x00, /*!< external interrupt line interrupt mode */
+  EXINT_LINE_INTERRUPT                   = 0x00, /*!< same as EXINT_LINE_INTERRUPUT, fixed spelling error */
+  EXINT_LINE_EVENT                       = 0x01  /*!< external interrupt line event mode */
+} exint_line_mode_type;
+
+/**
+  * @brief exint polarity configuration type
+  */
+typedef enum
+{
+  EXINT_TRIGGER_RISING_EDGE              = 0x00, /*!< external interrupt line rising trigger mode */
+  EXINT_TRIGGER_FALLING_EDGE             = 0x01, /*!< external interrupt line falling trigger mode */
+  EXINT_TRIGGER_BOTH_EDGE                = 0x02  /*!< external interrupt line both rising and falling trigger mode */
+} exint_polarity_config_type;
+
+/**
+  * @brief exint init type
+  */
+typedef struct
+{
+  exint_line_mode_type                   line_mode;     /*!< choose mode event or interrupt mode */
+  uint32_t                               line_select;   /*!< select the exint line, availiable for single line or multiple lines */
+  exint_polarity_config_type             line_polarity; /*!< select the tregger polarity, with rising edge, falling edge or both edge */
+  confirm_state                          line_enable;   /*!< enable or disable exint */
+} exint_init_type;
+
+/**
+  * @brief type define exint register all
+  */
+typedef struct
+{
+
+  /**
+    * @brief exint inten register, offset:0x00
+    */
+  union
+  {
+    __IO uint32_t inten;
+    struct
+    {
+      __IO uint32_t intenx               : 29;/* [28:0] */
+      __IO uint32_t reserved1            : 3; /* [31:29] */
+    } inten_bit;
+  };
+
+  /**
+    * @brief exint evten register, offset:0x04
+    */
+  union
+  {
+    __IO uint32_t evten;
+    struct
+    {
+      __IO uint32_t evtenx               : 29;/* [28:0] */
+      __IO uint32_t reserved1            : 3; /* [31:29] */
+    } evten_bit;
+  };
+
+  /**
+    * @brief exint polcfg1 register, offset:0x08
+    */
+  union
+  {
+    __IO uint32_t polcfg1;
+    struct
+    {
+      __IO uint32_t rpx                  : 29;/* [28:0] */
+      __IO uint32_t reserved1            : 3; /* [31:29] */
+    } polcfg1_bit;
+  };
+
+  /**
+    * @brief exint polcfg2 register, offset:0x0C
+    */
+  union
+  {
+    __IO uint32_t polcfg2;
+    struct
+    {
+      __IO uint32_t fpx                  : 29;/* [28:0] */
+      __IO uint32_t reserved1            : 3; /* [31:29] */
+    } polcfg2_bit;
+  };
+
+  /**
+    * @brief exint swtrg register, offset:0x10
+    */
+  union
+  {
+    __IO uint32_t swtrg;
+    struct
+    {
+      __IO uint32_t swtx                 : 29;/* [28:0] */
+      __IO uint32_t reserved1            : 3; /* [31:29] */
+    } swtrg_bit;
+  };
+
+  /**
+    * @brief exint intsts register, offset:0x14
+    */
+  union
+  {
+    __IO uint32_t intsts;
+    struct
+    {
+      __IO uint32_t linex                : 29;/* [28:0] */
+      __IO uint32_t reserved1            : 3; /* [31:29] */
+    } intsts_bit;
+  };
+} exint_type;
+
+/**
+  * @}
+  */
+
+#define EXINT                             ((exint_type *) EXINT_BASE)
+
+/** @defgroup EXINT_exported_functions
+  * @{
+  */
+
+void exint_reset(void);
+void exint_default_para_init(exint_init_type *exint_struct);
+void exint_init(exint_init_type *exint_struct);
+void exint_flag_clear(uint32_t exint_line);
+flag_status exint_flag_get(uint32_t exint_line);
+flag_status exint_interrupt_flag_get(uint32_t exint_line);
+void exint_software_interrupt_event_generate(uint32_t exint_line);
+void exint_interrupt_enable(uint32_t exint_line, confirm_state new_state);
+void exint_event_enable(uint32_t exint_line, confirm_state new_state);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_flash.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_flash.h
@@ -1,0 +1,578 @@
+/**
+  **************************************************************************
+  * @file     at32f423_flash.h
+  * @brief    at32f423 flash header file
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __AT32F423_FLASH_H
+#define __AT32F423_FLASH_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "at32f423.h"
+
+/** @addtogroup AT32F423_periph_driver
+  * @{
+  */
+
+/** @addtogroup FLASH
+  * @{
+  */
+
+/** @defgroup FLASH_exported_constants
+  * @{
+  */
+
+/**
+  * @brief flash unlock keys
+  */
+#define FLASH_UNLOCK_KEY1                ((uint32_t)0x45670123) /*!< flash operation unlock order key1 */
+#define FLASH_UNLOCK_KEY2                ((uint32_t)0xCDEF89AB) /*!< flash operation unlock order key2 */
+#define FAP_RELIEVE_KEY                  ((uint16_t)0x00A5)     /*!< flash fap relieve key val */
+#define FAP_HIGH_LEVEL_KEY               ((uint16_t)0x00CC)     /*!< flash fap high level enable key val */
+#define SLIB_UNLOCK_KEY                  ((uint32_t)0xA35F6D24) /*!< flash slib operation unlock order key */
+
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_flags
+  * @brief flash flag
+  * @{
+  */
+
+#define FLASH_OBF_FLAG                   ((uint32_t)0x00000001)   /*!< flash operate busy flag */
+#define FLASH_ODF_FLAG                   ((uint32_t)0x00000020)   /*!< flash operate done flag */
+#define FLASH_PRGMERR_FLAG               ((uint32_t)0x00000004)   /*!< flash program error flag */
+#define FLASH_EPPERR_FLAG                ((uint32_t)0x00000010)   /*!< flash erase/program protection error flag */
+#define FLASH_USDERR_FLAG                ((uint32_t)0x40000001)   /*!< flash user system data error flag */
+
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_interrupts
+  * @brief flash interrupts
+  * @{
+  */
+
+#define FLASH_ERR_INT                    ((uint32_t)0x00000001) /*!< flash error interrupt */
+#define FLASH_ODF_INT                    ((uint32_t)0x00000002) /*!< flash operate done interrupt */
+
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_slib_mask
+  * @brief flash slib mask
+  * @{
+  */
+
+#define FLASH_SLIB_START_SECTOR          ((uint32_t)0x000007FF) /*!< flash slib start sector */
+#define FLASH_SLIB_INST_START_SECTOR     ((uint32_t)0x003FF800) /*!< flash slib i-bus area start sector */
+#define FLASH_SLIB_END_SECTOR            ((uint32_t)0xFFC00000) /*!< flash slib end sector */
+
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_user_system_data
+  * @brief flash user system data
+  * @{
+  */
+
+#define USD_WDT_ATO_DISABLE              ((uint16_t)0x0001) /*!< wdt auto start disabled  */
+#define USD_WDT_ATO_ENABLE               ((uint16_t)0x0000) /*!< wdt auto start enabled */
+
+#define USD_DEPSLP_NO_RST                ((uint16_t)0x0002) /*!< no reset generated when entering in deepsleep */
+#define USD_DEPSLP_RST                   ((uint16_t)0x0000) /*!< reset generated when entering in deepsleep */
+
+#define USD_STDBY_NO_RST                 ((uint16_t)0x0004) /*!< no reset generated when entering in standby */
+#define USD_STDBY_RST                    ((uint16_t)0x0000) /*!< reset generated when entering in standby */
+
+#define USD_BOOT1_LOW                    ((uint16_t)0x0010) /*!< when boot0 is high level, boot from bootmem */
+#define USD_BOOT1_HIGH                   ((uint16_t)0x0000) /*!< when boot0 is high level, boot from sram */
+
+#define USD_DEPSLP_WDT_CONTINUE          ((uint16_t)0x0020) /*!< wdt continue count when entering in deepsleep */
+#define USD_DEPSLP_WDT_STOP              ((uint16_t)0x0000) /*!< wdt stop count when entering in deepsleep */
+
+#define USD_STDBY_WDT_CONTINUE           ((uint16_t)0x0040) /*!< wdt continue count when entering in standby */
+#define USD_STDBY_WDT_STOP               ((uint16_t)0x0000) /*!< wdt stop count when entering in standby */
+
+/**
+  * @}
+  */
+
+/** @defgroup FLASH_timeout_definition
+  * @brief flash timeout definition
+  * @{
+  */
+
+#define ERASE_TIMEOUT                    ((uint32_t)0x40000000) /*!< internal flash erase operation timeout */
+#define PROGRAMMING_TIMEOUT              ((uint32_t)0x00100000) /*!< internal flash program operation timeout */
+#define OPERATION_TIMEOUT                ((uint32_t)0x10000000) /*!< flash common operation timeout */
+
+/**
+  * @}
+  */
+
+/**
+  * @brief  set the flash psr register
+  * @param  wtcyc: the flash wait cycle.
+  *         this parameter can be one of the following values:
+  *         - FLASH_WAIT_CYCLE_0
+  *         - FLASH_WAIT_CYCLE_1
+  *         - FLASH_WAIT_CYCLE_2
+  *         - FLASH_WAIT_CYCLE_3
+  *         - FLASH_WAIT_CYCLE_4
+  */
+#define flash_psr_set(wtcyc)     (FLASH->psr = (uint32_t)(0x150 | wtcyc))
+
+/** @defgroup FLASH_exported_types
+  * @{
+  */
+
+/**
+  * @brief  flash status type
+  */
+typedef enum
+{
+  FLASH_OPERATE_BUSY                     = 0x00, /*!< flash status is operate busy */
+  FLASH_PROGRAM_ERROR                    = 0x01, /*!< flash status is program error */
+  FLASH_EPP_ERROR                        = 0x02, /*!< flash status is epp error */
+  FLASH_OPERATE_DONE                     = 0x03, /*!< flash status is operate done */
+  FLASH_OPERATE_TIMEOUT                  = 0x04  /*!< flash status is operate timeout */
+} flash_status_type;
+
+/**
+  * @brief  flash wait cycle type
+  */
+typedef enum
+{
+  FLASH_WAIT_CYCLE_0                     = 0x00, /*!< sysclk 1~32mhz */
+  FLASH_WAIT_CYCLE_1                     = 0x01, /*!< sysclk 33~64mhz */
+  FLASH_WAIT_CYCLE_2                     = 0x02, /*!< sysclk 65~96mhz */
+  FLASH_WAIT_CYCLE_3                     = 0x03, /*!< sysclk 97~128mhz */
+  FLASH_WAIT_CYCLE_4                     = 0x04  /*!< sysclk 129~150mhz */
+} flash_wait_cycle_type;
+
+/**
+  * @brief type define flash register all
+  */
+typedef struct
+{
+  /**
+    * @brief flash psr register, offset:0x00
+    */
+  union
+  {
+    __IO uint32_t psr;
+    struct
+    {
+      __IO uint32_t wtcyc                : 3; /* [2:0] */
+      __IO uint32_t reserved1            : 1; /* [3] */
+      __IO uint32_t pft_en               : 1; /* [4] */
+      __IO uint32_t pft_enf              : 1; /* [5] */
+      __IO uint32_t pft_en2              : 1; /* [6] */
+      __IO uint32_t pft_enf2             : 1; /* [7] */
+      __IO uint32_t pft_lat_dis          : 1; /* [8] */
+      __IO uint32_t reserved2            : 23;/* [31:9] */
+    } psr_bit;
+  };
+
+  /**
+    * @brief flash unlock register, offset:0x04
+    */
+  union
+  {
+    __IO uint32_t unlock;
+    struct
+    {
+      __IO uint32_t ukval                : 32;/* [31:0] */
+    } unlock_bit;
+  };
+
+  /**
+    * @brief flash usd unlock register, offset:0x08
+    */
+  union
+  {
+    __IO uint32_t usd_unlock;
+    struct
+    {
+      __IO uint32_t usd_ukval            : 32;/* [31:0] */
+    } usd_unlock_bit;
+  };
+
+  /**
+    * @brief flash sts register, offset:0x0C
+    */
+  union
+  {
+    __IO uint32_t sts;
+    struct
+    {
+      __IO uint32_t obf                  : 1; /* [0] */
+      __IO uint32_t reserved1            : 1; /* [1] */
+      __IO uint32_t prgmerr              : 1; /* [2] */
+      __IO uint32_t reserved2            : 1; /* [3] */
+      __IO uint32_t epperr               : 1; /* [4] */
+      __IO uint32_t odf                  : 1; /* [5] */
+      __IO uint32_t reserved3            : 26;/* [31:6] */
+    } sts_bit;
+  };
+
+  /**
+    * @brief flash ctrl register, offset:0x10
+    */
+  union
+  {
+    __IO uint32_t ctrl;
+    struct
+    {
+      __IO uint32_t fprgm                : 1; /* [0] */
+      __IO uint32_t secers               : 1; /* [1] */
+      __IO uint32_t bankers              : 1; /* [2] */
+      __IO uint32_t reserved1            : 1; /* [3] */
+      __IO uint32_t usdprgm              : 1; /* [4] */
+      __IO uint32_t usders               : 1; /* [5] */
+      __IO uint32_t erstr                : 1; /* [6] */
+      __IO uint32_t oplk                 : 1; /* [7] */
+      __IO uint32_t reserved2            : 1; /* [8] */
+      __IO uint32_t usdulks              : 1; /* [9] */
+      __IO uint32_t errie                : 1; /* [10] */
+      __IO uint32_t reserved3            : 1; /* [11] */
+      __IO uint32_t odfie                : 1; /* [12] */
+      __IO uint32_t reserved4            : 19;/* [31:13] */
+    } ctrl_bit;
+  };
+
+  /**
+    * @brief flash addr register, offset:0x14
+    */
+  union
+  {
+    __IO uint32_t addr;
+    struct
+    {
+      __IO uint32_t fa                   : 32;/* [31:0] */
+    } addr_bit;
+  };
+
+  /**
+    * @brief flash reserved1 register, offset:0x18
+    */
+  __IO uint32_t reserved1;
+
+  /**
+    * @brief flash usd register, offset:0x1C
+    */
+  union
+  {
+    __IO uint32_t usd;
+    struct
+    {
+      __IO uint32_t usderr               : 1; /* [0] */
+      __IO uint32_t fap                  : 1; /* [1] */
+      __IO uint32_t wdt_ato_en           : 1; /* [2] */
+      __IO uint32_t depslp_rst           : 1; /* [3] */
+      __IO uint32_t stdby_rst            : 1; /* [4] */
+      __IO uint32_t reserved1            : 1; /* [5] */
+      __IO uint32_t boot1                : 1; /* [6] */
+      __IO uint32_t depslp_wdt           : 1; /* [7] */
+      __IO uint32_t stdby_wdt            : 1; /* [8] */
+      __IO uint32_t reserved2            : 1; /* [9] */
+      __IO uint32_t user_d0              : 8; /* [17:10] */
+      __IO uint32_t user_d1              : 8; /* [25:18] */
+      __IO uint32_t fap_hl               : 1; /* [26] */
+      __IO uint32_t reserved3            : 5; /* [31:27] */
+    } usd_bit;
+  };
+
+  /**
+    * @brief flash epps register, offset:0x20
+    */
+  union
+  {
+    __IO uint32_t epps;
+    struct
+    {
+      __IO uint32_t epps                 : 32;/* [31:0] */
+    } epps_bit;
+  };
+
+  /**
+    * @brief flash reserved2 register, offset:0x70~0x24
+    */
+  __IO uint32_t reserved2[20];
+
+  /**
+    * @brief flash slib_sts0 register, offset:0x74
+    */
+  union
+  {
+    __IO uint32_t slib_sts0;
+    struct
+    {
+      __IO uint32_t btm_ap_enf           : 1; /* [0] */
+      __IO uint32_t reserved1            : 1; /* [1] */
+      __IO uint32_t em_slib_enf          : 1; /* [2] */
+      __IO uint32_t slib_enf             : 1; /* [3] */
+      __IO uint32_t reserved2            : 12;/* [15:4] */
+      __IO uint32_t em_slib_inst_ss      : 8; /* [23:16] */
+      __IO uint32_t reserved3            : 8; /* [31:24] */
+    } slib_sts0_bit;
+  };
+
+  /**
+    * @brief flash slib_sts1 register, offset:0x78
+    */
+  union
+  {
+    __IO uint32_t slib_sts1;
+    struct
+    {
+      __IO uint32_t slib_ss              : 11;/* [10:0] */
+      __IO uint32_t slib_inst_ss         : 11;/* [21:11] */
+      __IO uint32_t slib_es              : 10;/* [31:22] */
+    } slib_sts1_bit;
+  };
+
+  /**
+    * @brief flash slib_pwd_clr register, offset:0x7C
+    */
+  union
+  {
+    __IO uint32_t slib_pwd_clr;
+    struct
+    {
+      __IO uint32_t slib_pclr_val        : 32;/* [31:0] */
+    } slib_pwd_clr_bit;
+  };
+
+  /**
+    * @brief flash slib_misc_sts register, offset:0x80
+    */
+  union
+  {
+    __IO uint32_t slib_misc_sts;
+    struct
+    {
+      __IO uint32_t slib_pwd_err         : 1; /* [0] */
+      __IO uint32_t slib_pwd_ok          : 1; /* [1] */
+      __IO uint32_t slib_ulkf            : 1; /* [2] */
+      __IO uint32_t reserved1            : 29;/* [31:3] */
+    } slib_misc_sts_bit;
+  };
+
+  /**
+    * @brief flash crc_addr register, offset:0x84
+    */
+  union
+  {
+    __IO uint32_t crc_addr;
+    struct
+    {
+      __IO uint32_t crc_addr             : 32;/* [31:0] */
+    } crc_addr_bit;
+  };
+
+  /**
+    * @brief flash crc_ctrl register, offset:0x88
+    */
+  union
+  {
+    __IO uint32_t crc_ctrl;
+    struct
+    {
+      __IO uint32_t crc_sn               : 16;/* [15:0] */
+      __IO uint32_t crc_strt             : 1; /* [16] */
+      __IO uint32_t reserved1            : 15;/* [31:17] */
+    } crc_ctrl_bit;
+  };
+
+  /**
+    * @brief flash crc_chkr register, offset:0x8C
+    */
+  union
+  {
+    __IO uint32_t crc_chkr;
+    struct
+    {
+      __IO uint32_t crc_chkr             : 32;/* [31:0] */
+    } crc_chkr_bit;
+  };
+
+  /**
+    * @brief flash reserved3 register, offset:0x15C~0x90
+    */
+  __IO uint32_t reserved3[52];
+
+  /**
+    * @brief flash slib_set_pwd register, offset:0x160
+    */
+  union
+  {
+    __IO uint32_t slib_set_pwd;
+    struct
+    {
+      __IO uint32_t slib_pset_val        : 32;/* [31:0] */
+    } slib_set_pwd_bit;
+  };
+
+  /**
+    * @brief flash slib_set_range register, offset:0x164
+    */
+  union
+  {
+    __IO uint32_t slib_set_range;
+    struct
+    {
+      __IO uint32_t slib_ss_set          : 11;/* [10:0] */
+      __IO uint32_t slib_iss_set         : 11;/* [21:11] */
+      __IO uint32_t slib_es_set          : 10;/* [31:22] */
+    } slib_set_range_bit;
+  };
+
+  /**
+    * @brief flash em_slib_set register, offset:0x168
+    */
+  union
+  {
+    __IO uint32_t em_slib_set;
+    struct
+    {
+      __IO uint32_t em_slib_set          : 16;/* [15:0] */
+      __IO uint32_t em_slib_iss_set      : 8; /* [23:16] */
+      __IO uint32_t reserved1            : 8; /* [31:24] */
+    } em_slib_set_bit;
+  };
+
+  /**
+    * @brief flash btm_mode_set register, offset:0x16C
+    */
+  union
+  {
+    __IO uint32_t btm_mode_set;
+    struct
+    {
+      __IO uint32_t btm_mode_set         : 8; /* [7:0] */
+      __IO uint32_t reserved1            : 24;/* [31:8] */
+    } btm_mode_set_bit;
+  };
+
+  /**
+    * @brief flash slib_unlock register, offset:0x170
+    */
+  union
+  {
+    __IO uint32_t slib_unlock;
+    struct
+    {
+      __IO uint32_t slib_ukval           : 32;/* [31:0] */
+    } slib_unlock_bit;
+  };
+
+} flash_type;
+
+/**
+  * @brief user system data
+  */
+typedef struct
+{
+  __IO uint16_t fap;
+  __IO uint16_t ssb;
+  __IO uint16_t data0;
+  __IO uint16_t data1;
+  __IO uint16_t epp0;
+  __IO uint16_t epp1;
+  __IO uint16_t epp2;
+  __IO uint16_t epp3;
+} usd_type;
+
+/**
+  * @}
+  */
+
+#define FLASH                            ((flash_type *) FLASH_REG_BASE)
+#define USD                              ((usd_type *) USD_BASE)
+
+/** @defgroup FLASH_exported_functions
+  * @{
+  */
+
+flag_status flash_flag_get(uint32_t flash_flag);
+void flash_flag_clear(uint32_t flash_flag);
+flash_status_type flash_operation_status_get(void);
+flash_status_type flash_operation_wait_for(uint32_t time_out);
+void flash_unlock(void);
+void flash_lock(void);
+flash_status_type flash_sector_erase(uint32_t sector_address);
+flash_status_type flash_internal_all_erase(void);
+flash_status_type flash_user_system_data_erase(void);
+flash_status_type flash_word_program(uint32_t address, uint32_t data);
+flash_status_type flash_halfword_program(uint32_t address, uint16_t data);
+flash_status_type flash_byte_program(uint32_t address, uint8_t data);
+flash_status_type flash_user_system_data_program(uint32_t address, uint8_t data);
+flash_status_type flash_epp_set(uint32_t *sector_bits);
+void flash_epp_status_get(uint32_t *sector_bits);
+flash_status_type flash_fap_enable(confirm_state new_state);
+flag_status flash_fap_status_get(void);
+flash_status_type flash_fap_high_level_enable(void);
+flag_status flash_fap_high_level_status_get(void);
+flash_status_type flash_ssb_set(uint8_t usd_ssb);
+uint8_t flash_ssb_status_get(void);
+void flash_interrupt_enable(uint32_t flash_int, confirm_state new_state);
+flash_status_type flash_slib_enable(uint32_t pwd, uint16_t start_sector, uint16_t inst_start_sector, uint16_t end_sector);
+error_status flash_slib_disable(uint32_t pwd);
+flag_status flash_slib_state_get(void);
+uint16_t flash_slib_start_sector_get(void);
+uint16_t flash_slib_inststart_sector_get(void);
+uint16_t flash_slib_end_sector_get(void);
+uint32_t flash_crc_calibrate(uint32_t start_addr, uint32_t sector_cnt);
+void flash_boot_memory_extension_mode_enable(void);
+flash_status_type flash_extension_memory_slib_enable(uint32_t pwd, uint16_t inst_start_sector);
+flag_status flash_extension_memory_slib_state_get(void);
+uint16_t flash_em_slib_inststart_sector_get(void);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_gpio.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_gpio.h
@@ -1,0 +1,592 @@
+/**
+  **************************************************************************
+  * @file     at32f423_gpio.h
+  * @brief    at32f423 gpio header file
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+/* define to prevent recursive inclusion -------------------------------------*/
+#ifndef __AT32F423_GPIO_H
+#define __AT32F423_GPIO_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* includes ------------------------------------------------------------------*/
+#include "at32f423.h"
+
+/** @addtogroup AT32F423_periph_driver
+  * @{
+  */
+
+/** @addtogroup GPIO
+  * @{
+  */
+
+/** @defgroup GPIO_pins_number_definition
+  * @{
+  */
+
+#define GPIO_PINS_0                      0x0001 /*!< gpio pins number 0 */
+#define GPIO_PINS_1                      0x0002 /*!< gpio pins number 1 */
+#define GPIO_PINS_2                      0x0004 /*!< gpio pins number 2 */
+#define GPIO_PINS_3                      0x0008 /*!< gpio pins number 3 */
+#define GPIO_PINS_4                      0x0010 /*!< gpio pins number 4 */
+#define GPIO_PINS_5                      0x0020 /*!< gpio pins number 5 */
+#define GPIO_PINS_6                      0x0040 /*!< gpio pins number 6 */
+#define GPIO_PINS_7                      0x0080 /*!< gpio pins number 7 */
+#define GPIO_PINS_8                      0x0100 /*!< gpio pins number 8 */
+#define GPIO_PINS_9                      0x0200 /*!< gpio pins number 9 */
+#define GPIO_PINS_10                     0x0400 /*!< gpio pins number 10 */
+#define GPIO_PINS_11                     0x0800 /*!< gpio pins number 11 */
+#define GPIO_PINS_12                     0x1000 /*!< gpio pins number 12 */
+#define GPIO_PINS_13                     0x2000 /*!< gpio pins number 13 */
+#define GPIO_PINS_14                     0x4000 /*!< gpio pins number 14 */
+#define GPIO_PINS_15                     0x8000 /*!< gpio pins number 15 */
+#define GPIO_PINS_ALL                    0xFFFF /*!< gpio all pins */
+
+/**
+  * @}
+  */
+
+/** @defgroup GPIO_exported_types
+  * @{
+  */
+
+/**
+  * @brief gpio mode select
+  */
+typedef enum
+{
+  GPIO_MODE_INPUT                        = 0x00, /*!< gpio input mode */
+  GPIO_MODE_OUTPUT                       = 0x01, /*!< gpio output mode */
+  GPIO_MODE_MUX                          = 0x02, /*!< gpio mux function mode */
+  GPIO_MODE_ANALOG                       = 0x03  /*!< gpio analog in/out mode */
+} gpio_mode_type;
+
+/**
+  * @brief gpio output drive strength select
+  */
+typedef enum
+{
+  GPIO_DRIVE_STRENGTH_STRONGER           = 0x01, /*!< stronger sourcing/sinking strength */
+  GPIO_DRIVE_STRENGTH_MODERATE           = 0x02  /*!< moderate sourcing/sinking strength */
+} gpio_drive_type;
+
+/**
+  * @brief gpio output type
+  */
+typedef enum
+{
+  GPIO_OUTPUT_PUSH_PULL                  = 0x00, /*!< output push-pull */
+  GPIO_OUTPUT_OPEN_DRAIN                 = 0x01  /*!< output open-drain */
+} gpio_output_type;
+
+/**
+  * @brief gpio pull type
+  */
+typedef enum
+{
+  GPIO_PULL_NONE                         = 0x00, /*!< floating for input, no pull for output */
+  GPIO_PULL_UP                           = 0x01, /*!< pull-up */
+  GPIO_PULL_DOWN                         = 0x02  /*!< pull-down */
+} gpio_pull_type;
+
+/**
+  * @brief gpio init type
+  */
+typedef struct
+{
+  uint32_t                               gpio_pins;            /*!< pins number selection */
+  gpio_output_type                       gpio_out_type;        /*!< output type selection */
+  gpio_pull_type                         gpio_pull;            /*!< pull type selection */
+  gpio_mode_type                         gpio_mode;            /*!< mode selection */
+  gpio_drive_type                        gpio_drive_strength;  /*!< drive strength selection */
+} gpio_init_type;
+
+/**
+  * @brief gpio pins source type
+  */
+typedef enum
+{
+  GPIO_PINS_SOURCE0                      = 0x00, /*!< gpio pins source number 0 */
+  GPIO_PINS_SOURCE1                      = 0x01, /*!< gpio pins source number 1 */
+  GPIO_PINS_SOURCE2                      = 0x02, /*!< gpio pins source number 2 */
+  GPIO_PINS_SOURCE3                      = 0x03, /*!< gpio pins source number 3 */
+  GPIO_PINS_SOURCE4                      = 0x04, /*!< gpio pins source number 4 */
+  GPIO_PINS_SOURCE5                      = 0x05, /*!< gpio pins source number 5 */
+  GPIO_PINS_SOURCE6                      = 0x06, /*!< gpio pins source number 6 */
+  GPIO_PINS_SOURCE7                      = 0x07, /*!< gpio pins source number 7 */
+  GPIO_PINS_SOURCE8                      = 0x08, /*!< gpio pins source number 8 */
+  GPIO_PINS_SOURCE9                      = 0x09, /*!< gpio pins source number 9 */
+  GPIO_PINS_SOURCE10                     = 0x0A, /*!< gpio pins source number 10 */
+  GPIO_PINS_SOURCE11                     = 0x0B, /*!< gpio pins source number 11 */
+  GPIO_PINS_SOURCE12                     = 0x0C, /*!< gpio pins source number 12 */
+  GPIO_PINS_SOURCE13                     = 0x0D, /*!< gpio pins source number 13 */
+  GPIO_PINS_SOURCE14                     = 0x0E, /*!< gpio pins source number 14 */
+  GPIO_PINS_SOURCE15                     = 0x0F  /*!< gpio pins source number 15 */
+} gpio_pins_source_type;
+
+/**
+  * @brief  gpio muxing function selection type
+  */
+typedef enum
+{
+  GPIO_MUX_0                             = 0x00, /*!< gpio muxing function selection 0 */
+  GPIO_MUX_1                             = 0x01, /*!< gpio muxing function selection 1 */
+  GPIO_MUX_2                             = 0x02, /*!< gpio muxing function selection 2 */
+  GPIO_MUX_3                             = 0x03, /*!< gpio muxing function selection 3 */
+  GPIO_MUX_4                             = 0x04, /*!< gpio muxing function selection 4 */
+  GPIO_MUX_5                             = 0x05, /*!< gpio muxing function selection 5 */
+  GPIO_MUX_6                             = 0x06, /*!< gpio muxing function selection 6 */
+  GPIO_MUX_7                             = 0x07, /*!< gpio muxing function selection 7 */
+  GPIO_MUX_8                             = 0x08, /*!< gpio muxing function selection 8 */
+  GPIO_MUX_9                             = 0x09, /*!< gpio muxing function selection 9 */
+  GPIO_MUX_10                            = 0x0A, /*!< gpio muxing function selection 10 */
+  GPIO_MUX_11                            = 0x0B, /*!< gpio muxing function selection 11 */
+  GPIO_MUX_12                            = 0x0C, /*!< gpio muxing function selection 12 */
+  GPIO_MUX_13                            = 0x0D, /*!< gpio muxing function selection 13 */
+  GPIO_MUX_14                            = 0x0E, /*!< gpio muxing function selection 14 */
+  GPIO_MUX_15                            = 0x0F  /*!< gpio muxing function selection 15 */
+} gpio_mux_sel_type;
+
+/**
+  * @brief type define gpio register all
+  */
+typedef struct
+{
+  /**
+    * @brief gpio mode register, offset:0x00
+    */
+  union
+  {
+    __IO uint32_t cfgr;
+    struct
+    {
+      __IO uint32_t iomc0                : 2; /* [1:0] */
+      __IO uint32_t iomc1                : 2; /* [3:2] */
+      __IO uint32_t iomc2                : 2; /* [5:4] */
+      __IO uint32_t iomc3                : 2; /* [7:6] */
+      __IO uint32_t iomc4                : 2; /* [9:8] */
+      __IO uint32_t iomc5                : 2; /* [11:10] */
+      __IO uint32_t iomc6                : 2; /* [13:12] */
+      __IO uint32_t iomc7                : 2; /* [15:14] */
+      __IO uint32_t iomc8                : 2; /* [17:16] */
+      __IO uint32_t iomc9                : 2; /* [19:18] */
+      __IO uint32_t iomc10               : 2; /* [21:20] */
+      __IO uint32_t iomc11               : 2; /* [23:22] */
+      __IO uint32_t iomc12               : 2; /* [25:24] */
+      __IO uint32_t iomc13               : 2; /* [27:26] */
+      __IO uint32_t iomc14               : 2; /* [29:28] */
+      __IO uint32_t iomc15               : 2; /* [31:30] */
+    } cfgr_bit;
+  };
+
+  /**
+    * @brief gpio output type register, offset:0x04
+    */
+  union
+  {
+    __IO uint32_t omode;
+    struct
+    {
+      __IO uint32_t om0                  : 1; /* [0] */
+      __IO uint32_t om1                  : 1; /* [1] */
+      __IO uint32_t om2                  : 1; /* [2] */
+      __IO uint32_t om3                  : 1; /* [3] */
+      __IO uint32_t om4                  : 1; /* [4] */
+      __IO uint32_t om5                  : 1; /* [5] */
+      __IO uint32_t om6                  : 1; /* [6] */
+      __IO uint32_t om7                  : 1; /* [7] */
+      __IO uint32_t om8                  : 1; /* [8] */
+      __IO uint32_t om9                  : 1; /* [9] */
+      __IO uint32_t om10                 : 1; /* [10] */
+      __IO uint32_t om11                 : 1; /* [11] */
+      __IO uint32_t om12                 : 1; /* [12] */
+      __IO uint32_t om13                 : 1; /* [13] */
+      __IO uint32_t om14                 : 1; /* [14] */
+      __IO uint32_t om15                 : 1; /* [15] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } omode_bit;
+  };
+
+  /**
+    * @brief gpio output driver register, offset:0x08
+    */
+  union
+  {
+    __IO uint32_t odrvr;
+    struct
+    {
+      __IO uint32_t odrv0                : 2; /* [1:0] */
+      __IO uint32_t odrv1                : 2; /* [3:2] */
+      __IO uint32_t odrv2                : 2; /* [5:4] */
+      __IO uint32_t odrv3                : 2; /* [7:6] */
+      __IO uint32_t odrv4                : 2; /* [9:8] */
+      __IO uint32_t odrv5                : 2; /* [11:10] */
+      __IO uint32_t odrv6                : 2; /* [13:12] */
+      __IO uint32_t odrv7                : 2; /* [15:14] */
+      __IO uint32_t odrv8                : 2; /* [17:16] */
+      __IO uint32_t odrv9                : 2; /* [19:18] */
+      __IO uint32_t odrv10               : 2; /* [21:20] */
+      __IO uint32_t odrv11               : 2; /* [23:22] */
+      __IO uint32_t odrv12               : 2; /* [25:24] */
+      __IO uint32_t odrv13               : 2; /* [27:26] */
+      __IO uint32_t odrv14               : 2; /* [29:28] */
+      __IO uint32_t odrv15               : 2; /* [31:30] */
+    } odrvr_bit;
+  };
+
+  /**
+    * @brief gpio pull up/down register, offset:0x0C
+    */
+  union
+  {
+    __IO uint32_t pull;
+    struct
+    {
+      __IO uint32_t pull0                : 2; /* [1:0] */
+      __IO uint32_t pull1                : 2; /* [3:2] */
+      __IO uint32_t pull2                : 2; /* [5:4] */
+      __IO uint32_t pull3                : 2; /* [7:6] */
+      __IO uint32_t pull4                : 2; /* [9:8] */
+      __IO uint32_t pull5                : 2; /* [11:10] */
+      __IO uint32_t pull6                : 2; /* [13:12] */
+      __IO uint32_t pull7                : 2; /* [15:14] */
+      __IO uint32_t pull8                : 2; /* [17:16] */
+      __IO uint32_t pull9                : 2; /* [19:18] */
+      __IO uint32_t pull10               : 2; /* [21:20] */
+      __IO uint32_t pull11               : 2; /* [23:22] */
+      __IO uint32_t pull12               : 2; /* [25:24] */
+      __IO uint32_t pull13               : 2; /* [27:26] */
+      __IO uint32_t pull14               : 2; /* [29:28] */
+      __IO uint32_t pull15               : 2; /* [31:30] */
+    } pull_bit;
+  };
+
+  /**
+    * @brief gpio input data register, offset:0x10
+    */
+  union
+  {
+    __IO uint32_t idt;
+    struct
+    {
+      __IO uint32_t idt0                 : 1; /* [0] */
+      __IO uint32_t idt1                 : 1; /* [1] */
+      __IO uint32_t idt2                 : 1; /* [2] */
+      __IO uint32_t idt3                 : 1; /* [3] */
+      __IO uint32_t idt4                 : 1; /* [4] */
+      __IO uint32_t idt5                 : 1; /* [5] */
+      __IO uint32_t idt6                 : 1; /* [6] */
+      __IO uint32_t idt7                 : 1; /* [7] */
+      __IO uint32_t idt8                 : 1; /* [8] */
+      __IO uint32_t idt9                 : 1; /* [9] */
+      __IO uint32_t idt10                : 1; /* [10] */
+      __IO uint32_t idt11                : 1; /* [11] */
+      __IO uint32_t idt12                : 1; /* [12] */
+      __IO uint32_t idt13                : 1; /* [13] */
+      __IO uint32_t idt14                : 1; /* [14] */
+      __IO uint32_t idt15                : 1; /* [15] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } idt_bit;
+  };
+
+  /**
+    * @brief gpio output data register, offset:0x14
+    */
+  union
+  {
+    __IO uint32_t odt;
+    struct
+    {
+      __IO uint32_t odt0                 : 1; /* [0] */
+      __IO uint32_t odt1                 : 1; /* [1] */
+      __IO uint32_t odt2                 : 1; /* [2] */
+      __IO uint32_t odt3                 : 1; /* [3] */
+      __IO uint32_t odt4                 : 1; /* [4] */
+      __IO uint32_t odt5                 : 1; /* [5] */
+      __IO uint32_t odt6                 : 1; /* [6] */
+      __IO uint32_t odt7                 : 1; /* [7] */
+      __IO uint32_t odt8                 : 1; /* [8] */
+      __IO uint32_t odt9                 : 1; /* [9] */
+      __IO uint32_t odt10                : 1; /* [10] */
+      __IO uint32_t odt11                : 1; /* [11] */
+      __IO uint32_t odt12                : 1; /* [12] */
+      __IO uint32_t odt13                : 1; /* [13] */
+      __IO uint32_t odt14                : 1; /* [14] */
+      __IO uint32_t odt15                : 1; /* [15] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } odt_bit;
+  };
+
+  /**
+    * @brief gpio scr register, offset:0x18
+    */
+  union
+  {
+    __IO uint32_t scr;
+    struct
+    {
+      __IO uint32_t iosb0                : 1; /* [0] */
+      __IO uint32_t iosb1                : 1; /* [1] */
+      __IO uint32_t iosb2                : 1; /* [2] */
+      __IO uint32_t iosb3                : 1; /* [3] */
+      __IO uint32_t iosb4                : 1; /* [4] */
+      __IO uint32_t iosb5                : 1; /* [5] */
+      __IO uint32_t iosb6                : 1; /* [6] */
+      __IO uint32_t iosb7                : 1; /* [7] */
+      __IO uint32_t iosb8                : 1; /* [8] */
+      __IO uint32_t iosb9                : 1; /* [9] */
+      __IO uint32_t iosb10               : 1; /* [10] */
+      __IO uint32_t iosb11               : 1; /* [11] */
+      __IO uint32_t iosb12               : 1; /* [12] */
+      __IO uint32_t iosb13               : 1; /* [13] */
+      __IO uint32_t iosb14               : 1; /* [14] */
+      __IO uint32_t iosb15               : 1; /* [15] */
+      __IO uint32_t iocb0                : 1; /* [16] */
+      __IO uint32_t iocb1                : 1; /* [17] */
+      __IO uint32_t iocb2                : 1; /* [18] */
+      __IO uint32_t iocb3                : 1; /* [19] */
+      __IO uint32_t iocb4                : 1; /* [20] */
+      __IO uint32_t iocb5                : 1; /* [21] */
+      __IO uint32_t iocb6                : 1; /* [22] */
+      __IO uint32_t iocb7                : 1; /* [23] */
+      __IO uint32_t iocb8                : 1; /* [24] */
+      __IO uint32_t iocb9                : 1; /* [25] */
+      __IO uint32_t iocb10               : 1; /* [26] */
+      __IO uint32_t iocb11               : 1; /* [27] */
+      __IO uint32_t iocb12               : 1; /* [28] */
+      __IO uint32_t iocb13               : 1; /* [29] */
+      __IO uint32_t iocb14               : 1; /* [30] */
+      __IO uint32_t iocb15               : 1; /* [31] */
+    } scr_bit;
+  };
+
+  /**
+    * @brief gpio wpen register, offset:0x1C
+    */
+  union
+  {
+    __IO uint32_t wpr;
+    struct
+    {
+      __IO uint32_t wpen0                : 1; /* [0] */
+      __IO uint32_t wpen1                : 1; /* [1] */
+      __IO uint32_t wpen2                : 1; /* [2] */
+      __IO uint32_t wpen3                : 1; /* [3] */
+      __IO uint32_t wpen4                : 1; /* [4] */
+      __IO uint32_t wpen5                : 1; /* [5] */
+      __IO uint32_t wpen6                : 1; /* [6] */
+      __IO uint32_t wpen7                : 1; /* [7] */
+      __IO uint32_t wpen8                : 1; /* [8] */
+      __IO uint32_t wpen9                : 1; /* [9] */
+      __IO uint32_t wpen10               : 1; /* [10] */
+      __IO uint32_t wpen11               : 1; /* [11] */
+      __IO uint32_t wpen12               : 1; /* [12] */
+      __IO uint32_t wpen13               : 1; /* [13] */
+      __IO uint32_t wpen14               : 1; /* [14] */
+      __IO uint32_t wpen15               : 1; /* [15] */
+      __IO uint32_t wpseq                : 1; /* [16] */
+      __IO uint32_t reserved1            : 15;/* [31:17] */
+    } wpr_bit;
+  };
+
+  /**
+    * @brief gpio muxl register, offset:0x20
+    */
+  union
+  {
+    __IO uint32_t muxl;
+    struct
+    {
+      __IO uint32_t muxl0                : 4; /* [3:0] */
+      __IO uint32_t muxl1                : 4; /* [7:4] */
+      __IO uint32_t muxl2                : 4; /* [11:8] */
+      __IO uint32_t muxl3                : 4; /* [15:12] */
+      __IO uint32_t muxl4                : 4; /* [19:16] */
+      __IO uint32_t muxl5                : 4; /* [23:20] */
+      __IO uint32_t muxl6                : 4; /* [27:24] */
+      __IO uint32_t muxl7                : 4; /* [31:28] */
+    } muxl_bit;
+  };
+
+  /**
+    * @brief gpio muxh register, offset:0x24
+    */
+  union
+  {
+    __IO uint32_t muxh;
+    struct
+    {
+      __IO uint32_t muxh8                : 4; /* [3:0] */
+      __IO uint32_t muxh9                : 4; /* [7:4] */
+      __IO uint32_t muxh10               : 4; /* [11:8] */
+      __IO uint32_t muxh11               : 4; /* [15:12] */
+      __IO uint32_t muxh12               : 4; /* [19:16] */
+      __IO uint32_t muxh13               : 4; /* [23:20] */
+      __IO uint32_t muxh14               : 4; /* [27:24] */
+      __IO uint32_t muxh15               : 4; /* [31:28] */
+    } muxh_bit;
+  };
+
+  /**
+    * @brief gpio clr register, offset:0x28
+    */
+  union
+  {
+    __IO uint32_t clr;
+    struct
+    {
+      __IO uint32_t iocb0                : 1; /* [0] */
+      __IO uint32_t iocb1                : 1; /* [1] */
+      __IO uint32_t iocb2                : 1; /* [2] */
+      __IO uint32_t iocb3                : 1; /* [3] */
+      __IO uint32_t iocb4                : 1; /* [4] */
+      __IO uint32_t iocb5                : 1; /* [5] */
+      __IO uint32_t iocb6                : 1; /* [6] */
+      __IO uint32_t iocb7                : 1; /* [7] */
+      __IO uint32_t iocb8                : 1; /* [8] */
+      __IO uint32_t iocb9                : 1; /* [9] */
+      __IO uint32_t iocb10               : 1; /* [10] */
+      __IO uint32_t iocb11               : 1; /* [11] */
+      __IO uint32_t iocb12               : 1; /* [12] */
+      __IO uint32_t iocb13               : 1; /* [13] */
+      __IO uint32_t iocb14               : 1; /* [14] */
+      __IO uint32_t iocb15               : 1; /* [15] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } clr_bit;
+  };
+
+  /**
+  * @brief gpio togr register, offset:0x2C
+  */
+  union
+  {
+    __IO uint32_t togr;
+    struct
+    {
+      __IO uint32_t iotb0                : 1; /* [0] */
+      __IO uint32_t iotb1                : 1; /* [1] */
+      __IO uint32_t iotb2                : 1; /* [2] */
+      __IO uint32_t iotb3                : 1; /* [3] */
+      __IO uint32_t iotb4                : 1; /* [4] */
+      __IO uint32_t iotb5                : 1; /* [5] */
+      __IO uint32_t iotb6                : 1; /* [6] */
+      __IO uint32_t iotb7                : 1; /* [7] */
+      __IO uint32_t iotb8                : 1; /* [8] */
+      __IO uint32_t iotb9                : 1; /* [9] */
+      __IO uint32_t iotb10               : 1; /* [10] */
+      __IO uint32_t iotb11               : 1; /* [11] */
+      __IO uint32_t iotb12               : 1; /* [12] */
+      __IO uint32_t iotb13               : 1; /* [13] */
+      __IO uint32_t iotb14               : 1; /* [14] */
+      __IO uint32_t iotb15               : 1; /* [15] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } togr_bit;
+  };
+
+  
+  /**
+    * @brief gpio reserved1 register, offset:0x30~0x38
+    */
+  __IO uint32_t reserved1[3];
+
+  /**
+    * @brief gpio hdrv register, offset:0x3C
+    */
+  union
+  {
+    __IO uint32_t hdrv;
+    struct
+    {
+      __IO uint32_t hdrv0                : 1; /* [0] */
+      __IO uint32_t hdrv1                : 1; /* [1] */
+      __IO uint32_t hdrv2                : 1; /* [2] */
+      __IO uint32_t hdrv3                : 1; /* [3] */
+      __IO uint32_t hdrv4                : 1; /* [4] */
+      __IO uint32_t hdrv5                : 1; /* [5] */
+      __IO uint32_t hdrv6                : 1; /* [6] */
+      __IO uint32_t hdrv7                : 1; /* [7] */
+      __IO uint32_t hdrv8                : 1; /* [8] */
+      __IO uint32_t hdrv9                : 1; /* [9] */
+      __IO uint32_t hdrv10               : 1; /* [10] */
+      __IO uint32_t hdrv11               : 1; /* [11] */
+      __IO uint32_t hdrv12               : 1; /* [12] */
+      __IO uint32_t hdrv13               : 1; /* [13] */
+      __IO uint32_t hdrv14               : 1; /* [14] */
+      __IO uint32_t hdrv15               : 1; /* [15] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } hdrv_bit;
+  };
+
+} gpio_type;
+
+/**
+  * @}
+  */
+
+#define GPIOA                            ((gpio_type *) GPIOA_BASE)
+#define GPIOB                            ((gpio_type *) GPIOB_BASE)
+#define GPIOC                            ((gpio_type *) GPIOC_BASE)
+#define GPIOD                            ((gpio_type *) GPIOD_BASE)
+#define GPIOE                            ((gpio_type *) GPIOE_BASE)
+#define GPIOF                            ((gpio_type *) GPIOF_BASE)
+
+/** @defgroup GPIO_exported_functions
+  * @{
+  */
+
+void gpio_reset(gpio_type *gpio_x);
+void gpio_init(gpio_type *gpio_x, gpio_init_type *gpio_init_struct);
+void gpio_default_para_init(gpio_init_type *gpio_init_struct);
+flag_status gpio_input_data_bit_read(gpio_type *gpio_x, uint16_t pins);
+uint16_t gpio_input_data_read(gpio_type *gpio_x);
+flag_status gpio_output_data_bit_read(gpio_type *gpio_x, uint16_t pins);
+uint16_t gpio_output_data_read(gpio_type *gpio_x);
+void gpio_bits_set(gpio_type *gpio_x, uint16_t pins);
+void gpio_bits_reset(gpio_type *gpio_x, uint16_t pins);
+void gpio_bits_toggle(gpio_type *gpio_x, uint16_t pins);
+void gpio_bits_write(gpio_type *gpio_x, uint16_t pins, confirm_state bit_state);
+void gpio_port_write(gpio_type *gpio_x, uint16_t port_value);
+void gpio_pin_wp_config(gpio_type *gpio_x, uint16_t pins);
+void gpio_pins_huge_driven_config(gpio_type *gpio_x, uint16_t pins, confirm_state new_state);
+void gpio_pin_mux_config(gpio_type *gpio_x, gpio_pins_source_type gpio_pin_source, gpio_mux_sel_type gpio_mux);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_i2c.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_i2c.h
@@ -1,0 +1,482 @@
+/**
+  **************************************************************************
+  * @file     at32f423_i2c.h
+  * @brief    at32f423 i2c header file
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+/* define to prevent recursive inclusion -------------------------------------*/
+#ifndef __AT32F423_I2C_H
+#define __AT32F423_I2C_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* includes ------------------------------------------------------------------*/
+#include "at32f423.h"
+
+/** @addtogroup AT32F423_periph_driver
+  * @{
+  */
+
+/** @addtogroup I2C
+  * @{
+  */
+
+/**
+  * @brief maximum number of single transfers
+  */
+#define MAX_TRANSFER_CNT                 255 /*!< maximum number of single transfers */
+
+/** @defgroup I2C_interrupts_definition
+  * @brief i2c interrupt
+  * @{
+  */
+
+#define I2C_TD_INT                       ((uint32_t)0x00000002) /*!< i2c transmit data interrupt */
+#define I2C_RD_INT                       ((uint32_t)0x00000004) /*!< i2c receive data interrupt */
+#define I2C_ADDR_INT                     ((uint32_t)0x00000008) /*!< i2c address match interrupt */
+#define I2C_ACKFIAL_INT                  ((uint32_t)0x00000010) /*!< i2c ack fail interrupt */
+#define I2C_STOP_INT                     ((uint32_t)0x00000020) /*!< i2c stop detect interrupt */
+#define I2C_TDC_INT                      ((uint32_t)0x00000040) /*!< i2c transmit data complete interrupt */
+#define I2C_ERR_INT                      ((uint32_t)0x00000080) /*!< i2c bus error interrupt */
+
+/**
+  * @}
+  */
+
+/** @defgroup I2C_flags_definition
+  * @brief i2c flag
+  * @{
+  */
+
+#define  I2C_TDBE_FLAG                   ((uint32_t)0x00000001) /*!< i2c transmit data buffer empty flag */
+#define  I2C_TDIS_FLAG                   ((uint32_t)0x00000002) /*!< i2c send interrupt status */
+#define  I2C_RDBF_FLAG                   ((uint32_t)0x00000004) /*!< i2c receive data buffer full flag */
+#define  I2C_ADDRF_FLAG                  ((uint32_t)0x00000008) /*!< i2c 0~7 bit address match flag */
+#define  I2C_ACKFAIL_FLAG                ((uint32_t)0x00000010) /*!< i2c acknowledge failure flag */
+#define  I2C_STOPF_FLAG                  ((uint32_t)0x00000020) /*!< i2c stop condition generation complete flag */
+#define  I2C_TDC_FLAG                    ((uint32_t)0x00000040) /*!< i2c transmit data complete flag */
+#define  I2C_TCRLD_FLAG                  ((uint32_t)0x00000080) /*!< i2c transmission is complete, waiting to load data */
+#define  I2C_BUSERR_FLAG                 ((uint32_t)0x00000100) /*!< i2c bus error flag */
+#define  I2C_ARLOST_FLAG                 ((uint32_t)0x00000200) /*!< i2c arbitration lost flag */
+#define  I2C_OUF_FLAG                    ((uint32_t)0x00000400) /*!< i2c overflow or underflow flag */
+#define  I2C_PECERR_FLAG                 ((uint32_t)0x00000800) /*!< i2c pec receive error flag */
+#define  I2C_TMOUT_FLAG                  ((uint32_t)0x00001000) /*!< i2c smbus timeout flag */
+#define  I2C_ALERTF_FLAG                 ((uint32_t)0x00002000) /*!< i2c smbus alert flag */
+#define  I2C_BUSYF_FLAG                  ((uint32_t)0x00008000) /*!< i2c bus busy flag transmission mode */
+#define  I2C_SDIR_FLAG                   ((uint32_t)0x00010000) /*!< i2c slave data transmit direction */
+
+/**
+  * @}
+  */
+
+/** @defgroup I2C_exported_types
+  * @{
+  */
+
+/**
+  * @brief i2c smbus mode set
+  */
+typedef enum
+{
+  I2C_SMBUS_MODE_DEVICE                  = 0x00, /*!< smbus device mode */
+  I2C_SMBUS_MODE_HOST                    = 0x01  /*!< smbus host mode */
+} i2c_smbus_mode_type;
+
+/**
+  * @brief i2c address mode
+  */
+typedef enum
+{
+  I2C_ADDRESS_MODE_7BIT                  = 0x00, /*!< 7bit address mode */
+  I2C_ADDRESS_MODE_10BIT                 = 0x01  /*!< 10bit address mode */
+} i2c_address_mode_type;
+
+/**
+  * @brief i2c transfer direction
+  */
+typedef enum
+{
+  I2C_DIR_TRANSMIT                       = 0x00, /*!< master request a write transfer */
+  I2C_DIR_RECEIVE                        = 0x01  /*!< master request a read transfer */
+} i2c_transfer_dir_type;
+
+/**
+  * @brief i2c dma requests direction
+  */
+typedef enum
+{
+  I2C_DMA_REQUEST_TX                     = 0x00, /*!< dma transmit request */
+  I2C_DMA_REQUEST_RX                     = 0x01  /*!< dma receive request */
+} i2c_dma_request_type;
+
+/**
+  * @brief i2c smbus alert pin set
+  */
+typedef enum
+{
+  I2C_SMBUS_ALERT_HIGH                   = 0x00, /*!< smbus alert pin set high */
+  I2C_SMBUS_ALERT_LOW                    = 0x01  /*!< smbus alert pin set low */
+} i2c_smbus_alert_set_type;
+
+/**
+  * @brief i2c clock timeout detection mode
+  */
+typedef enum
+{
+  I2C_TIMEOUT_DETCET_LOW                 = 0x00, /*!< detect low level timeout */
+  I2C_TIMEOUT_DETCET_HIGH                = 0x01  /*!< detect high level timeout */
+} i2c_timeout_detcet_type;
+
+/**
+  * @brief i2c own address2 mask
+  */
+typedef enum
+{
+  I2C_ADDR2_NOMASK                       = 0x00, /*!< compare bit      [7:1] */
+  I2C_ADDR2_MASK01                       = 0x01, /*!< only compare bit [7:2] */
+  I2C_ADDR2_MASK02                       = 0x02, /*!< only compare bit [7:3] */
+  I2C_ADDR2_MASK03                       = 0x03, /*!< only compare bit [7:4] */
+  I2C_ADDR2_MASK04                       = 0x04, /*!< only compare bit [7:5] */
+  I2C_ADDR2_MASK05                       = 0x05, /*!< only compare bit [7:6] */
+  I2C_ADDR2_MASK06                       = 0x06, /*!< only compare bit [7] */
+  I2C_ADDR2_MASK07                       = 0x07  /*!< response all addresses other than those reserved for i2c */
+} i2c_addr2_mask_type;
+
+/**
+  * @brief i2c reload end mode
+  */
+typedef enum
+{
+  I2C_AUTO_STOP_MODE                     = 0x02000000, /*!< auto generate stop mode */
+  I2C_SOFT_STOP_MODE                     = 0x00000000, /*!< soft generate stop mode */
+  I2C_RELOAD_MODE                        = 0x01000000  /*!< reload mode */
+} i2c_reload_stop_mode_type;
+
+/**
+  * @brief i2c start mode
+  */
+typedef enum
+{
+  I2C_WITHOUT_START                      = 0x00000000, /*!< transfer data without start condition */
+  I2C_GEN_START_READ                     = 0x00002400, /*!< read data and generate start */
+  I2C_GEN_START_WRITE                    = 0x00002000  /*!< send data and generate start */
+} i2c_start_mode_type;
+
+/**
+  * @brief type define i2c register all
+  */
+typedef struct
+{
+  /**
+    * @brief i2c ctrl1 register, offset:0x00
+    */
+  union
+  {
+    __IO uint32_t ctrl1;
+    struct
+    {
+      __IO uint32_t i2cen                : 1; /* [0] */
+      __IO uint32_t tdien                : 1; /* [1] */
+      __IO uint32_t rdien                : 1; /* [2] */
+      __IO uint32_t addrien              : 1; /* [3] */
+      __IO uint32_t ackfailien           : 1; /* [4] */
+      __IO uint32_t stopien              : 1; /* [5] */
+      __IO uint32_t tdcien               : 1; /* [6] */
+      __IO uint32_t errien               : 1; /* [7] */
+      __IO uint32_t dflt                 : 4; /* [11:8] */
+      __IO uint32_t angnfoff             : 1; /* [12] */
+      __IO uint32_t reserved1            : 1; /* [13] */
+      __IO uint32_t dmaten               : 1; /* [14] */
+      __IO uint32_t dmaren               : 1; /* [15] */
+      __IO uint32_t sctrl                : 1; /* [16] */
+      __IO uint32_t stretch              : 1; /* [17] */
+      __IO uint32_t wakeupen             : 1; /* [18] */
+      __IO uint32_t gcaen                : 1; /* [19] */
+      __IO uint32_t haddren              : 1; /* [20] */
+      __IO uint32_t devaddren            : 1; /* [21] */
+      __IO uint32_t smbalert             : 1; /* [22] */
+      __IO uint32_t pecen                : 1; /* [23] */
+      __IO uint32_t reserved3            : 8; /* [31:24] */
+    } ctrl1_bit;
+  };
+
+  /**
+    * @brief i2c ctrl2 register, offset:0x04
+    */
+  union
+  {
+    __IO uint32_t ctrl2;
+    struct
+    {
+      __IO uint32_t saddr                : 10;/* [9:0] */
+      __IO uint32_t dir                  : 1; /* [10] */
+      __IO uint32_t addr10               : 1; /* [11] */
+      __IO uint32_t readh10              : 1; /* [12] */
+      __IO uint32_t genstart             : 1; /* [13] */
+      __IO uint32_t genstop              : 1; /* [14] */
+      __IO uint32_t nacken               : 1; /* [15] */
+      __IO uint32_t cnt                  : 8; /* [23:16] */
+      __IO uint32_t rlden                : 1; /* [24] */
+      __IO uint32_t astopen              : 1; /* [25] */
+      __IO uint32_t pecten               : 1; /* [26] */
+      __IO uint32_t reserved1            : 5; /* [31:27] */
+    } ctrl2_bit;
+  };
+
+  /**
+    * @brief i2c oaddr1 register, offset:0x08
+    */
+  union
+  {
+    __IO uint32_t oaddr1;
+    struct
+    {
+      __IO uint32_t addr1                : 10;/* [9:0] */
+      __IO uint32_t addr1mode            : 1; /* [10] */
+      __IO uint32_t reserved1            : 4; /* [14:11] */
+      __IO uint32_t addr1en              : 1; /* [15] */
+      __IO uint32_t reserved2            : 16;/* [31:16] */
+    } oaddr1_bit;
+  };
+
+  /**
+    * @brief i2c oaddr2 register, offset:0x0c
+    */
+  union
+  {
+    __IO uint32_t oaddr2;
+    struct
+    {
+      __IO uint32_t reserved1            : 1; /* [0] */
+      __IO uint32_t addr2                : 7; /* [7:1] */
+      __IO uint32_t addr2mask            : 3; /* [10:8] */
+      __IO uint32_t reserved2            : 4; /* [14:11] */
+      __IO uint32_t addr2en              : 1; /* [15] */
+      __IO uint32_t reserved3            : 16;/* [31:16] */
+    } oaddr2_bit;
+  };
+
+  /**
+    * @brief i2c clkctrl register, offset:0x10
+    */
+  union
+  {
+    __IO uint32_t clkctrl;
+    struct
+    {
+      __IO uint32_t scll                 : 8; /* [7:0] */
+      __IO uint32_t sclh                 : 8; /* [15:8] */
+      __IO uint32_t sdad                 : 4; /* [19:16] */
+      __IO uint32_t scld                 : 4; /* [23:20] */
+      __IO uint32_t divh                 : 4; /* [27:24] */
+      __IO uint32_t divl                 : 4; /* [31:28] */
+    } clkctrl_bit;
+  };
+
+  /**
+    * @brief i2c timeout register, offset:0x14
+    */
+  union
+  {
+    __IO uint32_t timeout;
+    struct
+    {
+      __IO uint32_t totime               : 12;/* [11:0] */
+      __IO uint32_t tomode               : 1; /* [12] */
+      __IO uint32_t reserved1            : 2; /* [14:13] */
+      __IO uint32_t toen                 : 1; /* [15] */
+      __IO uint32_t exttime              : 12;/* [27:16] */
+      __IO uint32_t reserved2            : 3; /* [30:28] */
+      __IO uint32_t exten                : 1; /* [31] */
+    } timeout_bit;
+  };
+
+  /**
+    * @brief i2c sts register, offset:0x18
+    */
+  union
+  {
+    __IO uint32_t sts;
+    struct
+    {
+      __IO uint32_t tdbe                 : 1; /* [0] */
+      __IO uint32_t tdis                 : 1; /* [1] */
+      __IO uint32_t rdbf                 : 1; /* [2] */
+      __IO uint32_t addrf                : 1; /* [3] */
+      __IO uint32_t ackfail              : 1; /* [4] */
+      __IO uint32_t stopf                : 1; /* [5] */
+      __IO uint32_t tdc                  : 1; /* [6] */
+      __IO uint32_t tcrld                : 1; /* [7] */
+      __IO uint32_t buserr               : 1; /* [8] */
+      __IO uint32_t arlost               : 1; /* [9] */
+      __IO uint32_t ouf                  : 1; /* [10] */
+      __IO uint32_t pecerr               : 1; /* [11] */
+      __IO uint32_t tmout                : 1; /* [12] */
+      __IO uint32_t alertf               : 1; /* [13] */
+      __IO uint32_t reserved1            : 1; /* [14] */
+      __IO uint32_t busyf                : 1; /* [15] */
+      __IO uint32_t sdir                 : 1; /* [16] */
+      __IO uint32_t addr                 : 7; /* [23:17] */
+      __IO uint32_t reserved2            : 8; /* [31:24] */
+    } sts_bit;
+  };
+
+  /**
+    * @brief i2c clr register, offset:0x1c
+    */
+  union
+  {
+    __IO uint32_t clr;
+    struct
+    {
+      __IO uint32_t reserved1            : 3; /* [2:0] */
+      __IO uint32_t addrc                : 1; /* [3] */
+      __IO uint32_t ackfailc             : 1; /* [4] */
+      __IO uint32_t stopc                : 1; /* [5] */
+      __IO uint32_t reserved2            : 2; /* [6:7] */
+      __IO uint32_t buserrc              : 1; /* [8] */
+      __IO uint32_t arlostc              : 1; /* [9] */
+      __IO uint32_t oufc                 : 1; /* [10] */
+      __IO uint32_t pecerrc              : 1; /* [11] */
+      __IO uint32_t tmoutc               : 1; /* [12] */
+      __IO uint32_t alertc               : 1; /* [13] */
+      __IO uint32_t reserved3            : 18;/* [31:14] */
+    } clr_bit;
+  };
+
+  /**
+    * @brief i2c pec register, offset:0x20
+    */
+  union
+  {
+    __IO uint32_t pec;
+    struct
+    {
+      __IO uint32_t pecval               : 8; /* [7:0] */
+      __IO uint32_t reserved1            : 24;/* [31:8] */
+    } pec_bit;
+  };
+
+  /**
+    * @brief i2c rxdt register, offset:0x20
+    */
+  union
+  {
+    __IO uint32_t rxdt;
+    struct
+    {
+      __IO uint32_t dt                   : 8; /* [7:0] */
+      __IO uint32_t reserved1            : 24;/* [31:8] */
+    } rxdt_bit;
+  };
+
+  /**
+    * @brief i2c txdt register, offset:0x20
+    */
+  union
+  {
+    __IO uint32_t txdt;
+    struct
+    {
+      __IO uint32_t dt                   : 8; /* [7:0] */
+      __IO uint32_t reserved1            : 24;/* [31:8] */
+    } txdt_bit;
+  };
+
+} i2c_type;
+
+/**
+  * @}
+  */
+
+#define I2C1                             ((i2c_type *) I2C1_BASE)
+#define I2C2                             ((i2c_type *) I2C2_BASE)
+#define I2C3                             ((i2c_type *) I2C3_BASE)
+
+/** @defgroup I2C_exported_functions
+  * @{
+  */
+
+void i2c_reset(i2c_type *i2c_x);
+void i2c_init(i2c_type *i2c_x, uint8_t dfilters, uint32_t clk);
+void i2c_own_address1_set(i2c_type *i2c_x, i2c_address_mode_type mode, uint16_t address);
+void i2c_own_address2_set(i2c_type *i2c_x, uint8_t address, i2c_addr2_mask_type mask);
+void i2c_own_address2_enable(i2c_type *i2c_x, confirm_state new_state);
+void i2c_smbus_enable(i2c_type *i2c_x, i2c_smbus_mode_type mode, confirm_state new_state);
+void i2c_enable(i2c_type *i2c_x, confirm_state new_state);
+void i2c_clock_stretch_enable(i2c_type *i2c_x, confirm_state new_state);
+void i2c_ack_enable(i2c_type *i2c_x, confirm_state new_state);
+void i2c_addr10_mode_enable(i2c_type *i2c_x, confirm_state new_state);
+void i2c_transfer_addr_set(i2c_type *i2c_x, uint16_t address);
+uint16_t i2c_transfer_addr_get(i2c_type *i2c_x);
+void i2c_transfer_dir_set(i2c_type *i2c_x, i2c_transfer_dir_type i2c_direction);
+i2c_transfer_dir_type i2c_transfer_dir_get(i2c_type *i2c_x);
+uint8_t i2c_matched_addr_get(i2c_type *i2c_x);
+void i2c_auto_stop_enable(i2c_type *i2c_x, confirm_state new_state);
+void i2c_reload_enable(i2c_type *i2c_x, confirm_state new_state);
+void i2c_cnt_set(i2c_type *i2c_x, uint8_t cnt);
+void i2c_addr10_header_enable(i2c_type *i2c_x, confirm_state new_state);
+void i2c_general_call_enable(i2c_type *i2c_x, confirm_state new_state);
+void i2c_smbus_alert_set(i2c_type *i2c_x, i2c_smbus_alert_set_type level);
+void i2c_slave_data_ctrl_enable(i2c_type *i2c_x, confirm_state new_state);
+void i2c_pec_calculate_enable(i2c_type *i2c_x, confirm_state new_state);
+void i2c_pec_transmit_enable(i2c_type *i2c_x, confirm_state new_state);
+uint8_t i2c_pec_value_get(i2c_type *i2c_x);
+void i2c_timeout_set(i2c_type *i2c_x, uint16_t timeout);
+void i2c_timeout_detcet_set(i2c_type *i2c_x, i2c_timeout_detcet_type mode);
+void i2c_timeout_enable(i2c_type *i2c_x, confirm_state new_state);
+void i2c_ext_timeout_set(i2c_type *i2c_x, uint16_t timeout);
+void i2c_ext_timeout_enable(i2c_type *i2c_x, confirm_state new_state);
+void i2c_interrupt_enable(i2c_type *i2c_x, uint32_t source, confirm_state new_state);
+flag_status i2c_interrupt_get(i2c_type *i2c_x, uint16_t source);
+void i2c_dma_enable(i2c_type *i2c_x, i2c_dma_request_type dma_req, confirm_state new_state);
+void i2c_transmit_set(i2c_type *i2c_x, uint16_t address, uint8_t cnt, i2c_reload_stop_mode_type rld_stop, i2c_start_mode_type start);
+void i2c_start_generate(i2c_type *i2c_x);
+void i2c_stop_generate(i2c_type *i2c_x);
+void i2c_data_send(i2c_type *i2c_x, uint8_t data);
+uint8_t i2c_data_receive(i2c_type *i2c_x);
+flag_status i2c_flag_get(i2c_type *i2c_x, uint32_t flag);
+flag_status i2c_interrupt_flag_get(i2c_type *i2c_x, uint32_t flag);
+void i2c_flag_clear(i2c_type *i2c_x, uint32_t flag);
+void i2c_wakeup_enable(i2c_type *i2c_x, confirm_state new_state);
+void i2c_analog_filter_enable(i2c_type *i2c_x, confirm_state new_state);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_misc.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_misc.h
@@ -1,0 +1,124 @@
+/**
+  **************************************************************************
+  * @file     at32f423_misc.h
+  * @brief    at32f423 misc header file
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+/* define to prevent recursive inclusion -------------------------------------*/
+#ifndef __AT32F423_MISC_H
+#define __AT32F423_MISC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* includes ------------------------------------------------------------------*/
+#include "at32f423.h"
+
+/** @addtogroup AT32F423_periph_driver
+  * @{
+  */
+
+/** @addtogroup MISC
+  * @{
+  */
+
+/** @defgroup MISC_vector_table_base_address
+  * @{
+  */
+
+#define NVIC_VECTTAB_RAM                 ((uint32_t)0x20000000) /*!< nvic vector table based ram address */
+#define NVIC_VECTTAB_FLASH               ((uint32_t)0x08000000) /*!< nvic vector table based flash address */
+
+/**
+  * @}
+  */
+
+/** @defgroup MISC_exported_types
+  * @{
+  */
+
+/**
+  * @brief nvic interrupt priority group
+  */
+typedef enum
+{
+  NVIC_PRIORITY_GROUP_0                  = ((uint32_t)0x7), /*!< 0 bits for preemption priority, 4 bits for subpriority */
+  NVIC_PRIORITY_GROUP_1                  = ((uint32_t)0x6), /*!< 1 bits for preemption priority, 3 bits for subpriority */
+  NVIC_PRIORITY_GROUP_2                  = ((uint32_t)0x5), /*!< 2 bits for preemption priority, 2 bits for subpriority */
+  NVIC_PRIORITY_GROUP_3                  = ((uint32_t)0x4), /*!< 3 bits for preemption priority, 1 bits for subpriority */
+  NVIC_PRIORITY_GROUP_4                  = ((uint32_t)0x3)  /*!< 4 bits for preemption priority, 0 bits for subpriority */
+} nvic_priority_group_type;
+
+/**
+  * @brief nvic low power mode
+  */
+typedef enum
+{
+  NVIC_LP_SLEEPONEXIT                    = 0x02, /*!< enable sleep-on-exit feature */
+  NVIC_LP_SLEEPDEEP                      = 0x04, /*!< enable sleep-deep output signal when entering sleep mode */
+  NVIC_LP_SEVONPEND                      = 0x10  /*!< send event on pending */
+} nvic_lowpower_mode_type;
+
+/**
+  * @brief systick clock source
+  */
+typedef enum
+{
+  SYSTICK_CLOCK_SOURCE_AHBCLK_DIV8       = ((uint32_t)0x00000000), /*!< systick clock source from core clock div8 */
+  SYSTICK_CLOCK_SOURCE_AHBCLK_NODIV      = ((uint32_t)0x00000004)  /*!< systick clock source from core clock */
+} systick_clock_source_type;
+
+/**
+  * @}
+  */
+
+/** @defgroup MISC_exported_functions
+  * @{
+  */
+
+void nvic_system_reset(void);
+void nvic_irq_enable(IRQn_Type irqn, uint32_t preempt_priority, uint32_t sub_priority);
+void nvic_irq_disable(IRQn_Type irqn);
+void nvic_priority_group_config(nvic_priority_group_type priority_group);
+void nvic_vector_table_set(uint32_t base, uint32_t offset);
+void nvic_lowpower_mode_config(nvic_lowpower_mode_type lp_mode, confirm_state new_state);
+void systick_clock_source_config(systick_clock_source_type source);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_pwc.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_pwc.h
@@ -1,0 +1,236 @@
+/**
+  **************************************************************************
+  * @file     at32f423_pwc.h
+  * @brief    at32f423 pwc header file
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __AT32F423_PWC_H
+#define __AT32F423_PWC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "at32f423.h"
+
+/** @addtogroup AT32F423_periph_driver
+  * @{
+  */
+
+/** @addtogroup PWC
+  * @{
+  */
+
+/** @defgroup PWC_flags_definition
+  * @brief pwc flag
+  * @{
+  */
+
+#define PWC_WAKEUP_FLAG                  ((uint32_t)0x00000001) /*!< wakeup flag */
+#define PWC_STANDBY_FLAG                 ((uint32_t)0x00000002) /*!< standby flag */
+#define PWC_PVM_OUTPUT_FLAG              ((uint32_t)0x00000004) /*!< pvm output flag */
+
+/**
+  * @}
+  */
+
+/**
+  * @brief pwc wakeup pin num definition
+  */
+#define PWC_WAKEUP_PIN_1                 ((uint32_t)0x00000100) /*!< standby wake-up pin1(pa0) */
+#define PWC_WAKEUP_PIN_2                 ((uint32_t)0x00000200) /*!< standby wake-up pin2(pc13) */
+#define PWC_WAKEUP_PIN_6                 ((uint32_t)0x00002000) /*!< standby wake-up pin6(pb5) */
+#define PWC_WAKEUP_PIN_7                 ((uint32_t)0x00004000) /*!< standby wake-up pin7(pb15) */
+
+/**
+  * @brief  select ldo output voltage.
+  * @param  val: set the ldo output voltage.
+  *         this parameter can be one of the following values:
+  *         - PWC_LDO_OUTPUT_1V3: system clock up to 150MHz.
+  *         - PWC_LDO_OUTPUT_1V2: system clock up to 120MHz.
+  *         - PWC_LDO_OUTPUT_1V1: system clock up to 64MHz.
+  * @note   none.
+  */
+#define pwc_ldo_output_voltage_set(val)  (PWC->ldoov_bit.ldoovsel = val)
+
+/** @defgroup PWC_exported_types
+  * @{
+  */
+
+/**
+  * @brief pwc pvm voltage type
+  */
+typedef enum
+{
+  PWC_PVM_VOLTAGE_2V3                    = 0x01, /*!< power voltage monitoring boundary 2.3v */
+  PWC_PVM_VOLTAGE_2V4                    = 0x02, /*!< power voltage monitoring boundary 2.4v */
+  PWC_PVM_VOLTAGE_2V5                    = 0x03, /*!< power voltage monitoring boundary 2.5v */
+  PWC_PVM_VOLTAGE_2V6                    = 0x04, /*!< power voltage monitoring boundary 2.6v */
+  PWC_PVM_VOLTAGE_2V7                    = 0x05, /*!< power voltage monitoring boundary 2.7v */
+  PWC_PVM_VOLTAGE_2V8                    = 0x06, /*!< power voltage monitoring boundary 2.8v */
+  PWC_PVM_VOLTAGE_2V9                    = 0x07  /*!< power voltage monitoring boundary 2.9v */
+} pwc_pvm_voltage_type;
+
+/**
+  * @brief pwc ldo output voltage type
+  */
+typedef enum
+{
+  PWC_LDO_OUTPUT_1V1                     = 0x01, /*!< ldo output voltage is 1.1v */
+  PWC_LDO_OUTPUT_1V2                     = 0x02, /*!< ldo output voltage is 1.2v */
+  PWC_LDO_OUTPUT_1V3                     = 0x03  /*!< ldo output voltage is 1.3v */
+} pwc_ldo_output_voltage_type;
+
+/**
+  * @brief pwc sleep enter type
+  */
+typedef enum
+{
+  PWC_SLEEP_ENTER_WFI                    = 0x00, /*!< use wfi enter sleep mode */
+  PWC_SLEEP_ENTER_WFE                    = 0x01  /*!< use wfe enter sleep mode */
+} pwc_sleep_enter_type ;
+
+/**
+  * @brief pwc deep sleep enter type
+  */
+typedef enum
+{
+  PWC_DEEP_SLEEP_ENTER_WFI               = 0x00, /*!< use wfi enter deepsleep mode */
+  PWC_DEEP_SLEEP_ENTER_WFE               = 0x01  /*!< use wfe enter deepsleep mode */
+} pwc_deep_sleep_enter_type ;
+
+/**
+  * @brief pwc regulator type
+  */
+typedef enum
+{
+  PWC_REGULATOR_ON                       = 0x00, /*!< voltage regulator state on when deepsleep mode */
+  PWC_REGULATOR_LOW_POWER                = 0x01, /*!< voltage regulator state low power when deepsleep mode */
+  PWC_REGULATOR_EXTRA_LOW_POWER          = 0x02  /*!< voltage regulator state extra low power when deepsleep mode */
+} pwc_regulator_type ;
+
+/**
+  * @brief type define pwc register all
+  */
+typedef struct
+{
+  /**
+    * @brief pwc ctrl register, offset:0x00
+    */
+  union
+  {
+    __IO uint32_t ctrl;
+    struct
+    {
+      __IO uint32_t vrsel                : 1; /* [0] */
+      __IO uint32_t lpsel                : 1; /* [1] */
+      __IO uint32_t clswef               : 1; /* [2] */
+      __IO uint32_t clsef                : 1; /* [3] */
+      __IO uint32_t pvmen                : 1; /* [4] */
+      __IO uint32_t pvmsel               : 3; /* [7:5] */
+      __IO uint32_t bpwen                : 1; /* [8] */
+      __IO uint32_t reserved1            : 23;/* [31:9] */
+    } ctrl_bit;
+  };
+
+  /**
+    * @brief pwc ctrlsts register, offset:0x04
+    */
+  union
+  {
+    __IO uint32_t ctrlsts;
+    struct
+    {
+      __IO uint32_t swef                 : 1; /* [0] */
+      __IO uint32_t sef                  : 1; /* [1] */
+      __IO uint32_t pvmof                : 1; /* [2] */
+      __IO uint32_t reserved1            : 5; /* [7:3] */
+      __IO uint32_t swpen1               : 1; /* [8] */
+      __IO uint32_t swpen2               : 1; /* [9] */
+      __IO uint32_t reserved2            : 3;/* [12:10] */
+      __IO uint32_t swpen6               : 1; /* [13] */
+      __IO uint32_t swpen7               : 1; /* [14] */
+      __IO uint32_t reserved3            : 17;/* [31:15] */
+    } ctrlsts_bit;
+  };
+
+  __IO uint32_t reserved1[2];
+
+  /**
+    * @brief pwc ldoov register, offset:0x10
+    */
+  union
+  {
+    __IO uint32_t ldoov;
+    struct
+    {
+      __IO uint32_t ldoovsel             : 2; /* [1:0] */
+      __IO uint32_t reserved1            : 2; /* [3:2] */
+      __IO uint32_t vrexlpen             : 1; /* [4] */
+      __IO uint32_t reserved2            : 27;/* [31:5] */
+    } ldoov_bit;
+  };
+
+} pwc_type;
+
+/**
+  * @}
+  */
+
+#define PWC                              ((pwc_type *) PWC_BASE)
+
+/** @defgroup PWC_exported_functions
+  * @{
+  */
+
+void pwc_reset(void);
+void pwc_battery_powered_domain_access(confirm_state new_state);
+void pwc_pvm_level_select(pwc_pvm_voltage_type pvm_voltage);
+void pwc_power_voltage_monitor_enable(confirm_state new_state);
+void pwc_wakeup_pin_enable(uint32_t pin_num, confirm_state new_state);
+void pwc_flag_clear(uint32_t pwc_flag);
+flag_status pwc_flag_get(uint32_t pwc_flag);
+void pwc_sleep_mode_enter(pwc_sleep_enter_type pwc_sleep_enter);
+void pwc_deep_sleep_mode_enter(pwc_deep_sleep_enter_type pwc_deep_sleep_enter);
+void pwc_voltage_regulate_set(pwc_regulator_type pwc_regulator);
+void pwc_standby_mode_enter(void);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_scfg.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_scfg.h
@@ -1,0 +1,302 @@
+/**
+  **************************************************************************
+  * @file     at32f423_scfg.h
+  * @brief    at32f423 system config header file
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+/* define to prevent recursive inclusion -------------------------------------*/
+#ifndef __AT32F423_SCFG_H
+#define __AT32F423_SCFG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "at32f423.h"
+
+/** @addtogroup AT32F423_periph_driver
+  * @{
+  */
+
+/** @addtogroup SCFG
+  * @{
+  */
+
+#define SCFG_REG(value)                  PERIPH_REG(SCFG_BASE, value)
+#define SCFG_REG_BIT(value)              PERIPH_REG_BIT(value)
+
+/** @defgroup SCFG_exported_types
+  * @{
+  */
+
+/**
+  * @brief scfg infrared modulation signal source selecting type
+  */
+typedef enum
+{
+  SCFG_IR_SOURCE_TMR10                   = 0x00  /* infrared signal source select tmr10 */
+} scfg_ir_source_type;
+
+/**
+  * @brief scfg infrared output polarity selecting type
+  */
+typedef enum
+{
+  SCFG_IR_POLARITY_NO_AFFECTE            = 0x00, /* infrared output polarity no affecte */
+  SCFG_IR_POLARITY_REVERSE               = 0x01  /* infrared output polarity reverse */
+} scfg_ir_polarity_type;
+
+/**
+  * @brief scfg memory address mapping selecting type
+  */
+typedef enum
+{
+  SCFG_MEM_MAP_MAIN_MEMORY               = 0x00, /* 0x00000000 address mapping from main memory */
+  SCFG_MEM_MAP_BOOT_MEMORY               = 0x01, /* 0x00000000 address mapping from boot memory */
+  SCFG_MEM_MAP_INTERNAL_SRAM             = 0x03, /* 0x00000000 address mapping from internal sram */
+} scfg_mem_map_type;
+
+/**
+  * @brief scfg pin source type
+  */
+typedef enum
+{
+  SCFG_PINS_SOURCE0                      = 0x00,
+  SCFG_PINS_SOURCE1                      = 0x01,
+  SCFG_PINS_SOURCE2                      = 0x02,
+  SCFG_PINS_SOURCE3                      = 0x03,
+  SCFG_PINS_SOURCE4                      = 0x04,
+  SCFG_PINS_SOURCE5                      = 0x05,
+  SCFG_PINS_SOURCE6                      = 0x06,
+  SCFG_PINS_SOURCE7                      = 0x07,
+  SCFG_PINS_SOURCE8                      = 0x08,
+  SCFG_PINS_SOURCE9                      = 0x09,
+  SCFG_PINS_SOURCE10                     = 0x0A,
+  SCFG_PINS_SOURCE11                     = 0x0B,
+  SCFG_PINS_SOURCE12                     = 0x0C,
+  SCFG_PINS_SOURCE13                     = 0x0D,
+  SCFG_PINS_SOURCE14                     = 0x0E,
+  SCFG_PINS_SOURCE15                     = 0x0F
+} scfg_pins_source_type;
+
+/**
+  * @brief gpio port source type
+  */
+typedef enum
+{
+  SCFG_PORT_SOURCE_GPIOA                 = 0x00,
+  SCFG_PORT_SOURCE_GPIOB                 = 0x01,
+  SCFG_PORT_SOURCE_GPIOC                 = 0x02,
+  SCFG_PORT_SOURCE_GPIOD                 = 0x03,
+  SCFG_PORT_SOURCE_GPIOE                 = 0x04,
+  SCFG_PORT_SOURCE_GPIOF                 = 0x05,
+  SCFG_PORT_SOURCE_GPIOG                 = 0x06,
+  SCFG_PORT_SOURCE_GPIOH                 = 0x07
+} scfg_port_source_type;
+
+/**
+  * @brief scfg i2s full duplex type
+  */
+typedef enum
+{
+  SCFG_FULL_DUPLEX_I2S_NONE              = 0x00, /* no i2s full duplex */
+  SCFG_FULL_DUPLEX_I2S1_I2S3             = 0x01, /* i2s full duplex with i2s1 and i2s3 */
+  SCFG_FULL_DUPLEX_I2S2_I2S3             = 0x02, /* i2s full duplex with i2s2 and i2s3 */
+  SCFG_FULL_DUPLEX_I2S1_I2S2             = 0x03, /* i2s full duplex with i2s1 and i2s2 */
+} scfg_i2s_type;
+
+/**
+  * @brief scfg ultra high sourcing/sinking strength pins type
+  */
+typedef enum
+{
+  SCFG_ULTRA_DRIVEN_PB9                  = MAKE_VALUE(0x2C, 1),
+  SCFG_ULTRA_DRIVEN_PB8                  = MAKE_VALUE(0x2C, 3),
+  SCFG_ULTRA_DRIVEN_PD12                 = MAKE_VALUE(0x2C, 5),
+  SCFG_ULTRA_DRIVEN_PD13                 = MAKE_VALUE(0x2C, 6)
+} scfg_ultra_driven_pins_type;
+
+/**
+  * @brief type define system config register all
+  */
+typedef struct
+{
+  /**
+    * @brief scfg cfg1 register, offset:0x00
+    */
+  union
+  {
+    __IO uint32_t cfg1;
+    struct
+    {
+      __IO uint32_t mem_map_sel          : 2; /* [1:0] */
+      __IO uint32_t reserved1            : 3; /* [4:2] */
+      __IO uint32_t ir_pol               : 1; /* [5] */
+      __IO uint32_t ir_src_sel           : 2; /* [7:6] */
+      __IO uint32_t reserved2            : 24;/* [31:8] */
+    } cfg1_bit;
+  };
+
+  /**
+    * @brief scfg cfg2 register, offset:0x04
+    */
+  union
+  {
+    __IO uint32_t cfg2;
+    struct
+    {
+      __IO uint32_t lockup_lk            : 1; /* [0] */
+      __IO uint32_t reserved1            : 1; /* [1] */
+      __IO uint32_t pvm_lk               : 1; /* [2] */
+      __IO uint32_t reserved2            : 27;/* [29:3] */
+      __IO uint32_t i2s_fd               : 2; /* [31:30] */
+    } cfg2_bit;
+  };
+
+  /**
+    * @brief scfg exintc1 register, offset:0x08
+    */
+  union
+  {
+    __IO uint32_t exintc1;
+    struct
+    {
+      __IO uint32_t exint0               : 4; /* [3:0] */
+      __IO uint32_t exint1               : 4; /* [7:4] */
+      __IO uint32_t exint2               : 4; /* [11:8] */
+      __IO uint32_t exint3               : 4; /* [15:12] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } exintc1_bit;
+  };
+
+  /**
+    * @brief scfg exintc2 register, offset:0x0C
+    */
+  union
+  {
+    __IO uint32_t exintc2;
+    struct
+    {
+      __IO uint32_t exint4               : 4; /* [3:0] */
+      __IO uint32_t exint5               : 4; /* [7:4] */
+      __IO uint32_t exint6               : 4; /* [11:8] */
+      __IO uint32_t exint7               : 4; /* [15:12] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } exintc2_bit;
+  };
+
+  /**
+    * @brief scfg exintc3 register, offset:0x10
+    */
+  union
+  {
+    __IO uint32_t exintc3;
+    struct
+    {
+      __IO uint32_t exint8               : 4; /* [3:0] */
+      __IO uint32_t exint9               : 4; /* [7:4] */
+      __IO uint32_t exint10              : 4; /* [11:8] */
+      __IO uint32_t exint11              : 4; /* [15:12] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } exintc3_bit;
+  };
+
+  /**
+    * @brief scfg exintc4 register, offset:0x14
+    */
+  union
+  {
+    __IO uint32_t exintc4;
+    struct
+    {
+      __IO uint32_t exint12              : 4; /* [3:0] */
+      __IO uint32_t exint13              : 4; /* [7:4] */
+      __IO uint32_t exint14              : 4; /* [11:8] */
+      __IO uint32_t exint15              : 4; /* [15:12] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } exintc4_bit;
+  };
+
+  /**
+    * @brief crm reserved1 register, offset:0x18~0x28
+    */
+  __IO uint32_t reserved1[5];
+
+  /**
+    * @brief scfg uhdrv register, offset:0x2C
+    */
+  union
+  {
+    __IO uint32_t uhdrv;
+    struct
+    {
+      __IO uint32_t reserved1            : 1; /* [0] */
+      __IO uint32_t pb9_uh               : 1; /* [1] */
+      __IO uint32_t reserved2            : 1; /* [2] */
+      __IO uint32_t pb8_uh               : 1; /* [3] */
+      __IO uint32_t reserved3            : 1; /* [4] */
+      __IO uint32_t pd12_uh              : 1; /* [5] */
+      __IO uint32_t pd13_uh              : 1; /* [6] */
+      __IO uint32_t reserved4            : 25;/* [31:7] */
+    } uhdrv_bit;
+  };
+
+} scfg_type;
+
+/**
+  * @}
+  */
+
+#define SCFG                             ((scfg_type *) SCFG_BASE)
+
+/** @defgroup SCFG_exported_functions
+  * @{
+  */
+
+void scfg_reset(void);
+void scfg_infrared_config(scfg_ir_source_type source, scfg_ir_polarity_type polarity);
+scfg_mem_map_type scfg_mem_map_get(void);
+void scfg_i2s_full_duplex_config(scfg_i2s_type i2s_full_duplex);
+void scfg_pvm_lock_enable(confirm_state new_state);
+void scfg_lockup_enable(confirm_state new_state);
+void scfg_exint_line_config(scfg_port_source_type port_source, scfg_pins_source_type pin_source);
+void scfg_pins_ultra_driven_enable(scfg_ultra_driven_pins_type value, confirm_state new_state);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_spi.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_spi.h
@@ -1,0 +1,502 @@
+/**
+  **************************************************************************
+  * @file     at32f423_spi.h
+  * @brief    at32f423 spi header file
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __AT32F423_SPI_H
+#define __AT32F423_SPI_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "at32f423.h"
+
+/** @addtogroup AT32F423_periph_driver
+  * @{
+  */
+
+/** @addtogroup SPI
+  * @{
+  */
+
+/**
+  * @defgroup SPI_I2S_flags_definition
+  * @brief spi i2s flag
+  * @{
+  */
+
+#define SPI_I2S_RDBF_FLAG                0x0001 /*!< spi or i2s receive data buffer full flag */
+#define SPI_I2S_TDBE_FLAG                0x0002 /*!< spi or i2s transmit data buffer empty flag */
+#define I2S_ACS_FLAG                     0x0004 /*!< i2s audio channel state flag */
+#define I2S_TUERR_FLAG                   0x0008 /*!< i2s transmitter underload error flag */
+#define SPI_CCERR_FLAG                   0x0010 /*!< spi crc calculation error flag */
+#define SPI_MMERR_FLAG                   0x0020 /*!< spi master mode error flag */
+#define SPI_I2S_ROERR_FLAG               0x0040 /*!< spi or i2s receiver overflow error flag */
+#define SPI_I2S_BF_FLAG                  0x0080 /*!< spi or i2s busy flag */
+#define SPI_CSPAS_FLAG                   0x0100 /*!< spi cs pulse abnormal setting fiag */
+
+/**
+  * @}
+  */
+
+/**
+  * @defgroup SPI_I2S_interrupts_definition
+  * @brief spi i2s interrupt
+  * @{
+  */
+
+#define SPI_I2S_ERROR_INT                0x0020 /*!< error interrupt */
+#define SPI_I2S_RDBF_INT                 0x0040 /*!< receive data buffer full interrupt */
+#define SPI_I2S_TDBE_INT                 0x0080 /*!< transmit data buffer empty interrupt */
+
+/**
+  * @}
+  */
+
+/** @defgroup SPI_exported_types
+  * @{
+  */
+
+/**
+  * @brief spi frame bit num type
+  */
+typedef enum
+{
+  SPI_FRAME_8BIT                         = 0x00, /*!< 8-bit data frame format */
+  SPI_FRAME_16BIT                        = 0x01  /*!< 16-bit data frame format */
+} spi_frame_bit_num_type;
+
+/**
+  * @brief spi master/slave mode type
+  */
+typedef enum
+{
+  SPI_MODE_SLAVE                         = 0x00, /*!< select as slave mode */
+  SPI_MODE_MASTER                        = 0x01  /*!< select as master mode */
+} spi_master_slave_mode_type;
+
+/**
+  * @brief spi clock polarity (clkpol) type
+  */
+typedef enum
+{
+  SPI_CLOCK_POLARITY_LOW                 = 0x00, /*!< sck keeps low at idle state */
+  SPI_CLOCK_POLARITY_HIGH                = 0x01  /*!< sck keeps high at idle state */
+} spi_clock_polarity_type;
+
+/**
+  * @brief spi clock phase (clkpha) type
+  */
+typedef enum
+{
+  SPI_CLOCK_PHASE_1EDGE                  = 0x00, /*!< data capture start from the first clock edge */
+  SPI_CLOCK_PHASE_2EDGE                  = 0x01  /*!< data capture start from the second clock edge */
+} spi_clock_phase_type;
+
+/**
+  * @brief spi cs mode type
+  */
+typedef enum
+{
+  SPI_CS_HARDWARE_MODE                   = 0x00, /*!< cs is hardware mode */
+  SPI_CS_SOFTWARE_MODE                   = 0x01  /*!< cs is software mode */
+} spi_cs_mode_type;
+
+/**
+  * @brief spi master clock frequency division type
+  */
+typedef enum
+{
+  SPI_MCLK_DIV_2                         = 0x00, /*!< master clock frequency division 2 */
+  SPI_MCLK_DIV_3                         = 0x0A, /*!< master clock frequency division 3 */
+  SPI_MCLK_DIV_4                         = 0x01, /*!< master clock frequency division 4 */
+  SPI_MCLK_DIV_8                         = 0x02, /*!< master clock frequency division 8 */
+  SPI_MCLK_DIV_16                        = 0x03, /*!< master clock frequency division 16 */
+  SPI_MCLK_DIV_32                        = 0x04, /*!< master clock frequency division 32 */
+  SPI_MCLK_DIV_64                        = 0x05, /*!< master clock frequency division 64 */
+  SPI_MCLK_DIV_128                       = 0x06, /*!< master clock frequency division 128 */
+  SPI_MCLK_DIV_256                       = 0x07, /*!< master clock frequency division 256 */
+  SPI_MCLK_DIV_512                       = 0x08, /*!< master clock frequency division 512 */
+  SPI_MCLK_DIV_1024                      = 0x09  /*!< master clock frequency division 1024 */
+} spi_mclk_freq_div_type;
+
+/**
+  * @brief spi transmit first bit (lsb/msb) type
+  */
+typedef enum
+{
+  SPI_FIRST_BIT_MSB                      = 0x00, /*!< the frame format is msb first */
+  SPI_FIRST_BIT_LSB                      = 0x01  /*!< the frame format is lsb first */
+} spi_first_bit_type;
+
+/**
+  * @brief spi transmission mode type
+  */
+typedef enum
+{
+  SPI_TRANSMIT_FULL_DUPLEX               = 0x00, /*!< dual line unidirectional full-duplex mode(slben = 0 and ora = 0) */
+  SPI_TRANSMIT_SIMPLEX_RX                = 0x01, /*!< dual line unidirectional simplex receive-only mode(slben = 0 and ora = 1) */
+  SPI_TRANSMIT_HALF_DUPLEX_RX            = 0x02, /*!< single line bidirectional half duplex mode-receiving(slben = 1 and slbtd = 0) */
+  SPI_TRANSMIT_HALF_DUPLEX_TX            = 0x03  /*!< single line bidirectional half duplex mode-transmitting(slben = 1 and slbtd = 1) */
+} spi_transmission_mode_type;
+
+/**
+  * @brief spi crc direction type
+  */
+typedef enum
+{
+  SPI_CRC_RX                             = 0x0014, /*!< crc direction is rx */
+  SPI_CRC_TX                             = 0x0018  /*!< crc direction is tx */
+} spi_crc_direction_type;
+
+/**
+  * @brief spi single line bidirectional direction type
+  */
+typedef enum
+{
+  SPI_HALF_DUPLEX_DIRECTION_RX           = 0x00, /*!< single line bidirectional half duplex mode direction: receive(slbtd = 0) */
+  SPI_HALF_DUPLEX_DIRECTION_TX           = 0x01  /*!< single line bidirectional half duplex mode direction: transmit(slbtd = 1) */
+} spi_half_duplex_direction_type;
+
+/**
+  * @brief spi software cs internal level type
+  */
+typedef enum
+{
+  SPI_SWCS_INTERNAL_LEVEL_LOW            = 0x00, /*!< internal level low */
+  SPI_SWCS_INTERNAL_LEVEL_HIGHT          = 0x01  /*!< internal level high */
+} spi_software_cs_level_type;
+
+/**
+  * @brief i2s audio protocol type
+  */
+typedef enum
+{
+  I2S_AUDIO_PROTOCOL_PHILLIPS            = 0x00, /*!< i2s philip standard */
+  I2S_AUDIO_PROTOCOL_MSB                 = 0x01, /*!< msb-justified standard */
+  I2S_AUDIO_PROTOCOL_LSB                 = 0x02, /*!< lsb-justified standard */
+  I2S_AUDIO_PROTOCOL_PCM_SHORT           = 0x03, /*!< pcm standard-short frame */
+  I2S_AUDIO_PROTOCOL_PCM_LONG            = 0x04  /*!< pcm standard-long frame */
+} i2s_audio_protocol_type;
+
+/**
+  * @brief i2s audio frequency type
+  */
+typedef enum
+{
+  I2S_AUDIO_FREQUENCY_DEFAULT            = 2,     /*!< i2s audio sampling frequency default */
+  I2S_AUDIO_FREQUENCY_8K                 = 8000,  /*!< i2s audio sampling frequency 8k */
+  I2S_AUDIO_FREQUENCY_11_025K            = 11025, /*!< i2s audio sampling frequency 11.025k */
+  I2S_AUDIO_FREQUENCY_16K                = 16000, /*!< i2s audio sampling frequency 16k */
+  I2S_AUDIO_FREQUENCY_22_05K             = 22050, /*!< i2s audio sampling frequency 22.05k */
+  I2S_AUDIO_FREQUENCY_32K                = 32000, /*!< i2s audio sampling frequency 32k */
+  I2S_AUDIO_FREQUENCY_44_1K              = 44100, /*!< i2s audio sampling frequency 44.1k */
+  I2S_AUDIO_FREQUENCY_48K                = 48000, /*!< i2s audio sampling frequency 48k */
+  I2S_AUDIO_FREQUENCY_96K                = 96000, /*!< i2s audio sampling frequency 96k */
+  I2S_AUDIO_FREQUENCY_192K               = 192000 /*!< i2s audio sampling frequency 192k */
+} i2s_audio_sampling_freq_type;
+
+/**
+  * @brief i2s data bit num and channel bit num type
+  */
+typedef enum
+{
+  I2S_DATA_16BIT_CHANNEL_16BIT           = 0x01, /*!< 16-bit data packed in 16-bit channel frame */
+  I2S_DATA_16BIT_CHANNEL_32BIT           = 0x02, /*!< 16-bit data packed in 32-bit channel frame */
+  I2S_DATA_24BIT_CHANNEL_32BIT           = 0x03, /*!< 24-bit data packed in 32-bit channel frame */
+  I2S_DATA_32BIT_CHANNEL_32BIT           = 0x04  /*!< 32-bit data packed in 32-bit channel frame */
+} i2s_data_channel_format_type;
+
+/**
+  * @brief i2s operation mode type
+  */
+typedef enum
+{
+  I2S_MODE_SLAVE_TX                      = 0x00, /*!< slave transmission mode */
+  I2S_MODE_SLAVE_RX                      = 0x01, /*!< slave reception mode */
+  I2S_MODE_MASTER_TX                     = 0x02, /*!< master transmission mode */
+  I2S_MODE_MASTER_RX                     = 0x03  /*!< master reception mode */
+} i2s_operation_mode_type;
+
+/**
+  * @brief i2s clock polarity type
+  */
+typedef enum
+{
+  I2S_CLOCK_POLARITY_LOW                 = 0x00, /*!< i2s clock steady state is low level */
+  I2S_CLOCK_POLARITY_HIGH                = 0x01  /*!< i2s clock steady state is high level */
+} i2s_clock_polarity_type;
+
+/**
+  * @brief spi init type
+  */
+typedef struct
+{
+  spi_transmission_mode_type             transmission_mode;     /*!< transmission mode selection */
+  spi_master_slave_mode_type             master_slave_mode;     /*!< master or slave mode selection */
+  spi_mclk_freq_div_type                 mclk_freq_division;    /*!< master clock frequency division selection */
+  spi_first_bit_type                     first_bit_transmission;/*!< transmit lsb or msb selection */
+  spi_frame_bit_num_type                 frame_bit_num;         /*!< frame bit num 8 or 16 bit selection */
+  spi_clock_polarity_type                clock_polarity;        /*!< clock polarity selection */
+  spi_clock_phase_type                   clock_phase;           /*!< clock phase selection */
+  spi_cs_mode_type                       cs_mode_selection;     /*!< hardware or software cs mode selection */
+} spi_init_type;
+
+/**
+  * @brief i2s init type
+  */
+typedef struct
+{
+  i2s_operation_mode_type                operation_mode;        /*!< operation mode selection */
+  i2s_audio_protocol_type                audio_protocol;        /*!< audio protocol selection */
+  i2s_audio_sampling_freq_type           audio_sampling_freq;   /*!< audio frequency selection */
+  i2s_data_channel_format_type           data_channel_format;   /*!< data bit num and channel bit num selection */
+  i2s_clock_polarity_type                clock_polarity;        /*!< clock polarity selection */
+  confirm_state                          mclk_output_enable;    /*!< mclk_output selection */
+} i2s_init_type;
+
+/**
+  * @brief type define spi register all
+  */
+typedef struct
+{
+
+  /**
+    * @brief spi ctrl1 register, offset:0x00
+    */
+  union
+  {
+    __IO uint32_t ctrl1;
+    struct
+    {
+      __IO uint32_t clkpha               : 1; /* [0] */
+      __IO uint32_t clkpol               : 1; /* [1] */
+      __IO uint32_t msten                : 1; /* [2] */
+      __IO uint32_t mdiv_l               : 3; /* [5:3] */
+      __IO uint32_t spien                : 1; /* [6] */
+      __IO uint32_t ltf                  : 1; /* [7] */
+      __IO uint32_t swcsil               : 1; /* [8] */
+      __IO uint32_t swcsen               : 1; /* [9] */
+      __IO uint32_t ora                  : 1; /* [10] */
+      __IO uint32_t fbn                  : 1; /* [11] */
+      __IO uint32_t ntc                  : 1; /* [12] */
+      __IO uint32_t ccen                 : 1; /* [13] */
+      __IO uint32_t slbtd                : 1; /* [14] */
+      __IO uint32_t slben                : 1; /* [15] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } ctrl1_bit;
+  };
+
+  /**
+    * @brief spi ctrl2 register, offset:0x04
+    */
+  union
+  {
+    __IO uint32_t ctrl2;
+    struct
+    {
+      __IO uint32_t dmaren               : 1; /* [0] */
+      __IO uint32_t dmaten               : 1; /* [1] */
+      __IO uint32_t hwcsoe               : 1; /* [2] */
+      __IO uint32_t reserved1            : 1; /* [3] */
+      __IO uint32_t tien                 : 1; /* [4] */
+      __IO uint32_t errie                : 1; /* [5] */
+      __IO uint32_t rdbfie               : 1; /* [6] */
+      __IO uint32_t tdbeie               : 1; /* [7] */
+      __IO uint32_t mdiv_h               : 1; /* [8] */
+      __IO uint32_t mdiv3en              : 1; /* [9] */
+      __IO uint32_t reserved2            : 22;/* [31:10] */
+    } ctrl2_bit;
+  };
+
+  /**
+    * @brief spi sts register, offset:0x08
+    */
+  union
+  {
+    __IO uint32_t sts;
+    struct
+    {
+      __IO uint32_t rdbf                 : 1; /* [0] */
+      __IO uint32_t tdbe                 : 1; /* [1] */
+      __IO uint32_t acs                  : 1; /* [2] */
+      __IO uint32_t tuerr                : 1; /* [3] */
+      __IO uint32_t ccerr                : 1; /* [4] */
+      __IO uint32_t mmerr                : 1; /* [5] */
+      __IO uint32_t roerr                : 1; /* [6] */
+      __IO uint32_t bf                   : 1; /* [7] */
+      __IO uint32_t cspas                : 1; /* [8] */
+      __IO uint32_t reserved1            : 23;/* [31:9] */
+    } sts_bit;
+  };
+
+  /**
+    * @brief spi dt register, offset:0x0C
+    */
+  union
+  {
+    __IO uint32_t dt;
+    struct
+    {
+      __IO uint32_t dt                  : 16;/* [15:0] */
+      __IO uint32_t reserved1           : 16;/* [31:16] */
+    } dt_bit;
+  };
+
+  /**
+    * @brief spi cpoly register, offset:0x10
+    */
+  union
+  {
+    __IO uint32_t cpoly;
+    struct
+    {
+      __IO uint32_t cpoly               : 16;/* [15:0] */
+      __IO uint32_t reserved1           : 16;/* [31:16] */
+    } cpoly_bit;
+  };
+
+  /**
+    * @brief spi rcrc register, offset:0x14
+    */
+  union
+  {
+    __IO uint32_t rcrc;
+    struct
+    {
+      __IO uint32_t rcrc                : 16;/* [15:0] */
+      __IO uint32_t reserved1           : 16;/* [31:16] */
+    } rcrc_bit;
+  };
+
+  /**
+    * @brief spi tcrc register, offset:0x18
+    */
+  union
+  {
+    __IO uint32_t tcrc;
+    struct
+    {
+      __IO uint32_t tcrc                : 16;/* [15:0] */
+      __IO uint32_t reserved1           : 16;/* [31:16] */
+    } tcrc_bit;
+  };
+
+  /**
+    * @brief spi i2sctrl register, offset:0x1C
+    */
+  union
+  {
+    __IO uint32_t i2sctrl;
+    struct
+    {
+      __IO uint32_t i2scbn              : 1; /* [0] */
+      __IO uint32_t i2sdbn              : 2; /* [2:1] */
+      __IO uint32_t i2sclkpol           : 1; /* [3] */
+      __IO uint32_t stdsel              : 2; /* [5:4] */
+      __IO uint32_t reserved1           : 1; /* [6] */
+      __IO uint32_t pcmfssel            : 1; /* [7] */
+      __IO uint32_t opersel             : 2; /* [9:8] */
+      __IO uint32_t i2sen               : 1; /* [10] */
+      __IO uint32_t i2smsel             : 1; /* [11] */
+      __IO uint32_t reserved2           : 20;/* [31:12] */
+    } i2sctrl_bit;
+  };
+
+  /**
+    * @brief spi i2sclk register, offset:0x20
+    */
+  union
+  {
+    __IO uint32_t i2sclk;
+    struct
+    {
+      __IO uint32_t i2sdiv_l            : 8; /* [7:0] */
+      __IO uint32_t i2sodd              : 1; /* [8] */
+      __IO uint32_t i2smclkoe           : 1; /* [9] */
+      __IO uint32_t i2sdiv_h            : 2; /* [11:10] */
+      __IO uint32_t reserved1           : 20;/* [31:12] */
+    } i2sclk_bit;
+  };
+
+} spi_type;
+
+/**
+  * @}
+  */
+
+#define SPI1                            ((spi_type *) SPI1_BASE)
+#define SPI2                            ((spi_type *) SPI2_BASE)
+#define SPI3                            ((spi_type *) SPI3_BASE)
+
+/** @defgroup SPI_exported_functions
+  * @{
+  */
+
+void spi_i2s_reset(spi_type *spi_x);
+void spi_default_para_init(spi_init_type* spi_init_struct);
+void spi_init(spi_type* spi_x, spi_init_type* spi_init_struct);
+void spi_ti_mode_enable(spi_type* spi_x, confirm_state new_state);
+void spi_crc_next_transmit(spi_type* spi_x);
+void spi_crc_polynomial_set(spi_type* spi_x, uint16_t crc_poly);
+uint16_t spi_crc_polynomial_get(spi_type* spi_x);
+void spi_crc_enable(spi_type* spi_x, confirm_state new_state);
+uint16_t spi_crc_value_get(spi_type* spi_x, spi_crc_direction_type crc_direction);
+void spi_hardware_cs_output_enable(spi_type* spi_x, confirm_state new_state);
+void spi_software_cs_internal_level_set(spi_type* spi_x, spi_software_cs_level_type level);
+void spi_frame_bit_num_set(spi_type* spi_x, spi_frame_bit_num_type bit_num);
+void spi_half_duplex_direction_set(spi_type* spi_x, spi_half_duplex_direction_type direction);
+void spi_enable(spi_type* spi_x, confirm_state new_state);
+void i2s_default_para_init(i2s_init_type* i2s_init_struct);
+void i2s_init(spi_type* spi_x, i2s_init_type* i2s_init_struct);
+void i2s_enable(spi_type* spi_x, confirm_state new_state);
+void spi_i2s_interrupt_enable(spi_type* spi_x, uint32_t spi_i2s_int, confirm_state new_state);
+void spi_i2s_dma_transmitter_enable(spi_type* spi_x, confirm_state new_state);
+void spi_i2s_dma_receiver_enable(spi_type* spi_x, confirm_state new_state);
+void spi_i2s_data_transmit(spi_type* spi_x, uint16_t tx_data);
+uint16_t spi_i2s_data_receive(spi_type* spi_x);
+flag_status spi_i2s_flag_get(spi_type* spi_x, uint32_t spi_i2s_flag);
+flag_status spi_i2s_interrupt_flag_get(spi_type* spi_x, uint32_t spi_i2s_flag);
+void spi_i2s_flag_clear(spi_type* spi_x, uint32_t spi_i2s_flag);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_spi.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_spi.h
@@ -457,31 +457,31 @@ typedef struct
   * @{
   */
 
-void spi_i2s_reset(spi_type *spi_x);
-void spi_default_para_init(spi_init_type* spi_init_struct);
-void spi_init(spi_type* spi_x, spi_init_type* spi_init_struct);
-void spi_ti_mode_enable(spi_type* spi_x, confirm_state new_state);
-void spi_crc_next_transmit(spi_type* spi_x);
-void spi_crc_polynomial_set(spi_type* spi_x, uint16_t crc_poly);
-uint16_t spi_crc_polynomial_get(spi_type* spi_x);
-void spi_crc_enable(spi_type* spi_x, confirm_state new_state);
-uint16_t spi_crc_value_get(spi_type* spi_x, spi_crc_direction_type crc_direction);
-void spi_hardware_cs_output_enable(spi_type* spi_x, confirm_state new_state);
-void spi_software_cs_internal_level_set(spi_type* spi_x, spi_software_cs_level_type level);
-void spi_frame_bit_num_set(spi_type* spi_x, spi_frame_bit_num_type bit_num);
-void spi_half_duplex_direction_set(spi_type* spi_x, spi_half_duplex_direction_type direction);
-void spi_enable(spi_type* spi_x, confirm_state new_state);
-void i2s_default_para_init(i2s_init_type* i2s_init_struct);
-void i2s_init(spi_type* spi_x, i2s_init_type* i2s_init_struct);
-void i2s_enable(spi_type* spi_x, confirm_state new_state);
-void spi_i2s_interrupt_enable(spi_type* spi_x, uint32_t spi_i2s_int, confirm_state new_state);
-void spi_i2s_dma_transmitter_enable(spi_type* spi_x, confirm_state new_state);
-void spi_i2s_dma_receiver_enable(spi_type* spi_x, confirm_state new_state);
-void spi_i2s_data_transmit(spi_type* spi_x, uint16_t tx_data);
-uint16_t spi_i2s_data_receive(spi_type* spi_x);
-flag_status spi_i2s_flag_get(spi_type* spi_x, uint32_t spi_i2s_flag);
-flag_status spi_i2s_interrupt_flag_get(spi_type* spi_x, uint32_t spi_i2s_flag);
-void spi_i2s_flag_clear(spi_type* spi_x, uint32_t spi_i2s_flag);
+// void spi_i2s_reset(spi_type *spi_x);
+// void spi_default_para_init(spi_init_type* spi_init_struct);
+// void spi_init(spi_type* spi_x, spi_init_type* spi_init_struct);
+// void spi_ti_mode_enable(spi_type* spi_x, confirm_state new_state);
+// void spi_crc_next_transmit(spi_type* spi_x);
+// void spi_crc_polynomial_set(spi_type* spi_x, uint16_t crc_poly);
+// uint16_t spi_crc_polynomial_get(spi_type* spi_x);
+// void spi_crc_enable(spi_type* spi_x, confirm_state new_state);
+// uint16_t spi_crc_value_get(spi_type* spi_x, spi_crc_direction_type crc_direction);
+// void spi_hardware_cs_output_enable(spi_type* spi_x, confirm_state new_state);
+// void spi_software_cs_internal_level_set(spi_type* spi_x, spi_software_cs_level_type level);
+// void spi_frame_bit_num_set(spi_type* spi_x, spi_frame_bit_num_type bit_num);
+// void spi_half_duplex_direction_set(spi_type* spi_x, spi_half_duplex_direction_type direction);
+// void spi_enable(spi_type* spi_x, confirm_state new_state);
+// void i2s_default_para_init(i2s_init_type* i2s_init_struct);
+// void i2s_init(spi_type* spi_x, i2s_init_type* i2s_init_struct);
+// void i2s_enable(spi_type* spi_x, confirm_state new_state);
+// void spi_i2s_interrupt_enable(spi_type* spi_x, uint32_t spi_i2s_int, confirm_state new_state);
+// void spi_i2s_dma_transmitter_enable(spi_type* spi_x, confirm_state new_state);
+// void spi_i2s_dma_receiver_enable(spi_type* spi_x, confirm_state new_state);
+// void spi_i2s_data_transmit(spi_type* spi_x, uint16_t tx_data);
+// uint16_t spi_i2s_data_receive(spi_type* spi_x);
+// flag_status spi_i2s_flag_get(spi_type* spi_x, uint32_t spi_i2s_flag);
+// flag_status spi_i2s_interrupt_flag_get(spi_type* spi_x, uint32_t spi_i2s_flag);
+// void spi_i2s_flag_clear(spi_type* spi_x, uint32_t spi_i2s_flag);
 
 /**
   * @}

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_tmr.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_tmr.h
@@ -1,0 +1,967 @@
+/**
+  **************************************************************************
+  * @file     at32f423_tmr.h
+  * @brief    at32f423 tmr header file
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+/* define to prevent recursive inclusion -------------------------------------*/
+#ifndef __AT32F423_TMR_H
+#define __AT32F423_TMR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* includes ------------------------------------------------------------------*/
+#include "at32f423.h"
+
+/** @addtogroup AT32F423_periph_driver
+  * @{
+  */
+
+/** @addtogroup TMR
+  * @{
+  */
+
+/** @defgroup TMR_flags_definition
+  * @brief tmr flag
+  * @{
+  */
+
+#define TMR_OVF_FLAG                     ((uint32_t)0x000001) /*!< tmr flag overflow */
+#define TMR_C1_FLAG                      ((uint32_t)0x000002) /*!< tmr flag channel 1 */
+#define TMR_C2_FLAG                      ((uint32_t)0x000004) /*!< tmr flag channel 2 */
+#define TMR_C3_FLAG                      ((uint32_t)0x000008) /*!< tmr flag channel 3 */
+#define TMR_C4_FLAG                      ((uint32_t)0x000010) /*!< tmr flag channel 4 */
+#define TMR_C5_FLAG                      ((uint32_t)0x010000) /*!< tmr flag channel 5 */
+#define TMR_HALL_FLAG                    ((uint32_t)0x000020) /*!< tmr flag hall */
+#define TMR_TRIGGER_FLAG                 ((uint32_t)0x000040) /*!< tmr flag trigger */
+#define TMR_BRK_FLAG                     ((uint32_t)0x000080) /*!< tmr flag brake */
+#define TMR_C1_RECAPTURE_FLAG            ((uint32_t)0x000200) /*!< tmr flag channel 1 recapture */
+#define TMR_C2_RECAPTURE_FLAG            ((uint32_t)0x000400) /*!< tmr flag channel 2 recapture */
+#define TMR_C3_RECAPTURE_FLAG            ((uint32_t)0x000800) /*!< tmr flag channel 3 recapture */
+#define TMR_C4_RECAPTURE_FLAG            ((uint32_t)0x001000) /*!< tmr flag channel 4 recapture */
+
+/**
+  * @}
+  */
+
+/** @defgroup TMR_interrupt_select_type_definition
+  * @brief tmr interrupt select type
+  * @{
+  */
+
+#define TMR_OVF_INT                      ((uint32_t)0x000001) /*!< tmr interrupt overflow */
+#define TMR_C1_INT                       ((uint32_t)0x000002) /*!< tmr interrupt channel 1 */
+#define TMR_C2_INT                       ((uint32_t)0x000004) /*!< tmr interrupt channel 2 */
+#define TMR_C3_INT                       ((uint32_t)0x000008) /*!< tmr interrupt channel 3 */
+#define TMR_C4_INT                       ((uint32_t)0x000010) /*!< tmr interrupt channel 4 */
+#define TMR_HALL_INT                     ((uint32_t)0x000020) /*!< tmr interrupt hall */
+#define TMR_TRIGGER_INT                  ((uint32_t)0x000040) /*!< tmr interrupt trigger */
+#define TMR_BRK_INT                      ((uint32_t)0x000080) /*!< tmr interrupt brake */
+
+/**
+  * @}
+  */
+
+/** @defgroup TMR_exported_types
+  * @{
+  */
+
+/**
+  * @brief tmr clock division type
+  */
+typedef enum
+{
+  TMR_CLOCK_DIV1                         = 0x00, /*!< tmr clock division 1 */
+  TMR_CLOCK_DIV2                         = 0x01, /*!< tmr clock division 2 */
+  TMR_CLOCK_DIV4                         = 0x02  /*!< tmr clock division 4 */
+} tmr_clock_division_type;
+
+/**
+  * @brief tmr counter mode type
+  */
+typedef enum
+{
+  TMR_COUNT_UP                           = 0x00, /*!< tmr counter mode up */
+  TMR_COUNT_DOWN                         = 0x01, /*!< tmr counter mode down */
+  TMR_COUNT_TWO_WAY_1                    = 0x02, /*!< tmr counter mode two way 1 */
+  TMR_COUNT_TWO_WAY_2                    = 0x04, /*!< tmr counter mode two way 2 */
+  TMR_COUNT_TWO_WAY_3                    = 0x06  /*!< tmr counter mode two way 3 */
+} tmr_count_mode_type;
+
+/**
+  * @brief tmr primary mode select type
+  */
+typedef enum
+{
+  TMR_PRIMARY_SEL_RESET                  = 0x00, /*!< tmr primary mode select reset */
+  TMR_PRIMARY_SEL_ENABLE                 = 0x01, /*!< tmr primary mode select enable */
+  TMR_PRIMARY_SEL_OVERFLOW               = 0x02, /*!< tmr primary mode select overflow */
+  TMR_PRIMARY_SEL_COMPARE                = 0x03, /*!< tmr primary mode select compare */
+  TMR_PRIMARY_SEL_C1ORAW                 = 0x04, /*!< tmr primary mode select c1oraw */
+  TMR_PRIMARY_SEL_C2ORAW                 = 0x05, /*!< tmr primary mode select c2oraw */
+  TMR_PRIMARY_SEL_C3ORAW                 = 0x06, /*!< tmr primary mode select c3oraw */
+  TMR_PRIMARY_SEL_C4ORAW                 = 0x07  /*!< tmr primary mode select c4oraw */
+} tmr_primary_select_type;
+
+/**
+  * @brief tmr subordinate mode input select type
+  */
+typedef enum
+{
+  TMR_SUB_INPUT_SEL_IS0                  = 0x00, /*!< subordinate mode input select is0 */
+  TMR_SUB_INPUT_SEL_IS1                  = 0x01, /*!< subordinate mode input select is1 */
+  TMR_SUB_INPUT_SEL_IS2                  = 0x02, /*!< subordinate mode input select is2 */
+  TMR_SUB_INPUT_SEL_IS3                  = 0x03, /*!< subordinate mode input select is3 */
+  TMR_SUB_INPUT_SEL_C1INC                = 0x04, /*!< subordinate mode input select c1inc */
+  TMR_SUB_INPUT_SEL_C1DF1                = 0x05, /*!< subordinate mode input select c1df1 */
+  TMR_SUB_INPUT_SEL_C2DF2                = 0x06, /*!< subordinate mode input select c2df2 */
+  TMR_SUB_INPUT_SEL_EXTIN                = 0x07  /*!< subordinate mode input select extin */
+} sub_tmr_input_sel_type;
+
+/**
+  * @brief tmr subordinate mode select type
+  */
+typedef enum
+{
+  TMR_SUB_MODE_DIABLE                    = 0x00, /*!< subordinate mode disable */
+  TMR_SUB_ENCODER_MODE_A                 = 0x01, /*!< subordinate mode select encoder mode a */
+  TMR_SUB_ENCODER_MODE_B                 = 0x02, /*!< subordinate mode select encoder mode b */
+  TMR_SUB_ENCODER_MODE_C                 = 0x03, /*!< subordinate mode select encoder mode c */
+  TMR_SUB_RESET_MODE                     = 0x04, /*!< subordinate mode select reset */
+  TMR_SUB_HANG_MODE                      = 0x05, /*!< subordinate mode select hang */
+  TMR_SUB_TRIGGER_MODE                   = 0x06, /*!< subordinate mode select trigger */
+  TMR_SUB_EXTERNAL_CLOCK_MODE_A          = 0x07  /*!< subordinate mode external clock mode a */
+} tmr_sub_mode_select_type;
+
+/**
+  * @brief tmr encoder mode type
+  */
+typedef enum
+{
+  TMR_ENCODER_MODE_A                     = TMR_SUB_ENCODER_MODE_A, /*!< tmr encoder mode a */
+  TMR_ENCODER_MODE_B                     = TMR_SUB_ENCODER_MODE_B, /*!< tmr encoder mode b */
+  TMR_ENCODER_MODE_C                     = TMR_SUB_ENCODER_MODE_C  /*!< tmr encoder mode c */
+} tmr_encoder_mode_type;
+
+/**
+  * @brief tmr output control mode type
+  */
+typedef enum
+{
+  TMR_OUTPUT_CONTROL_OFF                 = 0x00, /*!< tmr output control mode off */
+  TMR_OUTPUT_CONTROL_HIGH                = 0x01, /*!< tmr output control mode high */
+  TMR_OUTPUT_CONTROL_LOW                 = 0x02, /*!< tmr output control mode low */
+  TMR_OUTPUT_CONTROL_SWITCH              = 0x03, /*!< tmr output control mode switch */
+  TMR_OUTPUT_CONTROL_FORCE_LOW           = 0x04, /*!< tmr output control mode force low */
+  TMR_OUTPUT_CONTROL_FORCE_HIGH          = 0x05, /*!< tmr output control mode force high */
+  TMR_OUTPUT_CONTROL_PWM_MODE_A          = 0x06, /*!< tmr output control mode pwm a */
+  TMR_OUTPUT_CONTROL_PWM_MODE_B          = 0x07  /*!< tmr output control mode pwm b */
+} tmr_output_control_mode_type;
+
+/**
+  * @brief tmr force output type
+  */
+typedef enum
+{
+  TMR_FORCE_OUTPUT_HIGH                  = TMR_OUTPUT_CONTROL_FORCE_HIGH, /*!< tmr force output high */
+  TMR_FORCE_OUTPUT_LOW                   = TMR_OUTPUT_CONTROL_FORCE_LOW   /*!< tmr force output low */
+} tmr_force_output_type;
+
+/**
+  * @brief tmr output channel polarity type
+  */
+typedef enum
+{
+  TMR_OUTPUT_ACTIVE_HIGH                 = 0x00, /*!< tmr output channel polarity high */
+  TMR_OUTPUT_ACTIVE_LOW                  = 0x01  /*!< tmr output channel polarity low */
+} tmr_output_polarity_type;
+
+/**
+  * @brief tmr input channel polarity type
+  */
+typedef enum
+{
+  TMR_INPUT_RISING_EDGE                  = 0x00, /*!< tmr input channel polarity rising */
+  TMR_INPUT_FALLING_EDGE                 = 0x01, /*!< tmr input channel polarity falling */
+  TMR_INPUT_BOTH_EDGE                    = 0x03  /*!< tmr input channel polarity both edge */
+} tmr_input_polarity_type;
+
+/**
+  * @brief tmr channel select type
+  */
+typedef enum
+{
+  TMR_SELECT_CHANNEL_1                   = 0x00, /*!< tmr channel select channel 1 */
+  TMR_SELECT_CHANNEL_1C                  = 0x01, /*!< tmr channel select channel 1 complementary */
+  TMR_SELECT_CHANNEL_2                   = 0x02, /*!< tmr channel select channel 2 */
+  TMR_SELECT_CHANNEL_2C                  = 0x03, /*!< tmr channel select channel 2 complementary */
+  TMR_SELECT_CHANNEL_3                   = 0x04, /*!< tmr channel select channel 3 */
+  TMR_SELECT_CHANNEL_3C                  = 0x05, /*!< tmr channel select channel 3 complementary */
+  TMR_SELECT_CHANNEL_4                   = 0x06  /*!< tmr channel select channel 4 */
+} tmr_channel_select_type;
+
+/**
+  * @brief tmr channel1 input connected type
+  */
+typedef enum
+{
+  TMR_CHANEL1_CONNECTED_C1IRAW           = 0x00, /*!< channel1 pins is only connected to C1IRAW input */
+  TMR_CHANEL1_2_3_CONNECTED_C1IRAW_XOR   = 0x01  /*!< channel1/2/3 pins are connected to C1IRAW input after xored */
+} tmr_channel1_input_connected_type;
+
+/**
+  * @brief tmr input channel mapped type channel direction
+  */
+typedef enum
+{
+  TMR_CC_CHANNEL_MAPPED_DIRECT           = 0x01, /*!< channel is configured as input, mapped direct */
+  TMR_CC_CHANNEL_MAPPED_INDIRECT         = 0x02, /*!< channel is configured as input, mapped indirect */
+  TMR_CC_CHANNEL_MAPPED_STI              = 0x03  /*!< channel is configured as input, mapped trc */
+} tmr_input_direction_mapped_type;
+
+/**
+  * @brief tmr input divider type
+  */
+typedef enum
+{
+  TMR_CHANNEL_INPUT_DIV_1                = 0x00, /*!< tmr channel input divider 1 */
+  TMR_CHANNEL_INPUT_DIV_2                = 0x01, /*!< tmr channel input divider 2 */
+  TMR_CHANNEL_INPUT_DIV_4                = 0x02, /*!< tmr channel input divider 4 */
+  TMR_CHANNEL_INPUT_DIV_8                = 0x03  /*!< tmr channel input divider 8 */
+} tmr_channel_input_divider_type;
+
+/**
+  * @brief tmr dma request source select type
+  */
+typedef enum
+{
+  TMR_DMA_REQUEST_BY_CHANNEL             = 0x00, /*!< tmr dma request source select channel */
+  TMR_DMA_REQUEST_BY_OVERFLOW            = 0x01  /*!< tmr dma request source select overflow */
+} tmr_dma_request_source_type;
+
+/**
+  * @brief tmr dma request type
+  */
+typedef enum
+{
+  TMR_OVERFLOW_DMA_REQUEST               = 0x00000100, /*!< tmr dma request select overflow */
+  TMR_C1_DMA_REQUEST                     = 0x00000200, /*!< tmr dma request select channel 1 */
+  TMR_C2_DMA_REQUEST                     = 0x00000400, /*!< tmr dma request select channel 2 */
+  TMR_C3_DMA_REQUEST                     = 0x00000800, /*!< tmr dma request select channel 3 */
+  TMR_C4_DMA_REQUEST                     = 0x00001000, /*!< tmr dma request select channel 4 */
+  TMR_HALL_DMA_REQUEST                   = 0x00002000, /*!< tmr dma request select hall */
+  TMR_TRIGGER_DMA_REQUEST                = 0x00004000  /*!< tmr dma request select trigger */
+} tmr_dma_request_type;
+
+/**
+  * @brief tmr event triggered by software type
+  */
+typedef enum
+{
+  TMR_OVERFLOW_SWTRIG                    = 0x00000001, /*!< tmr event triggered by software of overflow */
+  TMR_C1_SWTRIG                          = 0x00000002, /*!< tmr event triggered by software of channel 1 */
+  TMR_C2_SWTRIG                          = 0x00000004, /*!< tmr event triggered by software of channel 2 */
+  TMR_C3_SWTRIG                          = 0x00000008, /*!< tmr event triggered by software of channel 3 */
+  TMR_C4_SWTRIG                          = 0x00000010, /*!< tmr event triggered by software of channel 4 */
+  TMR_HALL_SWTRIG                        = 0x00000020, /*!< tmr event triggered by software of hall */
+  TMR_TRIGGER_SWTRIG                     = 0x00000040, /*!< tmr event triggered by software of trigger */
+  TMR_BRK_SWTRIG                         = 0x00000080  /*!< tmr event triggered by software of brake */
+}tmr_event_trigger_type;
+
+/**
+  * @brief tmr polarity active type
+  */
+typedef enum
+{
+  TMR_POLARITY_ACTIVE_HIGH               = 0x00, /*!< tmr polarity active high */
+  TMR_POLARITY_ACTIVE_LOW                = 0x01, /*!< tmr polarity active low */
+  TMR_POLARITY_ACTIVE_BOTH               = 0x02  /*!< tmr polarity active both high ande low */
+}tmr_polarity_active_type;
+
+/**
+  * @brief tmr external signal divider type
+  */
+typedef enum
+{
+  TMR_ES_FREQUENCY_DIV_1                 = 0x00, /*!< tmr external signal frequency divider 1 */
+  TMR_ES_FREQUENCY_DIV_2                 = 0x01, /*!< tmr external signal frequency divider 2 */
+  TMR_ES_FREQUENCY_DIV_4                 = 0x02, /*!< tmr external signal frequency divider 4 */
+  TMR_ES_FREQUENCY_DIV_8                 = 0x03  /*!< tmr external signal frequency divider 8 */
+}tmr_external_signal_divider_type;
+
+/**
+  * @brief tmr external signal polarity type
+  */
+typedef enum
+{
+  TMR_ES_POLARITY_NON_INVERTED           = 0x00, /*!< tmr external signal polarity non-inerted */
+  TMR_ES_POLARITY_INVERTED               = 0x01  /*!< tmr external signal polarity inerted */
+}tmr_external_signal_polarity_type;
+
+/**
+  * @brief tmr dma transfer length type
+  */
+typedef enum
+{
+  TMR_DMA_TRANSFER_1BYTE                 = 0x00, /*!< tmr dma transfer length 1 byte */
+  TMR_DMA_TRANSFER_2BYTES                = 0x01, /*!< tmr dma transfer length 2 bytes */
+  TMR_DMA_TRANSFER_3BYTES                = 0x02, /*!< tmr dma transfer length 3 bytes */
+  TMR_DMA_TRANSFER_4BYTES                = 0x03, /*!< tmr dma transfer length 4 bytes */
+  TMR_DMA_TRANSFER_5BYTES                = 0x04, /*!< tmr dma transfer length 5 bytes */
+  TMR_DMA_TRANSFER_6BYTES                = 0x05, /*!< tmr dma transfer length 6 bytes */
+  TMR_DMA_TRANSFER_7BYTES                = 0x06, /*!< tmr dma transfer length 7 bytes */
+  TMR_DMA_TRANSFER_8BYTES                = 0x07, /*!< tmr dma transfer length 8 bytes */
+  TMR_DMA_TRANSFER_9BYTES                = 0x08, /*!< tmr dma transfer length 9 bytes */
+  TMR_DMA_TRANSFER_10BYTES               = 0x09, /*!< tmr dma transfer length 10 bytes */
+  TMR_DMA_TRANSFER_11BYTES               = 0x0A, /*!< tmr dma transfer length 11 bytes */
+  TMR_DMA_TRANSFER_12BYTES               = 0x0B, /*!< tmr dma transfer length 12 bytes */
+  TMR_DMA_TRANSFER_13BYTES               = 0x0C, /*!< tmr dma transfer length 13 bytes */
+  TMR_DMA_TRANSFER_14BYTES               = 0x0D, /*!< tmr dma transfer length 14 bytes */
+  TMR_DMA_TRANSFER_15BYTES               = 0x0E, /*!< tmr dma transfer length 15 bytes */
+  TMR_DMA_TRANSFER_16BYTES               = 0x0F, /*!< tmr dma transfer length 16 bytes */
+  TMR_DMA_TRANSFER_17BYTES               = 0x10, /*!< tmr dma transfer length 17 bytes */
+  TMR_DMA_TRANSFER_18BYTES               = 0x11  /*!< tmr dma transfer length 18 bytes */
+}tmr_dma_transfer_length_type;
+
+/**
+  * @brief tmr dma base address type
+  */
+typedef enum
+{
+  TMR_CTRL1_ADDRESS                      = 0x0000, /*!< tmr dma base address ctrl1 */
+  TMR_CTRL2_ADDRESS                      = 0x0001, /*!< tmr dma base address ctrl2 */
+  TMR_STCTRL_ADDRESS                     = 0x0002, /*!< tmr dma base address stctrl */
+  TMR_IDEN_ADDRESS                       = 0x0003, /*!< tmr dma base address iden */
+  TMR_ISTS_ADDRESS                       = 0x0004, /*!< tmr dma base address ists */
+  TMR_SWEVT_ADDRESS                      = 0x0005, /*!< tmr dma base address swevt */
+  TMR_CM1_ADDRESS                        = 0x0006, /*!< tmr dma base address cm1 */
+  TMR_CM2_ADDRESS                        = 0x0007, /*!< tmr dma base address cm2 */
+  TMR_CCTRL_ADDRESS                      = 0x0008, /*!< tmr dma base address cctrl */
+  TMR_CVAL_ADDRESS                       = 0x0009, /*!< tmr dma base address cval */
+  TMR_DIV_ADDRESS                        = 0x000A, /*!< tmr dma base address div */
+  TMR_PR_ADDRESS                         = 0x000B, /*!< tmr dma base address pr */
+  TMR_RPR_ADDRESS                        = 0x000C, /*!< tmr dma base address rpr */
+  TMR_C1DT_ADDRESS                       = 0x000D, /*!< tmr dma base address c1dt */
+  TMR_C2DT_ADDRESS                       = 0x000E, /*!< tmr dma base address c2dt */
+  TMR_C3DT_ADDRESS                       = 0x000F, /*!< tmr dma base address c3dt */
+  TMR_C4DT_ADDRESS                       = 0x0010, /*!< tmr dma base address c4dt */
+  TMR_BRK_ADDRESS                        = 0x0011, /*!< tmr dma base address brake */
+  TMR_DMACTRL_ADDRESS                    = 0x0012  /*!< tmr dma base address dmactrl */
+}tmr_dma_address_type;
+
+/**
+  * @brief tmr brk polarity type
+  */
+typedef enum
+{
+  TMR_BRK_INPUT_ACTIVE_LOW               = 0x00, /*!< tmr brk input channel active low */
+  TMR_BRK_INPUT_ACTIVE_HIGH              = 0x01  /*!< tmr brk input channel active high */
+}tmr_brk_polarity_type;
+
+/**
+  * @brief tmr write protect level type
+  */
+typedef enum
+{
+  TMR_WP_OFF                             = 0x00, /*!< tmr write protect off */
+  TMR_WP_LEVEL_3                         = 0x01, /*!< tmr write protect level 3 */
+  TMR_WP_LEVEL_2                         = 0x02, /*!< tmr write protect level 2 */
+  TMR_WP_LEVEL_1                         = 0x03  /*!< tmr write protect level 1 */
+}tmr_wp_level_type;
+
+/**
+  * @brief tmr input remap type
+  */
+typedef enum
+{
+  TMR14_GPIO                             = 0x00, /*!< tmr14 input remap to gpio */
+  TMR14_ERTCCLK                          = 0x01, /*!< tmr14 input remap to ertc clock */
+  TMR14_HEXT_DIV32                       = 0x02, /*!< tmr14 input remap to hext div32*/
+  TMR14_CLKOUT                           = 0x03  /*!< tmr14 input remap to clkout */
+}tmr_input_remap_type ;
+/**
+
+  * @brief tmr output config type
+  */
+typedef struct
+{
+  tmr_output_control_mode_type           oc_mode;             /*!< output channel mode */
+  confirm_state                          oc_idle_state;       /*!< output channel idle state */
+  confirm_state                          occ_idle_state;      /*!< output channel complementary idle state */
+  tmr_output_polarity_type               oc_polarity;         /*!< output channel polarity */
+  tmr_output_polarity_type               occ_polarity;        /*!< output channel complementary polarity */
+  confirm_state                          oc_output_state;     /*!< output channel enable */
+  confirm_state                          occ_output_state;    /*!< output channel complementary enable */
+} tmr_output_config_type;
+
+/**
+  * @brief tmr input capture config type
+  */
+typedef struct
+{
+  tmr_channel_select_type                input_channel_select;   /*!< tmr input channel select */
+  tmr_input_polarity_type                input_polarity_select;  /*!< tmr input polarity select */
+  tmr_input_direction_mapped_type        input_mapped_select;    /*!< tmr channel mapped direct or indirect */
+  uint8_t                                input_filter_value;     /*!< tmr channel filter value */
+} tmr_input_config_type;
+
+/**
+  * @brief tmr brkdt config type
+  */
+typedef struct
+{
+  uint8_t                                deadtime;            /*!< dead-time generator setup */
+  tmr_brk_polarity_type                  brk_polarity;        /*!< tmr brake polarity */
+  tmr_wp_level_type                      wp_level;            /*!< write protect configuration */
+  confirm_state                          auto_output_enable;  /*!< automatic output enable */
+  confirm_state                          fcsoen_state;        /*!< frozen channel status when output enable */
+  confirm_state                          fcsodis_state;       /*!< frozen channel status when output disable */
+  confirm_state                          brk_enable;          /*!< tmr brk enale */
+} tmr_brkdt_config_type;
+
+/**
+  * @brief type define tmr register all
+  */
+typedef struct
+{
+  /**
+    * @brief tmr ctrl1 register, offset:0x00
+    */
+  union
+  {
+    __IO uint32_t ctrl1;
+    struct
+    {
+      __IO uint32_t tmren                : 1; /* [0] */
+      __IO uint32_t ovfen                : 1; /* [1] */
+      __IO uint32_t ovfs                 : 1; /* [2] */
+      __IO uint32_t ocmen                : 1; /* [3] */
+      __IO uint32_t cnt_dir              : 3; /* [6:4] */
+      __IO uint32_t prben                : 1; /* [7] */
+      __IO uint32_t clkdiv               : 2; /* [9:8] */
+      __IO uint32_t pmen                 : 1; /* [10] */
+      __IO uint32_t reserved1            : 21;/* [31:11] */
+    } ctrl1_bit;
+  };
+
+  /**
+    * @brief tmr ctrl2 register, offset:0x04
+    */
+  union
+  {
+    __IO uint32_t ctrl2;
+    struct
+    {
+      __IO uint32_t cbctrl               : 1; /* [0] */
+      __IO uint32_t reserved1            : 1; /* [1] */
+      __IO uint32_t ccfs                 : 1; /* [2] */
+      __IO uint32_t drs                  : 1; /* [3] */
+      __IO uint32_t ptos                 : 3; /* [6:4] */
+      __IO uint32_t c1insel              : 1; /* [7] */
+      __IO uint32_t c1ios                : 1; /* [8] */
+      __IO uint32_t c1cios               : 1; /* [9] */
+      __IO uint32_t c2ios                : 1; /* [10] */
+      __IO uint32_t c2cios               : 1; /* [11] */
+      __IO uint32_t c3ios                : 1; /* [12] */
+      __IO uint32_t c3cios               : 1; /* [13] */
+      __IO uint32_t c4ios                : 1; /* [14] */
+      __IO uint32_t reserved2            : 16;/* [30:15] */
+      __IO uint32_t trgout2en            : 1; /* [31] */
+    } ctrl2_bit;
+  };
+
+  /**
+    * @brief tmr smc register, offset:0x08
+    */
+  union
+  {
+    __IO uint32_t stctrl;
+    struct
+    {
+      __IO uint32_t smsel                : 3; /* [2:0] */
+      __IO uint32_t reserved1            : 1; /* [3] */
+      __IO uint32_t stis                 : 3; /* [6:4] */
+      __IO uint32_t sts                  : 1; /* [7] */
+      __IO uint32_t esf                  : 4; /* [11:8] */
+      __IO uint32_t esdiv                : 2; /* [13:12] */
+      __IO uint32_t ecmben               : 1; /* [14] */
+      __IO uint32_t esp                  : 1; /* [15] */
+      __IO uint32_t reserved2            : 16;/* [31:16] */
+    } stctrl_bit;
+  };
+
+  /**
+    * @brief tmr die register, offset:0x0C
+    */
+  union
+  {
+    __IO uint32_t iden;
+    struct
+    {
+      __IO uint32_t ovfien               : 1; /* [0] */
+      __IO uint32_t c1ien                : 1; /* [1] */
+      __IO uint32_t c2ien                : 1; /* [2] */
+      __IO uint32_t c3ien                : 1; /* [3] */
+      __IO uint32_t c4ien                : 1; /* [4] */
+      __IO uint32_t hallien              : 1; /* [5] */
+      __IO uint32_t tien                 : 1; /* [6] */
+      __IO uint32_t brkie                : 1; /* [7] */
+      __IO uint32_t ovfden               : 1; /* [8] */
+      __IO uint32_t c1den                : 1; /* [9] */
+      __IO uint32_t c2den                : 1; /* [10] */
+      __IO uint32_t c3den                : 1; /* [11] */
+      __IO uint32_t c4den                : 1; /* [12] */
+      __IO uint32_t hallde               : 1; /* [13] */
+      __IO uint32_t tden                 : 1; /* [14] */
+      __IO uint32_t reserved1            : 17;/* [31:15] */
+    } iden_bit;
+  };
+
+  /**
+    * @brief tmr ists register, offset:0x10
+    */
+  union
+  {
+    __IO uint32_t ists;
+    struct
+    {
+      __IO uint32_t ovfif                : 1; /* [0] */
+      __IO uint32_t c1if                 : 1; /* [1] */
+      __IO uint32_t c2if                 : 1; /* [2] */
+      __IO uint32_t c3if                 : 1; /* [3] */
+      __IO uint32_t c4if                 : 1; /* [4] */
+      __IO uint32_t hallif               : 1; /* [5] */
+      __IO uint32_t trgif                : 1; /* [6] */
+      __IO uint32_t brkif                : 1; /* [7] */
+      __IO uint32_t reserved1            : 1; /* [8] */
+      __IO uint32_t c1rf                 : 1; /* [9] */
+      __IO uint32_t c2rf                 : 1; /* [10] */
+      __IO uint32_t c3rf                 : 1; /* [11] */
+      __IO uint32_t c4rf                 : 1; /* [12] */
+      __IO uint32_t reserved2            : 19;/* [31:13] */
+    } ists_bit;
+  };
+
+  /**
+    * @brief tmr eveg register, offset:0x14
+    */
+  union
+  {
+    __IO uint32_t swevt;
+    struct
+    {
+      __IO uint32_t  ovfswtr             : 1; /* [0] */
+      __IO uint32_t  c1swtr              : 1; /* [1] */
+      __IO uint32_t  c2swtr              : 1; /* [2] */
+      __IO uint32_t  c3swtr              : 1; /* [3] */
+      __IO uint32_t  c4swtr              : 1; /* [4] */
+      __IO uint32_t  hallswtr            : 1; /* [5] */
+      __IO uint32_t  trgswtr             : 1; /* [6] */
+      __IO uint32_t  brkswtr             : 1; /* [7] */
+      __IO uint32_t  reserved            : 24;/* [31:8] */
+    } swevt_bit;
+  };
+
+  /**
+    * @brief tmr ccm1 register, offset:0x18
+    */
+  union
+  {
+    __IO uint32_t cm1;
+
+    /**
+     * @brief channel mode
+     */
+    struct
+    {
+      __IO uint32_t c1c                  : 2; /* [1:0] */
+      __IO uint32_t c1oien               : 1; /* [2] */
+      __IO uint32_t c1oben               : 1; /* [3] */
+      __IO uint32_t c1octrl              : 3; /* [6:4] */
+      __IO uint32_t c1osen               : 1; /* [7] */
+      __IO uint32_t c2c                  : 2; /* [9:8] */
+      __IO uint32_t c2oien               : 1; /* [10] */
+      __IO uint32_t c2oben               : 1; /* [11] */
+      __IO uint32_t c2octrl              : 3; /* [14:12] */
+      __IO uint32_t c2osen               : 1; /* [15] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } cm1_output_bit;
+
+    /**
+      * @brief input capture mode
+      */
+    struct
+    {
+      __IO uint32_t c1c                  : 2; /* [1:0] */
+      __IO uint32_t c1idiv               : 2; /* [3:2] */
+      __IO uint32_t c1df                 : 4; /* [7:4] */
+      __IO uint32_t c2c                  : 2; /* [9:8] */
+      __IO uint32_t c2idiv               : 2; /* [11:10] */
+      __IO uint32_t c2df                 : 4; /* [15:12] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } cm1_input_bit;
+  };
+
+  /**
+    * @brief tmr ccm2 register, offset:0x1C
+    */
+  union
+  {
+    __IO uint32_t cm2;
+
+    /**
+      * @brief channel mode
+      */
+    struct
+    {
+      __IO uint32_t c3c                  : 2; /* [1:0] */
+      __IO uint32_t c3oien               : 1; /* [2] */
+      __IO uint32_t c3oben               : 1; /* [3] */
+      __IO uint32_t c3octrl              : 3; /* [6:4] */
+      __IO uint32_t c3osen               : 1; /* [7] */
+      __IO uint32_t c4c                  : 2; /* [9:8] */
+      __IO uint32_t c4oien               : 1; /* [10] */
+      __IO uint32_t c4oben               : 1; /* [11] */
+      __IO uint32_t c4octrl              : 3; /* [14:12] */
+      __IO uint32_t c4osen               : 1; /* [15] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } cm2_output_bit;
+
+    /**
+      * @brief input capture mode
+      */
+    struct
+    {
+      __IO uint32_t c3c                  : 2; /* [1:0] */
+      __IO uint32_t c3idiv               : 2; /* [3:2] */
+      __IO uint32_t c3df                 : 4; /* [7:4] */
+      __IO uint32_t c4c                  : 2; /* [9:8] */
+      __IO uint32_t c4idiv               : 2; /* [11:10] */
+      __IO uint32_t c4df                 : 4; /* [15:12] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } cm2_input_bit;
+  };
+
+  /**
+    * @brief tmr cce register, offset:0x20
+    */
+  union
+  {
+    uint32_t cctrl;
+    struct
+    {
+      __IO uint32_t c1en                 : 1; /* [0] */
+      __IO uint32_t c1p                  : 1; /* [1] */
+      __IO uint32_t c1cen                : 1; /* [2] */
+      __IO uint32_t c1cp                 : 1; /* [3] */
+      __IO uint32_t c2en                 : 1; /* [4] */
+      __IO uint32_t c2p                  : 1; /* [5] */
+      __IO uint32_t c2cen                : 1; /* [6] */
+      __IO uint32_t c2cp                 : 1; /* [7] */
+      __IO uint32_t c3en                 : 1; /* [8] */
+      __IO uint32_t c3p                  : 1; /* [9] */
+      __IO uint32_t c3cen                : 1; /* [10] */
+      __IO uint32_t c3cp                 : 1; /* [11] */
+      __IO uint32_t c4en                 : 1; /* [12] */
+      __IO uint32_t c4p                  : 1; /* [13] */
+      __IO uint32_t reserved1            : 18;/* [31:14] */
+    } cctrl_bit;
+  };
+
+  /**
+    * @brief tmr cnt register, offset:0x24
+    */
+  union
+  {
+    __IO uint32_t cval;
+    struct
+    {
+      __IO uint32_t cval                 : 32;/* [31:0] */
+    } cval_bit;
+  };
+
+  /**
+    * @brief tmr div, offset:0x28
+    */
+  union
+  {
+    __IO uint32_t div;
+    struct
+    {
+      __IO uint32_t div                  : 16;/* [15:0] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } div_bit;
+  };
+
+  /**
+    * @brief tmr pr register, offset:0x2C
+    */
+  union
+  {
+    __IO  uint32_t pr;
+    struct
+    {
+      __IO uint32_t pr                   : 32;/* [31:0] */
+    } pr_bit;
+  };
+
+  /**
+    * @brief tmr rpr register, offset:0x30
+    */
+  union
+  {
+    __IO uint32_t rpr;
+    struct
+    {
+      __IO uint32_t rpr                  : 16;/* [15:0] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } rpr_bit;
+  };
+
+  /**
+    * @brief tmr c1dt register, offset:0x34
+    */
+  union
+  {
+    uint32_t c1dt;
+    struct
+    {
+      __IO uint32_t c1dt                 : 32;/* [31:0] */
+    } c1dt_bit;
+  };
+
+  /**
+    * @brief tmr c2dt register, offset:0x38
+    */
+  union
+  {
+    uint32_t c2dt;
+    struct
+    {
+      __IO uint32_t c2dt                 : 32;/* [31:0] */
+    } c2dt_bit;
+  };
+
+  /**
+    * @brief tmr c3dt register, offset:0x3C
+    */
+  union
+  {
+    __IO uint32_t c3dt;
+    struct
+    {
+      __IO uint32_t c3dt                 : 32;/* [31:0] */
+    } c3dt_bit;
+  };
+
+  /**
+    * @brief tmr c4dt register, offset:0x40
+    */
+  union
+  {
+    __IO uint32_t c4dt;
+    struct
+    {
+      __IO uint32_t c4dt                 : 32;/* [31:0] */
+    } c4dt_bit;
+  };
+
+  /**
+    * @brief tmr brk register, offset:0x44
+    */
+  union
+  {
+    __IO uint32_t brk;
+    struct
+    {
+      __IO uint32_t dtc                  : 8; /* [7:0] */
+      __IO uint32_t wpc                  : 2; /* [9:8] */
+      __IO uint32_t fcsodis              : 1; /* [10] */
+      __IO uint32_t fcsoen               : 1; /* [11] */
+      __IO uint32_t brken                : 1; /* [12] */
+      __IO uint32_t brkv                 : 1; /* [13] */
+      __IO uint32_t aoen                 : 1; /* [14] */
+      __IO uint32_t oen                  : 1; /* [15] */
+      __IO uint32_t brkf                 : 4; /* [19:16] */
+      __IO uint32_t reserved1            : 12;/* [31:20] */
+    } brk_bit;
+  };
+  /**
+    * @brief tmr dmactrl register, offset:0x48
+    */
+  union
+  {
+    __IO uint32_t dmactrl;
+    struct
+    {
+      __IO uint32_t addr                 : 5; /* [4:0] */
+      __IO uint32_t reserved1            : 3; /* [7:5] */
+      __IO uint32_t dtb                  : 5; /* [12:8] */
+      __IO uint32_t reserved2            : 19;/* [31:13] */
+    } dmactrl_bit;
+  };
+
+  /**
+    * @brief tmr dmadt register, offset:0x4C
+    */
+  union
+  {
+    __IO uint32_t dmadt;
+    struct
+    {
+      __IO uint32_t dmadt                : 16;/* [15:0] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } dmadt_bit;
+  };
+
+  /**
+    * @brief tmr rmp register, offset:0x50
+    */
+  union
+  {
+    __IO uint32_t rmp;
+    struct
+    {
+      __IO uint32_t tmr14_ch1_irmp        : 2; /* [1:0] */      
+      __IO uint32_t reserved1             : 30;/* [31:2] */
+    } rmp_bit;
+  };
+} tmr_type;
+
+/**
+  * @}
+  */
+
+#define TMR1                             ((tmr_type *) TMR1_BASE)
+#define TMR2                             ((tmr_type *) TMR2_BASE)
+#define TMR3                             ((tmr_type *) TMR3_BASE)
+#define TMR4                             ((tmr_type *) TMR4_BASE)
+#define TMR6                             ((tmr_type *) TMR6_BASE)
+#define TMR7                             ((tmr_type *) TMR7_BASE)
+#define TMR9                             ((tmr_type *) TMR9_BASE)
+#define TMR10                            ((tmr_type *) TMR10_BASE)
+#define TMR11                            ((tmr_type *) TMR11_BASE)
+#define TMR12                            ((tmr_type *) TMR12_BASE)
+#define TMR13                            ((tmr_type *) TMR13_BASE)
+#define TMR14                            ((tmr_type *) TMR14_BASE)
+
+/** @defgroup TMR_exported_functions
+  * @{
+  */
+
+void tmr_reset(tmr_type *tmr_x);
+void tmr_counter_enable(tmr_type *tmr_x, confirm_state new_state);
+void tmr_output_default_para_init(tmr_output_config_type *tmr_output_struct);
+void tmr_input_default_para_init(tmr_input_config_type *tmr_input_struct);
+void tmr_brkdt_default_para_init(tmr_brkdt_config_type *tmr_brkdt_struct);
+void tmr_base_init(tmr_type* tmr_x, uint32_t tmr_pr, uint32_t tmr_div);
+void tmr_clock_source_div_set(tmr_type *tmr_x, tmr_clock_division_type tmr_clock_div);
+void tmr_cnt_dir_set(tmr_type *tmr_x, tmr_count_mode_type tmr_cnt_dir);
+void tmr_repetition_counter_set(tmr_type *tmr_x, uint16_t tmr_rpr_value);
+void tmr_counter_value_set(tmr_type *tmr_x, uint32_t tmr_cnt_value);
+uint32_t tmr_counter_value_get(tmr_type *tmr_x);
+void tmr_div_value_set(tmr_type *tmr_x, uint32_t tmr_div_value);
+uint32_t tmr_div_value_get(tmr_type *tmr_x);
+void tmr_output_channel_config(tmr_type *tmr_x, tmr_channel_select_type tmr_channel, \
+                               tmr_output_config_type *tmr_output_struct);
+void tmr_output_channel_mode_select(tmr_type *tmr_x, tmr_channel_select_type tmr_channel, \
+                                    tmr_output_control_mode_type oc_mode);
+void tmr_period_value_set(tmr_type *tmr_x, uint32_t tmr_pr_value);
+uint32_t tmr_period_value_get(tmr_type *tmr_x);
+void tmr_channel_value_set(tmr_type *tmr_x, tmr_channel_select_type tmr_channel, \
+                           uint32_t tmr_channel_value);
+uint32_t tmr_channel_value_get(tmr_type *tmr_x, tmr_channel_select_type tmr_channel);
+void tmr_period_buffer_enable(tmr_type *tmr_x, confirm_state new_state);
+void tmr_output_channel_buffer_enable(tmr_type *tmr_x, tmr_channel_select_type tmr_channel, \
+                                   confirm_state new_state);
+void tmr_output_channel_immediately_set(tmr_type *tmr_x, tmr_channel_select_type tmr_channel, \
+                                        confirm_state new_state);
+void tmr_output_channel_switch_set(tmr_type *tmr_x, tmr_channel_select_type tmr_channel, \
+                                   confirm_state new_state);
+void tmr_one_cycle_mode_enable(tmr_type *tmr_x, confirm_state new_state);
+void tmr_32_bit_function_enable (tmr_type *tmr_x, confirm_state new_state);
+void tmr_overflow_request_source_set(tmr_type *tmr_x, confirm_state new_state);
+void tmr_overflow_event_disable(tmr_type *tmr_x, confirm_state new_state);
+void tmr_input_channel_init(tmr_type *tmr_x, tmr_input_config_type *input_struct, \
+                            tmr_channel_input_divider_type divider_factor);
+void tmr_channel_enable(tmr_type *tmr_x, tmr_channel_select_type tmr_channel, confirm_state new_state);
+void tmr_input_channel_filter_set(tmr_type *tmr_x, tmr_channel_select_type tmr_channel, \
+                                  uint16_t filter_value);
+void tmr_pwm_input_config(tmr_type *tmr_x, tmr_input_config_type *input_struct, \
+                          tmr_channel_input_divider_type divider_factor);
+void tmr_channel1_input_select(tmr_type *tmr_x, tmr_channel1_input_connected_type ch1_connect);
+void tmr_input_channel_divider_set(tmr_type *tmr_x, tmr_channel_select_type tmr_channel, \
+                                   tmr_channel_input_divider_type divider_factor);
+void tmr_primary_mode_select(tmr_type *tmr_x, tmr_primary_select_type primary_mode);
+void tmr_sub_mode_select(tmr_type *tmr_x, tmr_sub_mode_select_type sub_mode);
+void tmr_channel_dma_select(tmr_type *tmr_x, tmr_dma_request_source_type cc_dma_select);
+void tmr_hall_select(tmr_type *tmr_x,  confirm_state new_state);
+void tmr_channel_buffer_enable(tmr_type *tmr_x, confirm_state new_state);
+void tmr_trgout2_enable(tmr_type *tmr_x, confirm_state new_state);
+void tmr_trigger_input_select(tmr_type *tmr_x, sub_tmr_input_sel_type trigger_select);
+void tmr_sub_sync_mode_set(tmr_type *tmr_x, confirm_state new_state);
+void tmr_dma_request_enable(tmr_type *tmr_x, tmr_dma_request_type dma_request, confirm_state new_state);
+void tmr_interrupt_enable(tmr_type *tmr_x, uint32_t tmr_interrupt, confirm_state new_state);
+flag_status tmr_interrupt_flag_get(tmr_type *tmr_x, uint32_t tmr_flag);
+flag_status tmr_flag_get(tmr_type *tmr_x, uint32_t tmr_flag);
+void tmr_flag_clear(tmr_type *tmr_x, uint32_t tmr_flag);
+void tmr_event_sw_trigger(tmr_type *tmr_x, tmr_event_trigger_type tmr_event);
+void tmr_output_enable(tmr_type *tmr_x, confirm_state new_state);
+void tmr_internal_clock_set(tmr_type *tmr_x);
+void tmr_output_channel_polarity_set(tmr_type *tmr_x, tmr_channel_select_type tmr_channel, \
+                                     tmr_polarity_active_type oc_polarity);
+void tmr_external_clock_config(tmr_type *tmr_x, tmr_external_signal_divider_type es_divide, \
+                               tmr_external_signal_polarity_type  es_polarity, uint16_t es_filter);
+void tmr_external_clock_mode1_config(tmr_type *tmr_x, tmr_external_signal_divider_type es_divide, \
+                                     tmr_external_signal_polarity_type  es_polarity, uint16_t es_filter);
+void tmr_external_clock_mode2_config(tmr_type *tmr_x, tmr_external_signal_divider_type es_divide, \
+                                     tmr_external_signal_polarity_type  es_polarity, uint16_t es_filter);
+void tmr_encoder_mode_config(tmr_type *tmr_x, tmr_encoder_mode_type encoder_mode, tmr_input_polarity_type \
+                             ic1_polarity, tmr_input_polarity_type ic2_polarity);
+void tmr_force_output_set(tmr_type *tmr_x,  tmr_channel_select_type tmr_channel, \
+                          tmr_force_output_type force_output);
+void tmr_dma_control_config(tmr_type *tmr_x, tmr_dma_transfer_length_type dma_length, \
+                            tmr_dma_address_type dma_base_address);
+void tmr_brkdt_config(tmr_type *tmr_x, tmr_brkdt_config_type *brkdt_struct);
+void tmr_brk_filter_value_set(tmr_type *tmr_x, uint8_t filter_value);
+void tmr_iremap_config(tmr_type *tmr_x, tmr_input_remap_type input_remap);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_usart.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_usart.h
@@ -1,0 +1,490 @@
+/**
+  **************************************************************************
+  * @file     at32f423_usart.h
+  * @brief    at32f423 usart header file
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+/* define to prevent recursive inclusion -------------------------------------*/
+#ifndef __AT32F423_USART_H
+#define __AT32F423_USART_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* includes ------------------------------------------------------------------*/
+#include "at32f423.h"
+
+/** @addtogroup AT32F423_periph_driver
+  * @{
+  */
+
+/** @addtogroup USART
+  * @{
+  */
+
+/** @defgroup USART_flags_definition
+  * @brief usart flag
+  * @{
+  */
+
+#define USART_PERR_FLAG                  ((uint32_t)0x00000001) /*!< usart parity error flag */
+#define USART_FERR_FLAG                  ((uint32_t)0x00000002) /*!< usart framing error flag */
+#define USART_NERR_FLAG                  ((uint32_t)0x00000004) /*!< usart noise error flag */
+#define USART_ROERR_FLAG                 ((uint32_t)0x00000008) /*!< usart receiver overflow error flag */
+#define USART_IDLEF_FLAG                 ((uint32_t)0x00000010) /*!< usart idle flag */
+#define USART_RDBF_FLAG                  ((uint32_t)0x00000020) /*!< usart receive data buffer full flag */
+#define USART_TDC_FLAG                   ((uint32_t)0x00000040) /*!< usart transmit data complete flag */
+#define USART_TDBE_FLAG                  ((uint32_t)0x00000080) /*!< usart transmit data buffer empty flag */
+#define USART_BFF_FLAG                   ((uint32_t)0x00000100) /*!< usart break frame flag */
+#define USART_CTSCF_FLAG                 ((uint32_t)0x00000200) /*!< usart cts change flag */
+#define USART_RTODF_FLAG                 ((uint32_t)0x00000800) /*!< usart receiver time out detection flag */
+#define USART_OCCUPY_FLAG                ((uint32_t)0x00010000) /*!< usart receiver occupy flag */
+#define USART_CMDF_FLAG                  ((uint32_t)0x00020000) /*!< usart character match detection flag */
+#define USART_LPWUF_FLAG                 ((uint32_t)0x00100000) /*!< usart low power wake up flag */
+#define USART_TXON_FLAG                  ((uint32_t)0x00200000) /*!< usart transmitter turned on flag */
+#define USART_RXON_FLAG                  ((uint32_t)0x00400000) /*!< usart receiver turned on flag */
+
+/**
+  * @}
+  */
+
+/** @defgroup USART_interrupts_definition
+  * @brief usart interrupt
+  * @{
+  */
+
+#define USART_IDLE_INT                   MAKE_VALUE(0x0C,0x04) /*!< usart idle interrupt */
+#define USART_RDBF_INT                   MAKE_VALUE(0x0C,0x05) /*!< usart receive data buffer full interrupt */
+#define USART_TDC_INT                    MAKE_VALUE(0x0C,0x06) /*!< usart transmit data complete interrupt */
+#define USART_TDBE_INT                   MAKE_VALUE(0x0C,0x07) /*!< usart transmit data buffer empty interrupt */
+#define USART_PERR_INT                   MAKE_VALUE(0x0C,0x08) /*!< usart parity error interrupt */
+#define USART_BF_INT                     MAKE_VALUE(0x10,0x06) /*!< usart break frame interrupt */
+#define USART_ERR_INT                    MAKE_VALUE(0x14,0x00) /*!< usart error interrupt */
+#define USART_CTSCF_INT                  MAKE_VALUE(0x14,0x0A) /*!< usart cts change interrupt */
+#define USART_LPWUF_INT                  MAKE_VALUE(0x14,0x0D) /*!< usart low power wakeup flag interrupt */
+#define USART_RTOD_INT                   MAKE_VALUE(0x0C,0x1A) /*!< usart receiver time out detection flag interrupt */
+#define USART_CMD_INT                    MAKE_VALUE(0x0C,0x0E) /*!< usart character match detection flag interrupt */
+
+/**
+  * @}
+  */
+
+/** @defgroup USART_exported_types
+  * @{
+  */
+
+/**
+  * @brief  usart parity selection type
+  */
+typedef enum
+{
+  USART_PARITY_NONE                      = 0x00, /*!< usart no parity */
+  USART_PARITY_EVEN                      = 0x01, /*!< usart even parity */
+  USART_PARITY_ODD                       = 0x02  /*!< usart odd parity */
+} usart_parity_selection_type;
+
+/**
+  * @brief  usart wakeup mode type
+  */
+typedef enum
+{
+  USART_WAKEUP_BY_IDLE_FRAME             = 0x00, /*!< usart wakeup by idle frame */
+  USART_WAKEUP_BY_MATCHING_ID            = 0x01  /*!< usart wakeup by matching id */
+} usart_wakeup_mode_type;
+
+/**
+  * @brief  usart data bit num type
+  */
+typedef enum
+{
+  USART_DATA_8BITS                       = 0x00, /*!< usart data size is 8 bits */
+  USART_DATA_9BITS                       = 0x01, /*!< usart data size is 9 bits */
+  USART_DATA_7BITS                       = 0x02  /*!< usart data size is 7 bits */
+} usart_data_bit_num_type;
+
+/**
+  * @brief  usart break frame bit num type
+  */
+typedef enum
+{
+  USART_BREAK_10BITS                     = 0x00, /*!< usart lin mode berak frame detection 10 bits */
+  USART_BREAK_11BITS                     = 0x01  /*!< usart lin mode berak frame detection 11 bits */
+} usart_break_bit_num_type;
+
+/**
+  * @brief  usart phase of the clock type
+  */
+typedef enum
+{
+  USART_CLOCK_PHASE_1EDGE                = 0x00, /*!< usart data capture is done on the clock leading edge */
+  USART_CLOCK_PHASE_2EDGE                = 0x01  /*!< usart data capture is done on the clock trailing edge */
+} usart_clock_phase_type;
+
+/**
+  * @brief  usart polarity of the clock type
+  */
+typedef enum
+{
+  USART_CLOCK_POLARITY_LOW               = 0x00, /*!< usart clock stay low level outside transmission window */
+  USART_CLOCK_POLARITY_HIGH              = 0x01  /*!< usart clock stay high level outside transmission window */
+} usart_clock_polarity_type;
+
+/**
+  * @brief  usart last bit clock pulse type
+  */
+typedef enum
+{
+  USART_CLOCK_LAST_BIT_NONE              = 0x00, /*!< usart clock pulse of the last data bit is not outputted */
+  USART_CLOCK_LAST_BIT_OUTPUT            = 0x01  /*!< usart clock pulse of the last data bit is outputted */
+} usart_lbcp_type;
+
+/**
+  * @brief  usart stop bit num type
+  */
+typedef enum
+{
+  USART_STOP_1_BIT                       = 0x00, /*!< usart stop bits num is 1 */
+  USART_STOP_0_5_BIT                     = 0x01, /*!< usart stop bits num is 0.5 */
+  USART_STOP_2_BIT                       = 0x02, /*!< usart stop bits num is 2 */
+  USART_STOP_1_5_BIT                     = 0x03  /*!< usart stop bits num is 1.5 */
+} usart_stop_bit_num_type;
+
+/**
+  * @brief  usart hardware flow control type
+  */
+typedef enum
+{
+  USART_HARDWARE_FLOW_NONE               = 0x00, /*!< usart without hardware flow */
+  USART_HARDWARE_FLOW_RTS                = 0x01, /*!< usart hardware flow only rts */
+  USART_HARDWARE_FLOW_CTS                = 0x02, /*!< usart hardware flow only cts */
+  USART_HARDWARE_FLOW_RTS_CTS            = 0x03  /*!< usart hardware flow both rts and cts */
+} usart_hardware_flow_control_type;
+
+/**
+  * @brief  usart identification bit num type
+  */
+typedef enum
+{
+  USART_ID_FIXED_4_BIT                   = 0x00, /*!< usart id bit num fixed 4 bits */
+  USART_ID_RELATED_DATA_BIT              = 0x01  /*!< usart id bit num related data bits */
+} usart_identification_bit_num_type;
+
+/**
+  * @brief  usart de polarity type
+  */
+typedef enum
+{
+  USART_DE_POLARITY_HIGH                 = 0x00, /*!< usart de polarity high */
+  USART_DE_POLARITY_LOW                  = 0x01  /*!< usart de polarity low */
+} usart_de_polarity_type;
+
+/**
+  * @brief  usart wakeup method type
+  */
+typedef enum
+{
+  USART_WAKEUP_METHOD_ID                 = 0x00, /*!< usart low power wakeup method id match */
+  USART_WAKEUP_METHOD_START              = 0x02, /*!< usart low power wakeup method start bit */
+  USART_WAKEUP_METHOD_RDBF               = 0x03, /*!< usart low power wakeup method receive data buffer full */
+} usart_wakeup_method_type;
+
+/**
+  * @brief type define usart register all
+  */
+typedef struct
+{
+  /**
+    * @brief usart sts register, offset:0x00
+    */
+  union
+  {
+    __IO uint32_t sts;
+    struct
+    {
+      __IO uint32_t perr                 : 1; /* [0] */
+      __IO uint32_t ferr                 : 1; /* [1] */
+      __IO uint32_t nerr                 : 1; /* [2] */
+      __IO uint32_t roerr                : 1; /* [3] */
+      __IO uint32_t idlef                : 1; /* [4] */
+      __IO uint32_t rdbf                 : 1; /* [5] */
+      __IO uint32_t tdc                  : 1; /* [6] */
+      __IO uint32_t tdbe                 : 1; /* [7] */
+      __IO uint32_t bff                  : 1; /* [8] */
+      __IO uint32_t ctscf                : 1; /* [9] */
+      __IO uint32_t reserved1            : 1; /* [10] */
+      __IO uint32_t rtodf                : 1; /* [11] */
+      __IO uint32_t reserved2            : 4; /* [12:15] */
+      __IO uint32_t occupy               : 1; /* [16] */
+      __IO uint32_t cmdf                 : 1; /* [17] */
+      __IO uint32_t reserved3            : 2; /* [18:19] */
+      __IO uint32_t lpwuf                : 1; /* [20] */
+      __IO uint32_t txon                 : 1; /* [21] */
+      __IO uint32_t rxon                 : 1; /* [22] */
+      __IO uint32_t reserved4            : 9; /* [31:23] */
+    } sts_bit;
+  };
+
+  /**
+    * @brief usart dt register, offset:0x04
+    */
+  union
+  {
+    __IO uint32_t dt;
+    struct
+    {
+      __IO uint32_t dt                   : 9; /* [8:0] */
+      __IO uint32_t reserved1            : 23;/* [31:9] */
+    } dt_bit;
+  };
+
+  /**
+    * @brief usart baudr register, offset:0x08
+    */
+  union
+  {
+    __IO uint32_t baudr;
+    struct
+    {
+      __IO uint32_t div                  : 16;/* [15:0] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } baudr_bit;
+  };
+
+  /**
+    * @brief usart ctrl1 register, offset:0x0C
+    */
+  union
+  {
+    __IO uint32_t ctrl1;
+    struct
+    {
+      __IO uint32_t sbf                  : 1; /* [0] */
+      __IO uint32_t rm                   : 1; /* [1] */
+      __IO uint32_t ren                  : 1; /* [2] */
+      __IO uint32_t ten                  : 1; /* [3] */
+      __IO uint32_t idleien              : 1; /* [4] */
+      __IO uint32_t rdbfien              : 1; /* [5] */
+      __IO uint32_t tdcien               : 1; /* [6] */
+      __IO uint32_t tdbeien              : 1; /* [7] */
+      __IO uint32_t perrien              : 1; /* [8] */
+      __IO uint32_t psel                 : 1; /* [9] */
+      __IO uint32_t pen                  : 1; /* [10] */
+      __IO uint32_t wum                  : 1; /* [11] */
+      __IO uint32_t dbn0                 : 1; /* [12] */
+      __IO uint32_t uen                  : 1; /* [13] */
+      __IO uint32_t cmdie                : 1; /* [14] */
+      __IO uint32_t reserved1            : 1; /* [15] */
+      __IO uint32_t tcdt                 : 5; /* [20:16] */
+      __IO uint32_t tsdt                 : 5; /* [25:21] */
+      __IO uint32_t retodie              : 1; /* [26] */
+      __IO uint32_t rtoden               : 1; /* [27] */
+      __IO uint32_t dbn1                 : 1; /* [28] */
+      __IO uint32_t reserved2            : 3; /* [31:29] */
+    } ctrl1_bit;
+  };
+
+  /**
+    * @brief usart ctrl2 register, offset:0x10
+    */
+  union
+  {
+    __IO uint32_t ctrl2;
+    struct
+    {
+      __IO uint32_t idl                  : 4; /* [3:0] */
+      __IO uint32_t idbn                 : 1; /* [4] */
+      __IO uint32_t bfbn                 : 1; /* [5] */
+      __IO uint32_t bfien                : 1; /* [6] */
+      __IO uint32_t reserved1            : 1; /* [7] */
+      __IO uint32_t lbcp                 : 1; /* [8] */
+      __IO uint32_t clkpha               : 1; /* [9] */
+      __IO uint32_t clkpol               : 1; /* [10] */
+      __IO uint32_t clken                : 1; /* [11] */
+      __IO uint32_t stopbn               : 2; /* [13:12] */
+      __IO uint32_t linen                : 1; /* [14] */
+      __IO uint32_t trpswap              : 1; /* [15] */
+      __IO uint32_t rxrev                : 1; /* [16] */
+      __IO uint32_t txrev                : 1; /* [17] */
+      __IO uint32_t dtrev                : 1; /* [18] */
+      __IO uint32_t mtf                  : 1; /* [19] */
+      __IO uint32_t reserved2            : 8; /* [27:20] */
+      __IO uint32_t idh                  : 4; /* [31:28] */
+    } ctrl2_bit;
+  };
+
+  /**
+    * @brief usart ctrl3 register, offset:0x14
+    */
+  union
+  {
+    __IO uint32_t ctrl3;
+    struct
+    {
+      __IO uint32_t errien               : 1; /* [0] */
+      __IO uint32_t irdaen               : 1; /* [1] */
+      __IO uint32_t irdalp               : 1; /* [2] */
+      __IO uint32_t slben                : 1; /* [3] */
+      __IO uint32_t scnacken             : 1; /* [4] */
+      __IO uint32_t scmen                : 1; /* [5] */
+      __IO uint32_t dmaren               : 1; /* [6] */
+      __IO uint32_t dmaten               : 1; /* [7] */
+      __IO uint32_t rtsen                : 1; /* [8] */
+      __IO uint32_t ctsen                : 1; /* [9] */
+      __IO uint32_t ctscfien             : 1; /* [10] */
+      __IO uint32_t smusen               : 1; /* [11] */ 
+      __IO uint32_t reserved1            : 1; /* [12] */
+      __IO uint32_t lpwufie              : 1; /* [13] */
+      __IO uint32_t rs485en              : 1; /* [14] */
+      __IO uint32_t dep                  : 1; /* [15] */
+      __IO uint32_t lpwum                : 2; /* [17:16] */
+      __IO uint32_t reserved2            : 14;/* [31:18] */
+    } ctrl3_bit;
+  };
+
+  /**
+    * @brief usart gdiv register, offset:0x18
+    */
+  union
+  {
+    __IO uint32_t gdiv;
+    struct
+    {
+      __IO uint32_t isdiv                : 8; /* [7:0] */
+      __IO uint32_t scgt                 : 8; /* [15:8] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } gdiv_bit;
+  };
+  
+  /**
+  * @brief usart rtov register, offset:0x1C
+  */
+  union
+  {
+    __IO uint32_t rtov;
+    struct
+    {
+      __IO uint32_t rtov                 : 24;/* [23:0] */
+      __IO uint32_t reserved1            : 8; /* [31:24] */
+    } rtov_bit;
+  };
+  
+  /**
+  * @brief usart ifc register, offset:0x20
+  */
+  union
+  {
+    __IO uint32_t ifc;
+    struct
+    {
+      __IO uint32_t reserved1            : 11;/* [10:0] */
+      __IO uint32_t lpwufc               : 1; /* [11] */
+      __IO uint32_t reserved2            : 5; /* [16:12] */
+      __IO uint32_t cmdfc                : 1; /* [17] */
+      __IO uint32_t reserved3            : 2; /* [19:18] */
+      __IO uint32_t rtodfc               : 1; /* [20] */
+      __IO uint32_t reserved4            : 11;/* [31:21] */
+    } ifc_bit;
+  };
+} usart_type;
+
+/**
+  * @}
+  */
+
+#define USART1                           ((usart_type *) USART1_BASE)
+#define USART2                           ((usart_type *) USART2_BASE)
+#define USART3                           ((usart_type *) USART3_BASE)
+#define USART4                           ((usart_type *) USART4_BASE)
+#define USART5                           ((usart_type *) USART5_BASE)
+#define USART6                           ((usart_type *) USART6_BASE)
+#define USART7                           ((usart_type *) USART7_BASE)
+#if defined (AT32F423Rx) || defined (AT32F423Vx)
+#define USART8                           ((usart_type *) USART8_BASE)
+#endif
+
+/** @defgroup USART_exported_functions
+  * @{
+  */
+
+void usart_reset(usart_type* usart_x);
+void usart_init(usart_type* usart_x, uint32_t baud_rate, usart_data_bit_num_type data_bit, usart_stop_bit_num_type stop_bit);
+void usart_parity_selection_config(usart_type* usart_x, usart_parity_selection_type parity);
+void usart_enable(usart_type* usart_x, confirm_state new_state);
+void usart_transmitter_enable(usart_type* usart_x, confirm_state new_state);
+void usart_receiver_enable(usart_type* usart_x, confirm_state new_state);
+void usart_clock_config(usart_type* usart_x, usart_clock_polarity_type clk_pol, usart_clock_phase_type clk_pha, usart_lbcp_type clk_lb);
+void usart_clock_enable(usart_type* usart_x, confirm_state new_state);
+void usart_interrupt_enable(usart_type* usart_x, uint32_t usart_int, confirm_state new_state);
+void usart_dma_transmitter_enable(usart_type* usart_x, confirm_state new_state);
+void usart_dma_receiver_enable(usart_type* usart_x, confirm_state new_state);
+void usart_wakeup_id_set(usart_type* usart_x, uint8_t usart_id);
+void usart_wakeup_mode_set(usart_type* usart_x, usart_wakeup_mode_type wakeup_mode);
+void usart_receiver_mute_enable(usart_type* usart_x, confirm_state new_state);
+void usart_break_bit_num_set(usart_type* usart_x, usart_break_bit_num_type break_bit);
+void usart_lin_mode_enable(usart_type* usart_x, confirm_state new_state);
+void usart_data_transmit(usart_type* usart_x, uint16_t data);
+uint16_t usart_data_receive(usart_type* usart_x);
+void usart_break_send(usart_type* usart_x);
+void usart_smartcard_guard_time_set(usart_type* usart_x, uint8_t guard_time_val);
+void usart_irda_smartcard_division_set(usart_type* usart_x, uint8_t div_val);
+void usart_smartcard_mode_enable(usart_type* usart_x, confirm_state new_state);
+void usart_smartcard_nack_set(usart_type* usart_x, confirm_state new_state);
+void usart_single_line_halfduplex_select(usart_type* usart_x, confirm_state new_state);
+void usart_irda_mode_enable(usart_type* usart_x, confirm_state new_state);
+void usart_irda_low_power_enable(usart_type* usart_x, confirm_state new_state);
+void usart_hardware_flow_control_set(usart_type* usart_x,usart_hardware_flow_control_type flow_state);
+flag_status usart_flag_get(usart_type* usart_x, uint32_t flag);
+flag_status usart_interrupt_flag_get(usart_type* usart_x, uint32_t flag);
+void usart_flag_clear(usart_type* usart_x, uint32_t flag);
+void usart_rs485_delay_time_config(usart_type* usart_x, uint8_t start_delay_time, uint8_t complete_delay_time);
+void usart_transmit_receive_pin_swap(usart_type* usart_x, confirm_state new_state);
+void usart_id_bit_num_set(usart_type* usart_x, usart_identification_bit_num_type id_bit_num);
+void usart_de_polarity_set(usart_type* usart_x, usart_de_polarity_type de_polarity);
+void usart_rs485_mode_enable(usart_type* usart_x, confirm_state new_state);
+void usart_low_power_wakeup_set(usart_type* usart_x, usart_wakeup_method_type wakeup_method);
+void usart_deep_sleep_mode_enable(usart_type* usart_x, confirm_state new_state);
+void usart_msb_transmit_first_enable(usart_type* usart_x, confirm_state new_state);
+void usart_dt_polarity_reverse(usart_type* usart_x, confirm_state new_state);
+void usart_transmit_pin_polarity_reverse(usart_type* usart_x, confirm_state new_state);
+void usart_receive_pin_polarity_reverse(usart_type* usart_x, confirm_state new_state);
+void usart_receiver_timeout_detection_enable(usart_type* usart_x, confirm_state new_state);
+void usart_receiver_timeout_value_set(usart_type* usart_x, uint32_t time);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_usb.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_usb.h
@@ -1,0 +1,1422 @@
+/**
+  **************************************************************************
+  * @file     at32f423_usb.h
+  * @brief    at32f423 usb header file
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __AT32F423_USB_H
+#define __AT32F423_USB_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "at32f423.h"
+
+/** @addtogroup AT32F423_periph_driver
+  * @{
+  */
+
+/** @addtogroup USB
+  * @{
+  */
+
+/** @defgroup USB_global_interrupts_definition
+  * @brief usb global interrupt mask
+  * @{
+  */
+
+#define USB_OTG_MODEMIS_INT              ((uint32_t)0x00000002) /*!< usb otg mode mismatch interrupt */
+#define USB_OTG_OTGINT_INT               ((uint32_t)0x00000004) /*!< usb otg interrupt */
+#define USB_OTG_SOF_INT                  ((uint32_t)0x00000008) /*!< usb otg sof interrupt */
+#define USB_OTG_RXFLVL_INT               ((uint32_t)0x00000010) /*!< usb otg receive fifo non-empty interrupt */
+#define USB_OTG_NPTXFEMP_INT             ((uint32_t)0x00000020) /*!< usb otg non-periodic tx fifo empty interrupt */
+#define USB_OTG_GINNAKEFF_INT            ((uint32_t)0x00000040) /*!< usb otg global non-periodic in nak effective interrupt */
+#define USB_OTG_GOUTNAKEFF_INT           ((uint32_t)0x00000080) /*!< usb otg global out nak effective interrupt */
+#define USB_OTG_ERLYSUSP_INT             ((uint32_t)0x00000400) /*!< usb otg early suspend interrupt */
+#define USB_OTG_USBSUSP_INT              ((uint32_t)0x00000800) /*!< usb otg suspend interrupt */
+#define USB_OTG_USBRST_INT               ((uint32_t)0x00001000) /*!< usb otg reset interrupt */
+#define USB_OTG_ENUMDONE_INT             ((uint32_t)0x00002000) /*!< usb otg enumeration done interrupt */
+#define USB_OTG_ISOOUTDROP_INT           ((uint32_t)0x00004000) /*!< usb otg isochronous out packet dropped interrut */
+#define USB_OTG_EOPF_INT                 ((uint32_t)0x00008000) /*!< usb otg eop interrupt */
+#define USB_OTG_IEPT_INT                 ((uint32_t)0x00040000) /*!< usb otg in endpoint interrupt */
+#define USB_OTG_OEPT_INT                 ((uint32_t)0x00080000) /*!< usb otg out endpoint interrupt */
+#define USB_OTG_INCOMISOIN_INT           ((uint32_t)0x00100000) /*!< usb otg incomplete isochronous in transfer interrupt */
+#define USB_OTG_INCOMPIP_INCOMPISOOUT_INT ((uint32_t)0x00200000) /*!< usb otg incomplete periodic transfer/isochronous out interrupt */
+#define USB_OTG_PRT_INT                  ((uint32_t)0x01000000) /*!< usb otg host port interrupt */
+#define USB_OTG_HCH_INT                  ((uint32_t)0x02000000) /*!< usb otg host channel interrupt */
+#define USB_OTG_PTXFEMP_INT              ((uint32_t)0x04000000) /*!< usb otg periodic txfifo empty interrupt */
+#define USB_OTG_CONIDSCHG_INT            ((uint32_t)0x10000000) /*!< usb otg connector id status change interrupt */
+#define USB_OTG_DISCON_INT               ((uint32_t)0x20000000) /*!< usb otg disconnect detected interrupt */
+#define USB_OTG_WKUP_INT                 ((uint32_t)0x80000000) /*!< usb otg wakeup interrupt */
+
+/**
+  * @}
+  */
+
+/** @defgroup USB_global_interrupt_flags_definition
+  * @brief usb global interrupt flag
+  * @{
+  */
+
+#define USB_OTG_CURMODE                  ((uint32_t)0x00000001) /*!< usb otg current mode */
+#define USB_OTG_MODEMIS_FLAG             ((uint32_t)0x00000002) /*!< usb otg mode mismatch flag */
+#define USB_OTG_OTGINT_FLAG              ((uint32_t)0x00000004) /*!< usb otg flag */
+#define USB_OTG_SOF_FLAG                 ((uint32_t)0x00000008) /*!< usb otg sof flag */
+#define USB_OTG_RXFLVL_FLAG              ((uint32_t)0x00000010) /*!< usb otg receive fifo non-empty flag */
+#define USB_OTG_NPTXFEMP_FLAG            ((uint32_t)0x00000020) /*!< usb otg non-periodic tx fifo empty flag */
+#define USB_OTG_GINNAKEFF_FLAG           ((uint32_t)0x00000040) /*!< usb otg global non-periodic in nak effective flag */
+#define USB_OTG_GOUTNAKEFF_FLAG          ((uint32_t)0x00000080) /*!< usb otg global out nak effective flag */
+#define USB_OTG_ERLYSUSP_FLAG            ((uint32_t)0x00000400) /*!< usb otg early suspend flag */
+#define USB_OTG_USBSUSP_FLAG             ((uint32_t)0x00000800) /*!< usb otg suspend flag */
+#define USB_OTG_USBRST_FLAG              ((uint32_t)0x00001000) /*!< usb otg reset flag */
+#define USB_OTG_ENUMDONE_FLAG            ((uint32_t)0x00002000) /*!< usb otg enumeration done flag */
+#define USB_OTG_ISOOUTDROP_FLAG          ((uint32_t)0x00004000) /*!< usb otg isochronous out packet dropped flag */
+#define USB_OTG_EOPF_FLAG                ((uint32_t)0x00008000) /*!< usb otg eop flag */
+#define USB_OTG_IEPT_FLAG                ((uint32_t)0x00040000) /*!< usb otg in endpoint flag */
+#define USB_OTG_OEPT_FLAG                ((uint32_t)0x00080000) /*!< usb otg out endpoint flag */
+#define USB_OTG_INCOMISOIN_FLAG          ((uint32_t)0x00100000) /*!< usb otg incomplete isochronous in transfer flag */
+#define USB_OTG_INCOMPIP_INCOMPISOOUT_FLAG   ((uint32_t)0x00200000) /*!< usb otg incomplete periodic transfer/isochronous out flag */
+#define USB_OTG_PRT_FLAG                 ((uint32_t)0x01000000) /*!< usb otg host port flag */
+#define USB_OTG_HCH_FLAG                 ((uint32_t)0x02000000) /*!< usb otg host channel flag */
+#define USB_OTG_PTXFEMP_FLAG             ((uint32_t)0x04000000) /*!< usb otg periodic txfifo empty flag */
+#define USB_OTG_CONIDSCHG_FLAG           ((uint32_t)0x10000000) /*!< usb otg connector id status change flag */
+#define USB_OTG_DISCON_FLAG              ((uint32_t)0x20000000) /*!< usb otg disconnect detected flag */
+#define USB_OTG_WKUP_FLAG                ((uint32_t)0x80000000) /*!< usb otg wakeup flag */
+
+/**
+  * @}
+  */
+
+
+/** @defgroup USB_global_setting_definition
+  * @brief usb global setting
+  * @{
+  */
+
+/**
+  * @brief usb turnaround time
+  */
+#define USB_TRDTIM_8                     0x9 /*!< usb turn around time 8 */
+#define USB_TRDTIM_16                    0x5 /*!< usb turn around time 16 */
+
+/**
+  * @brief usb receive status
+  */
+#define USB_OTG_GRXSTSP_EPTNUM           ((uint32_t)0x0000000F) /*!< usb device receive packet endpoint number*/
+#define USB_OTG_GRXSTSP_CHNUM            ((uint32_t)0x0000000F) /*!< usb host receive packet channel number*/
+#define USB_OTG_GRXSTSP_BCNT             ((uint32_t)0x00007FF0) /*!< usb receive packet byte count */
+#define USB_OTG_GRXSTSP_DPID             ((uint32_t)0x00018000) /*!< usb receive packet pid */
+#define USB_OTG_GRXSTSP_PKTSTS           ((uint32_t)0x001E0000) /*!< usb receive packet status */
+
+/**
+  * @brief usb host packet status
+  */
+#define PKTSTS_IN_DATA_PACKET_RECV       0x2 /*!< usb host in data packet received */
+#define PKTSTS_IN_TRANSFER_COMPLETE      0x3 /*!< usb host in transfer completed */
+#define PKTSTS_DATA_BIT_ERROR            0x5 /*!< usb host data toggle error */
+#define PKTSTS_CHANNEL_STOP              0x7 /*!< usb host channel halted */
+
+/**
+  * @brief usb device  packet status
+  */
+#define USB_OUT_STS_NAK                  0x1 /*!< usb device global out nak */
+#define USB_OUT_STS_DATA                 0x2 /*!< usb device out data packet received */
+#define USB_OUT_STS_COMP                 0x3 /*!< usb device out transfer completed */
+#define USB_SETUP_STS_COMP               0x4 /*!< usb device setup transcation completed */
+#define USB_SETUP_STS_DATA               0x6 /*!< usb device setup data packet received */
+
+/**
+  * @}
+  */
+
+/** @defgroup USB_host_config_definition
+  * @{
+  */
+
+/**
+  * @brief usb host phy clock
+  */
+#define USB_HCFG_CLK_60M                 0 /*!< usb host phy clock 60mhz */
+#define USB_HCFG_CLK_48M                 1 /*!< usb host phy clock 48mhz */
+#define USB_HCFG_CLK_6M                  2 /*!< usb host phy clock 6mhz */
+
+/**
+  * @brief usb host port status
+  */
+#define USB_OTG_HPRT_PRTCONSTS           ((uint32_t)0x00000001) /*!< usb host port connect status */
+#define USB_OTG_HPRT_PRTCONDET           ((uint32_t)0x00000002) /*!< usb host port connect detected */
+#define USB_OTG_HPRT_PRTENA              ((uint32_t)0x00000004) /*!< usb host port enable */
+#define USB_OTG_HPRT_PRTENCHNG           ((uint32_t)0x00000008) /*!< usb host port enable/disable change */
+#define USB_OTG_HPRT_PRTOVRCACT          ((uint32_t)0x00000010) /*!< usb host port overcurrent active */
+#define USB_OTG_HPRT_PRTOVRCCHNG         ((uint32_t)0x00000020) /*!< usb host port overcurrent change */
+#define USB_OTG_HPRT_PRTRES              ((uint32_t)0x00000040) /*!< usb host port resume */
+#define USB_OTG_HPRT_PRTSUSP             ((uint32_t)0x00000080) /*!< usb host port suspend */
+#define USB_OTG_HPRT_PRTRST              ((uint32_t)0x00000100) /*!< usb host port reset */
+#define USB_OTG_HPRT_PRTLNSTS            ((uint32_t)0x00000C00) /*!< usb host port line status */
+#define USB_OTG_HPRT_PRTPWR              ((uint32_t)0x00001000) /*!< usb host port power */
+#define USB_OTG_HPRT_PRTSPD              ((uint32_t)0x00060000) /*!< usb host port speed */
+
+/**
+  * @brief usb port speed
+  */
+#define USB_PRTSPD_HIGH_SPEED            0 /*!< usb host port high speed */
+#define USB_PRTSPD_FULL_SPEED            1 /*!< usb host port full speed */
+#define USB_PRTSPD_LOW_SPEED             2 /*!< usb host port low speed */
+
+/**
+  * @brief usb host register hcchar bit define
+  */
+#define USB_OTG_HCCHAR_MPS               ((uint32_t)0x000007FF) /*!< channel maximum packet size */
+#define USB_OTG_HCCHAR_EPTNUM            ((uint32_t)0x00007800) /*!< endpoint number */
+#define USB_OTG_HCCHAR_EPTDIR            ((uint32_t)0x00008000) /*!< endpoint direction */
+#define USB_OTG_HCCHAR_LSPDDEV           ((uint32_t)0x00020000) /*!< low speed device */
+#define USB_OTG_HCCHAR_EPTYPE            ((uint32_t)0x000C0000) /*!< endpoint type */
+#define USB_OTG_HCCHAR_MC                ((uint32_t)0x00300000) /*!< multi count */
+#define USB_OTG_HCCHAR_DEVADDR           ((uint32_t)0x1FC00000) /*!< device address */
+#define USB_OTG_HCCHAR_ODDFRM            ((uint32_t)0x20000000) /*!< odd frame */
+#define USB_OTG_HCCHAR_CHDIS             ((uint32_t)0x40000000) /*!< channel disable */
+#define USB_OTG_HCCHAR_CHENA             ((uint32_t)0x80000000) /*!< channel enable */
+
+/**
+  * @brief usb host register hctsiz bit define
+  */
+#define USB_OTG_HCTSIZ_XFERSIZE          ((uint32_t)0x0007FFFF) /*!< channel transfer size */
+#define USB_OTG_HCTSIZ_PKTCNT            ((uint32_t)0x1FF80000) /*!< channel packet count */
+#define USB_OTG_HCTSIZ_PID               ((uint32_t)0x60000000) /*!< channel pid */
+
+/**
+  * @brief usb host channel interrupt mask
+  */
+#define USB_OTG_HC_XFERCM_INT            ((uint32_t)0x00000001) /*!< channel transfer complete interrupt */
+#define USB_OTG_HC_CHHLTDM_INT           ((uint32_t)0x00000002) /*!< channel halted interrupt */
+#define USB_OTG_HC_STALLM_INT            ((uint32_t)0x00000008) /*!< channel stall interrupt */
+#define USB_OTG_HC_NAKM_INT              ((uint32_t)0x00000010) /*!< channel nak interrupt */
+#define USB_OTG_HC_ACKM_INT              ((uint32_t)0x00000020) /*!< channel ack interrupt */
+#define USB_OTG_HC_NYETM_INT             ((uint32_t)0x00000040) /*!< channel nyet interrupt */
+#define USB_OTG_HC_XACTERRM_INT          ((uint32_t)0x00000080) /*!< channel transaction error interrupt */
+#define USB_OTG_HC_BBLERRM_INT           ((uint32_t)0x00000100) /*!< channel babble error interrupt */
+#define USB_OTG_HC_FRMOVRRUN_INT         ((uint32_t)0x00000200) /*!< channel frame overrun interrupt */
+#define USB_OTG_HC_DTGLERRM_INT          ((uint32_t)0x00000400) /*!< channel data toggle interrupt */
+
+/**
+  * @brief usb host channel interrupt flag
+  */
+#define USB_OTG_HC_XFERC_FLAG            ((uint32_t)0x00000001) /*!< channel transfer complete flag */
+#define USB_OTG_HC_CHHLTD_FLAG           ((uint32_t)0x00000002) /*!< channel halted flag */
+#define USB_OTG_HC_STALL_FLAG            ((uint32_t)0x00000008) /*!< channel stall flag */
+#define USB_OTG_HC_NAK_FLAG              ((uint32_t)0x00000010) /*!< channel nak flag */
+#define USB_OTG_HC_ACK_FLAG              ((uint32_t)0x00000020) /*!< channel ack flag */
+#define USB_OTG_HC_NYET_FLAG             ((uint32_t)0x00000040) /*!< channel nyet flag */
+#define USB_OTG_HC_XACTERR_FLAG          ((uint32_t)0x00000080) /*!< channel transaction error flag */
+#define USB_OTG_HC_BBLERR_FLAG           ((uint32_t)0x00000100) /*!< channel babble error flag */
+#define USB_OTG_HC_FRMOVRRUN_FLAG        ((uint32_t)0x00000200) /*!< channel frame overrun flag */
+#define USB_OTG_HC_DTGLERR_FLAG          ((uint32_t)0x00000400) /*!< channel data toggle flag */
+
+/**
+  * @}
+  */
+
+
+/** @defgroup USB_device_config_definition
+  * @{
+  */
+/**
+  * @brief usb device periodic frame interval
+  */
+typedef enum
+{
+  DCFG_PERFRINT_80                       = 0x00, /*!< periodic frame interval 80% */
+  DCFG_PERFRINT_85                       = 0x01, /*!< periodic frame interval 85% */
+  DCFG_PERFRINT_90                       = 0x02, /*!< periodic frame interval 90% */
+  DCFG_PERFRINT_95                       = 0x03  /*!< periodic frame interval 95% */
+} dcfg_perfrint_type;
+
+
+/**
+  * @brief usb device full speed
+  */
+#define USB_DCFG_FULL_SPEED              3 /*!< device full speed */
+
+/**
+  * @brief usb device ctrl define
+  */
+#define USB_OTG_DCTL_RWKUPSIG            ((uint32_t)0x00000001) /*!< usb device remote wakeup signaling */
+#define USB_OTG_DCTL_SFTDISCON           ((uint32_t)0x00000002) /*!< usb device soft disconnect */
+#define USB_OTG_DCTL_GNPINNAKSTS         ((uint32_t)0x00000004) /*!< usb device global non-periodic in nak status */
+#define USB_OTG_DCTL_GOUTNAKSTS          ((uint32_t)0x00000008) /*!< usb device global out nak status */
+#define USB_OTG_DCTL_SGNPINNAK           ((uint32_t)0x00000080) /*!< usb device set global non-periodic in nak */
+#define USB_OTG_DCTL_CGNPINNAK           ((uint32_t)0x00000100) /*!< usb device clear global non-periodic in nak */
+#define USB_OTG_DCTL_SGOUTNAK            ((uint32_t)0x00000200) /*!< usb device set global out nak status */
+#define USB_OTG_DCTL_CGOUTNAK            ((uint32_t)0x00000400) /*!< usb device clear global out nak status */
+#define USB_OTG_DCTL_PWROPRGDNE          ((uint32_t)0x00000800) /*!< usb device power on programming done */
+
+/**
+  * @brief usb device in endpoint flag
+  */
+#define USB_OTG_DIEPINT_XFERC_FLAG       ((uint32_t)0x00000001) /*!< usb device in transfer completed flag */
+#define USB_OTG_DIEPINT_EPTDISD_FLAG     ((uint32_t)0x00000002) /*!< usb device endpoint disable flag */
+#define USB_OTG_DIEPINT_TIMEOUT_FLAG     ((uint32_t)0x00000008) /*!< usb device in timeout */
+#define USB_OTG_DIEPINT_INTKNTXFEMP_FLAG ((uint32_t)0x00000010) /*!< usb device in token received when tx fifo is empty flag */
+#define USB_OTG_DIEPINT_INEPTNAK_FLAG    ((uint32_t)0x00000040) /*!< usb device in endpoint nak effective flag */
+#define USB_OTG_DIEPINT_TXFEMP_FLAG      ((uint32_t)0x00000080) /*!< usb device transmit fifo empty flag */
+
+/**
+  * @brief usb device out endpoint flag
+  */
+#define USB_OTG_DOEPINT_XFERC_FLAG       ((uint32_t)0x00000001) /*!< usb device out transfer completed flag */
+#define USB_OTG_DOEPINT_EPTDISD_FLAG     ((uint32_t)0x00000002) /*!< usb device endpoint disable flag */
+#define USB_OTG_DOEPINT_SETUP_FLAG       ((uint32_t)0x00000008) /*!< usb device setup flag */
+#define USB_OTG_DOEPINT_OUTTEPD_FLAG     ((uint32_t)0x00000010) /*!< usb device out token recevied when endpoint disable flag */
+#define USB_OTG_DOEPINT_B2BSTUP_FLAG     ((uint32_t)0x00000040) /*!< back-to-back setup packets received */
+
+/**
+  * @brief usb device in endpoint fifo space mask
+  */
+#define USB_OTG_DTXFSTS_INEPTFSAV        ((uint32_t)0x0000FFFF) /*!< usb device in endpoint tx fifo space avail */
+
+/**
+  * @brief endpoint0 maximum packet size
+  */
+#define USB_EPT0_MPS_64                  0 /*!< usb device endpoint 0 maximum packet size 64byte */
+#define USB_EPT0_MPS_32                  1 /*!< usb device endpoint 0 maximum packet size 32byte */
+#define USB_EPT0_MPS_16                  2 /*!< usb device endpoint 0 maximum packet size 16byte */
+#define USB_EPT0_MPS_8                   3 /*!< usb device endpoint 0 maximum packet size 8byte */
+
+/**
+  * @}
+  */
+
+/**
+  * @brief otg fifo size (word)
+  */
+#define OTG_FIFO_SIZE                    320 /*!< otg usb total fifo size */
+
+/**
+  * @brief otg host max buffer length (byte)
+  */
+#define USB_MAX_DATA_LENGTH              0x200 /*!< usb host maximum buffer size */
+
+#define OTGFS_USB_GLOBAL
+#define OTGFS_USB_DEVICE
+#define OTGFS_USB_HOST
+
+/** @defgroup USB_exported_enum_types
+  * @{
+  */
+
+/**
+  * @brief usb mode define(device, host, drd)
+  */
+typedef enum
+{
+  OTG_DEVICE_MODE, /*!< usb device mode */
+  OTG_HOST_MODE,   /*!< usb host mode */
+  OTG_DRD_MODE     /*!< usb drd mode */
+} otg_mode_type;
+
+/**
+  * @brief endpoint type define
+  */
+typedef enum
+{
+  EPT_CONTROL_TYPE                       = 0x00, /*!< usb endpoint type control */
+  EPT_ISO_TYPE                           = 0x01, /*!< usb endpoint type iso */
+  EPT_BULK_TYPE                          = 0x02, /*!< usb endpoint type bulk */
+  EPT_INT_TYPE                           = 0x03  /*!< usb endpoint type interrupt */
+} endpoint_trans_type;
+
+/**
+  * @brief usb endpoint number define type
+  */
+typedef enum
+{
+  USB_EPT0                               = 0x00, /*!< usb endpoint 0 */
+  USB_EPT1                               = 0x01, /*!< usb endpoint 1 */
+  USB_EPT2                               = 0x02, /*!< usb endpoint 2 */
+  USB_EPT3                               = 0x03, /*!< usb endpoint 3 */
+  USB_EPT4                               = 0x04, /*!< usb endpoint 4 */
+  USB_EPT5                               = 0x05, /*!< usb endpoint 5 */
+  USB_EPT6                               = 0x06, /*!< usb endpoint 6 */
+  USB_EPT7                               = 0x07  /*!< usb endpoint 7 */
+} usb_endpoint_number_type;
+
+/**
+  * @brief usb endpoint max num define
+  */
+#ifndef USB_EPT_MAX_NUM
+#define USB_EPT_MAX_NUM                   8  /*!< usb device support endpoint number */
+#endif
+/**
+  * @brief usb channel max num define
+  */
+#ifndef USB_HOST_CHANNEL_NUM
+#define USB_HOST_CHANNEL_NUM             16 /*!< usb host support channel number */
+#endif
+
+/**
+  * @brief endpoint trans dir type
+  */
+typedef enum
+{
+  EPT_DIR_IN                             = 0x00, /*!< usb transfer direction in */
+  EPT_DIR_OUT                            = 0x01  /*!< usb transfer direction out */
+} endpoint_dir_type;
+
+/**
+  * @brief otgfs1 and otgfs2 select type
+  */
+typedef enum
+{
+  USB_OTG1_ID, /*!< usb otg 1 id */
+  USB_OTG2_ID  /*!< usb otg 2 id */
+} otg_id_type;
+
+/**
+  * @brief usb clock select
+  */
+typedef enum
+{
+  USB_CLK_HICK,  /*!< usb clock use hick */
+  USB_CLK_HEXT   /*!< usb clock use hext */
+}usb_clk48_s;
+
+/**
+  * @}
+  */
+
+
+
+/** @defgroup USB_exported_types
+  * @{
+  */
+
+/**
+  * @brief  usb endpoint infomation structure definition
+  */
+typedef struct
+{
+  uint8_t                                eptn;                        /*!< endpoint register number (0~7) */
+  uint8_t                                ept_address;                 /*!< endpoint address */
+  uint8_t                                inout;                       /*!< endpoint dir EPT_DIR_IN or EPT_DIR_OUT */
+  uint8_t                                trans_type;                  /*!< endpoint type:
+                                                                         EPT_CONTROL_TYPE, EPT_BULK_TYPE, EPT_INT_TYPE, EPT_ISO_TYPE*/
+  uint16_t                               tx_addr;                     /*!< endpoint tx buffer offset address */
+  uint16_t                               rx_addr;                     /*!< endpoint rx buffer offset address */
+  uint32_t                               maxpacket;                   /*!< endpoint max packet*/
+  uint8_t                                is_double_buffer;            /*!< endpoint double buffer flag */
+  uint8_t                                stall;                       /*!< endpoint is stall state */
+  uint32_t                               status;
+
+  /* transmission buffer and count */
+  uint8_t                                *trans_buf;                  /*!< endpoint transmission buffer */
+  uint32_t                               total_len;                   /*!< endpoint transmission lengtg */
+  uint32_t                               trans_len;                   /*!< endpoint transmission length*/
+
+  uint32_t                               last_len;                    /*!< last transfer length */
+  uint32_t                               rem0_len;                    /*!< rem transfer length */
+  uint32_t                               ept0_slen;                   /*!< endpoint 0 transfer sum length */
+} usb_ept_info;
+
+
+/**
+  * @brief  usb host channel infomation structure definition
+  */
+typedef struct
+{
+  uint8_t                                ch_num;                      /*!< host channel number */
+  uint8_t                                address;                     /*!< device address */
+  uint8_t                                dir;                         /*!< transmission direction */
+  uint8_t                                ept_num;                     /*!< device endpoint number */
+  uint8_t                                ept_type;                    /*!< channel transmission type */
+  uint32_t                               maxpacket;                   /*!< support max packet size */
+  uint8_t                                data_pid;                    /*!< data pid */
+  uint8_t                                speed;                       /*!< usb speed */
+  uint8_t                                stall;                       /*!< channel stall flag */
+  uint32_t                               status;                      /*!< channel status */
+  uint32_t                               state;                       /*!< channel state */
+  uint32_t                               urb_sts;                     /*!< usb channel request block state */
+
+  uint8_t                                toggle_in;                   /*!< channel in transfer toggle */
+  uint8_t                                toggle_out;                  /*!< channel out transfer toggle */
+
+  /* transmission buffer and count */
+  uint8_t                                *trans_buf;                  /* host channel buffer */
+  uint32_t                               trans_len;                   /* host channel transmission len */
+  uint32_t                               trans_count;                 /* host channel transmission count*/
+} usb_hch_type;
+
+
+typedef struct
+{
+  /**
+  * @brief otgfs control and status register, offset:0x00
+  */
+  union
+  {
+    __IO uint32_t gotgctrl;
+    struct
+    {
+      __IO uint32_t reserved1                : 16; /* [15:0] */
+      __IO uint32_t cidsts                   : 1; /* [16] */
+      __IO uint32_t reserved2                : 4; /* [20:17] */
+      __IO uint32_t curmod                   : 1; /* [21] */
+      __IO uint32_t reserved3                : 10; /* [31:22] */
+    } gotgctrl_bit;
+  };
+
+  /**
+  * @brief otgfs interrupt register, offset:0x04
+  */
+  union
+  {
+    __IO uint32_t gotgint;
+    struct
+    {
+      __IO uint32_t reserved1                : 2; /* [1:0] */
+      __IO uint32_t sesenddet                : 1; /* [2] */
+      __IO uint32_t reserved2                : 29; /* [31:3] */
+
+    } gotgint_bit;
+  };
+
+  /**
+  * @brief otgfs gahbcfg configuration register, offset:0x08
+  */
+  union
+  {
+    __IO uint32_t gahbcfg;
+    struct
+    {
+      __IO uint32_t glbintmsk                : 1; /* [0] */
+      __IO uint32_t reserved1                : 6; /* [6:1] */
+      __IO uint32_t nptxfemplvl              : 1; /* [7] */
+      __IO uint32_t ptxfemplvl               : 1; /* [8] */
+      __IO uint32_t reserved2                : 23; /* [31:9] */
+    } gahbcfg_bit;
+  };
+
+  /**
+  * @brief otgfs usb configuration register, offset:0x0C
+  */
+  union
+  {
+    __IO uint32_t gusbcfg;
+    struct
+    {
+      __IO uint32_t toutcal                  : 3; /* [2:0] */
+      __IO uint32_t reserved1                : 7; /* [9:3] */
+      __IO uint32_t usbtrdtim                : 4; /* [13:10] */
+      __IO uint32_t reserved2                : 15; /* [28:14] */
+      __IO uint32_t fhstmode                 : 1; /* [29] */
+      __IO uint32_t fdevmode                 : 1; /* [30] */
+      __IO uint32_t cotxpkt                  : 1; /* [31] */
+    } gusbcfg_bit;
+  };
+
+  /**
+  * @brief otgfs reset register, offset:0x10
+  */
+  union
+  {
+    __IO uint32_t grstctl;
+    struct
+    {
+      __IO uint32_t csftrst                  : 1; /* [0] */
+      __IO uint32_t piusftrst                : 1; /* [1] */
+      __IO uint32_t frmcntrst                : 1; /* [2] */
+      __IO uint32_t reserved1                : 1; /* [3] */
+      __IO uint32_t rxfflsh                  : 1; /* [4] */
+      __IO uint32_t txfflsh                  : 1; /* [5] */
+      __IO uint32_t txfnum                   : 5; /* [10:6] */
+      __IO uint32_t reserved2                : 20; /* [30:11] */
+      __IO uint32_t ahbidle                  : 1; /* [31] */
+    } grstctl_bit;
+  };
+
+  /**
+  * @brief otgfs core interrupt register, offset:0x14
+  */
+  union
+  {
+    __IO uint32_t gintsts;
+    struct
+    {
+      __IO uint32_t curmode                  : 1; /* [0] */
+      __IO uint32_t modemis                  : 1; /* [1] */
+      __IO uint32_t otgint                   : 1; /* [2] */
+      __IO uint32_t sof                      : 1; /* [3] */
+      __IO uint32_t rxflvl                   : 1; /* [4] */
+      __IO uint32_t nptxfemp                 : 1; /* [5] */
+      __IO uint32_t ginnakeff                : 1; /* [6] */
+      __IO uint32_t goutnakeff               : 1; /* [7] */
+      __IO uint32_t reserved1                : 2; /* [9:8]] */
+      __IO uint32_t erlysusp                 : 1; /* [10] */
+      __IO uint32_t usbsusp                  : 1; /* [11] */
+      __IO uint32_t usbrst                   : 1; /* [12] */
+      __IO uint32_t enumdone                 : 1; /* [13] */
+      __IO uint32_t isooutdrop               : 1; /* [14] */
+      __IO uint32_t eopf                     : 1; /* [15] */
+      __IO uint32_t reserved2                : 2; /* [17:16]] */
+      __IO uint32_t ieptint                  : 1; /* [18] */
+      __IO uint32_t oeptint                  : 1; /* [19] */
+      __IO uint32_t incompisoin              : 1; /* [20] */
+      __IO uint32_t incompip_incompisoout    : 1; /* [21] */
+      __IO uint32_t reserved3                : 2; /* [23:22] */
+      __IO uint32_t prtint                   : 1; /* [24] */
+      __IO uint32_t hchint                   : 1; /* [25] */
+      __IO uint32_t ptxfemp                  : 1; /* [26] */
+      __IO uint32_t reserved4                : 1; /* [27] */
+      __IO uint32_t conidschg                : 1; /* [28] */
+      __IO uint32_t disconint                : 1; /* [29] */
+      __IO uint32_t reserved5                : 1; /* [30] */
+      __IO uint32_t wkupint                  : 1; /* [31] */
+    } gintsts_bit;
+  };
+
+  /**
+  * @brief otgfs interrupt mask register, offset:0x18
+  */
+  union
+  {
+    __IO uint32_t gintmsk;
+    struct
+    {
+      __IO uint32_t reserved1                : 1; /* [0] */
+      __IO uint32_t modemismsk               : 1; /* [1] */
+      __IO uint32_t otgintmsk                : 1; /* [2] */
+      __IO uint32_t sofmsk                   : 1; /* [3] */
+      __IO uint32_t rxflvlmsk                : 1; /* [4] */
+      __IO uint32_t nptxfempmsk              : 1; /* [5] */
+      __IO uint32_t ginnakeffmsk             : 1; /* [6] */
+      __IO uint32_t goutnakeffmsk            : 1; /* [7] */
+      __IO uint32_t reserved2                : 2; /* [9:8]] */
+      __IO uint32_t erlysuspmsk              : 1; /* [10] */
+      __IO uint32_t usbsuspmsk               : 1; /* [11] */
+      __IO uint32_t usbrstmsk                : 1; /* [12] */
+      __IO uint32_t enumdonemsk              : 1; /* [13] */
+      __IO uint32_t isooutdropmsk            : 1; /* [14] */
+      __IO uint32_t eopfmsk                  : 1; /* [15] */
+      __IO uint32_t reserved3                : 2; /* [17:16]] */
+      __IO uint32_t ieptintmsk               : 1; /* [18] */
+      __IO uint32_t oeptintmsk               : 1; /* [19] */
+      __IO uint32_t incompisoinmsk           : 1; /* [20] */
+      __IO uint32_t incompip_incompisooutmsk : 1; /* [21] */
+      __IO uint32_t reserved4                : 2; /* [23:22] */
+      __IO uint32_t prtintmsk                : 1; /* [24] */
+      __IO uint32_t hchintmsk                : 1; /* [25] */
+      __IO uint32_t ptxfempmsk               : 1; /* [26] */
+      __IO uint32_t reserved5                : 1; /* [27] */
+      __IO uint32_t conidschgmsk             : 1; /* [28] */
+      __IO uint32_t disconintmsk             : 1; /* [29] */
+      __IO uint32_t reserved6                : 1; /* [30] */
+      __IO uint32_t wkupintmsk               : 1; /* [31] */
+    } gintmsk_bit;
+  };
+
+   /**
+  * @brief otgfs rx status debug read register, offset:0x1C
+  */
+  union
+  {
+    __IO uint32_t grxstsr;
+    struct
+    {
+      __IO uint32_t eptnum                   : 4; /* [3:0] */
+      __IO uint32_t bcnt                     : 11; /* [14:4] */
+      __IO uint32_t dpid                     : 2; /* [16:15] */
+      __IO uint32_t pktsts                   : 4; /* [20:17] */
+      __IO uint32_t fn                       : 4; /* [24:21] */
+      __IO uint32_t reserved1                : 7; /* [31:25] */
+    } grxstsr_bit;
+  };
+
+  /**
+  * @brief otgfs rx status read and pop register, offset:0x20
+  */
+  union
+  {
+    __IO uint32_t grxstsp;
+    struct
+    {
+      __IO uint32_t chnum                    : 4; /* [3:0] */
+      __IO uint32_t bcnt                     : 11; /* [14:4] */
+      __IO uint32_t dpid                     : 2; /* [16:15] */
+      __IO uint32_t pktsts                   : 4; /* [20:17] */
+      __IO uint32_t reserved1                : 11; /* [31:21] */
+    } grxstsp_bit;
+  };
+
+  /**
+  * @brief otgfs rx fifo size register, offset:0x24
+  */
+  union
+  {
+    __IO uint32_t grxfsiz;
+    struct
+    {
+      __IO uint32_t rxfdep                   : 16; /* [15:0] */
+      __IO uint32_t reserved1                : 16; /* [31:16] */
+    } grxfsiz_bit;
+  };
+
+  /**
+  * @brief otgfs non-periodic and ept0 tx fifo size register, offset:0x28
+  */
+  union
+  {
+    __IO uint32_t gnptxfsiz_ept0tx;
+    struct
+    {
+      __IO uint32_t nptxfstaddr              : 16; /* [15:0] */
+      __IO uint32_t nptxfdep                 : 16; /* [31:16] */
+    } gnptxfsiz_ept0tx_bit;
+  };
+
+  /**
+  * @brief otgfs non-periodic tx fifo request queue status register, offset:0x2C
+  */
+  union
+  {
+    __IO uint32_t gnptxsts;
+    struct
+    {
+      __IO uint32_t nptxfspcavail            : 16; /* [15:0] */
+      __IO uint32_t nptxqspcavail            : 8; /* [23:16] */
+      __IO uint32_t nptxqtop                 : 7; /* [30:24] */
+      __IO uint32_t reserved1                : 1; /* [31]    */
+    } gnptxsts_bit;
+  };
+
+  __IO uint32_t reserved2[2];
+
+  /**
+  * @brief otgfs general core configuration register, offset:0x38
+  */
+  union
+  {
+    __IO uint32_t gccfg;
+    struct
+    {
+      __IO uint32_t reserved1                : 16; /* [15:0] */
+      __IO uint32_t pwrdown                  : 1; /* [16] */
+      __IO uint32_t lp_mode                  : 1; /* [17] */
+      __IO uint32_t reserved2                : 2; /* [19:18] */
+      __IO uint32_t sofouten                 : 1; /* [20] */
+      __IO uint32_t vbusig                   : 1; /* [21] */
+      __IO uint32_t reserved3                : 10; /* [31:22] */
+    } gccfg_bit;
+  };
+
+  /**
+  * @brief otgfs core id register, offset:0x3C
+  */
+  union
+  {
+    __IO uint32_t guid;
+    struct
+    {
+      __IO uint32_t userid                 : 32; /* [31:0] */
+    } guid_bit;
+  };
+
+  __IO uint32_t reserved3[48];
+
+  /**
+  * @brief otgfs host periodic tx fifo size register, offset:0x100
+  */
+  union
+  {
+    __IO uint32_t hptxfsiz;
+    struct
+    {
+      __IO uint32_t ptxfstaddr               : 16; /* [15:0] */
+      __IO uint32_t ptxfsize                 : 16; /* [31:16] */
+    } hptxfsiz_bit;
+  };
+
+   /**
+  * @brief otgfs host periodic tx fifo size register, offset:0x100
+  */
+  union
+  {
+    __IO uint32_t dieptxfn[7];
+    struct
+    {
+      __IO uint32_t ineptxfstaddr            : 16; /* [15:0] */
+      __IO uint32_t ineptxfdep               : 16; /* [31:16] */
+    } dieptxfn_bit[7];
+  };
+} otg_global_type;
+
+
+typedef struct
+{
+  /**
+  * @brief otgfs host mode configuration register, offset:0x400
+  */
+  union
+  {
+    __IO uint32_t hcfg;
+    struct
+    {
+      __IO uint32_t fslspclksel              : 2; /* [1:0] */
+      __IO uint32_t fslssupp                 : 1; /* [2] */
+      __IO uint32_t reserved1                : 29; /* [31:3] */
+    } hcfg_bit;
+  };
+
+  /**
+  * @brief otgfs host frame interval register, offset:0x404
+  */
+  union
+  {
+    __IO uint32_t hfir;
+    struct
+    {
+      __IO uint32_t frint                   : 16; /* [15:0] */
+      __IO uint32_t reserved1               : 16; /* [31:15] */
+    } hfir_bit;
+  };
+
+  /**
+  * @brief otgfs host frame number and time remaining register, offset:0x408
+  */
+  union
+  {
+    __IO uint32_t hfnum;
+    struct
+    {
+      __IO uint32_t frnum                   : 16; /* [15:0] */
+      __IO uint32_t ftrem                   : 16; /* [31:15] */
+    } hfnum_bit;
+  };
+
+  __IO uint32_t reserved1;
+
+  /**
+  * @brief otgfs host periodic tx fifo request queue register, offset:0x410
+  */
+  union
+  {
+    __IO uint32_t hptxsts;
+    struct
+    {
+      __IO uint32_t ptxfspcavil               : 16; /* [15:0] */
+      __IO uint32_t ptxqspcavil               : 8; /* [23:16] */
+      __IO uint32_t ptxqtop                  : 8; /* [31:24] */
+    } hptxsts_bit;
+  };
+
+  /**
+  * @brief otgfs host all channel interrupt register, offset:0x414
+  */
+  union
+  {
+    __IO uint32_t haint;
+    struct
+    {
+      __IO uint32_t haint                    : 16; /* [15:0] */
+      __IO uint32_t reserved1                : 16; /* [32:16] */
+    } haint_bit;
+  };
+
+  /**
+  * @brief otgfs host all channel interrupt mask register, offset:0x418
+  */
+  union
+  {
+    __IO uint32_t haintmsk;
+    struct
+    {
+      __IO uint32_t haintmsk                 : 16; /* [15:0] */
+      __IO uint32_t reserved1                : 16; /* [32:16] */
+    } haintmsk_bit;
+  };
+
+  __IO uint32_t reserved2[9];
+
+  /**
+  * @brief otgfs host port control and status register, offset:0x440
+  */
+  union
+  {
+    __IO uint32_t hprt;
+    struct
+    {
+      __IO uint32_t prtconsts                : 1; /* [0] */
+      __IO uint32_t prtcondet                : 1; /* [1] */
+      __IO uint32_t prtena                   : 1; /* [2] */
+      __IO uint32_t prtenchng                : 1; /* [3] */
+      __IO uint32_t prtovrcact               : 1; /* [4] */
+      __IO uint32_t prtovrcchng              : 1; /* [5] */
+      __IO uint32_t prtres                   : 1; /* [6] */
+      __IO uint32_t prtsusp                  : 1; /* [7] */
+      __IO uint32_t prtrst                   : 1; /* [8] */
+      __IO uint32_t reserved1                : 1; /* [9] */
+      __IO uint32_t prtlnsts                 : 2; /* [11:10] */
+      __IO uint32_t prtpwr                   : 1; /* [12] */
+      __IO uint32_t prttsctl                 : 4; /* [16:13] */
+      __IO uint32_t prtspd                   : 2; /* [18:17] */
+      __IO uint32_t reserved2                : 13; /* [31:19] */
+
+    } hprt_bit;
+  };
+} otg_host_type;
+
+typedef struct
+{
+  /**
+  * @brief otgfs host channel x characterisic register, offset:0x500
+  */
+  union
+  {
+    __IO uint32_t hcchar;
+    struct
+    {
+      __IO uint32_t mps                      : 11; /* [10:0] */
+      __IO uint32_t eptnum                   : 4; /* [14:11] */
+      __IO uint32_t eptdir                   : 1; /* [15] */
+      __IO uint32_t reserved1                : 1; /* [16] */
+      __IO uint32_t lspddev                  : 1; /* [17] */
+      __IO uint32_t eptype                   : 2; /* [19:18] */
+      __IO uint32_t mc                       : 2; /* [21:20] */
+      __IO uint32_t devaddr                  : 7; /* [28:22] */
+      __IO uint32_t oddfrm                   : 1; /* [29] */
+      __IO uint32_t chdis                    : 1; /* [30] */
+      __IO uint32_t chena                    : 1; /* [31] */
+    } hcchar_bit;
+  };
+
+  /**
+  * @brief otgfs host channel split control register, offset:0x504
+  */
+  union
+  {
+    __IO uint32_t hcsplt;
+    struct
+    {
+      __IO uint32_t prtaddr                  : 7; /* [6:0] */
+      __IO uint32_t hubaddr                  : 7; /* [13:7] */
+      __IO uint32_t xactpos                  : 2; /* [15:14] */
+      __IO uint32_t compsplt                 : 1; /* [16] */
+      __IO uint32_t reserved1                : 14; /* [30:17] */
+      __IO uint32_t spltena                  : 1; /* [31] */
+    } hcsplt_bit;
+  };
+
+  /**
+  * @brief otgfs host channel interrupt register, offset:0x508
+  */
+  union
+  {
+    __IO uint32_t hcint;
+    struct
+    {
+      __IO uint32_t xferc                    : 1; /* [0] */
+      __IO uint32_t chhltd                   : 1; /* [1] */
+      __IO uint32_t reserved1                : 1; /* [2] */
+      __IO uint32_t stall                    : 1; /* [3] */
+      __IO uint32_t nak                      : 1; /* [4] */
+      __IO uint32_t ack                      : 1; /* [5] */
+      __IO uint32_t reserved2                : 1; /* [6] */
+      __IO uint32_t xacterr                  : 1; /* [7] */
+      __IO uint32_t bblerr                   : 1; /* [8] */
+      __IO uint32_t frmovrun                 : 1; /* [9] */
+      __IO uint32_t dtglerr                  : 1; /* [10] */
+      __IO uint32_t reserved3                : 21; /* [31:11] */
+    } hcint_bit;
+  };
+
+  /**
+  * @brief otgfs host channel interrupt mask register, offset:0x50C
+  */
+  union
+  {
+    __IO uint32_t hcintmsk;
+    struct
+    {
+      __IO uint32_t xfercmsk                 : 1; /* [0] */
+      __IO uint32_t chhltdmsk                : 1; /* [1] */
+      __IO uint32_t reserved1                : 1; /* [2] */
+      __IO uint32_t stallmsk                 : 1; /* [3] */
+      __IO uint32_t nakmsk                   : 1; /* [4] */
+      __IO uint32_t ackmsk                   : 1; /* [5] */
+      __IO uint32_t reserved2                : 1; /* [6] */
+      __IO uint32_t xacterrmsk               : 1; /* [7] */
+      __IO uint32_t bblerrmsk                : 1; /* [8] */
+      __IO uint32_t frmovrunmsk              : 1; /* [9] */
+      __IO uint32_t dtglerrmsk               : 1; /* [10] */
+      __IO uint32_t reserved3                : 21; /* [31:11] */
+    } hcintmsk_bit;
+  };
+
+  /**
+  * @brief otgfs host channel transfer size register, offset:0x510
+  */
+  union
+  {
+    __IO uint32_t hctsiz;
+    struct
+    {
+      __IO uint32_t xfersize                 : 19; /* [18:0] */
+      __IO uint32_t pktcnt                   : 10; /* [28:19] */
+      __IO uint32_t pid                      : 2; /* [30:29] */
+      __IO uint32_t reserved1                : 1; /* [31] */
+    } hctsiz_bit;
+  };
+  __IO uint32_t reserved3[3];
+
+}otg_hchannel_type;
+
+
+typedef struct
+{
+  /**
+  * @brief otgfs device configuration register, offset:0x800
+  */
+  union
+  {
+    __IO uint32_t dcfg;
+    struct
+    {
+      __IO uint32_t devspd                   : 2; /* [1:0] */
+      __IO uint32_t nzstsouthshk             : 1; /* [2] */
+      __IO uint32_t reserved1                : 1; /* [3] */
+      __IO uint32_t devaddr                  : 7; /* [10:4] */
+      __IO uint32_t perfrint                 : 2; /* [12:11] */
+      __IO uint32_t reserved2                : 19; /* [31:13] */
+    } dcfg_bit;
+  };
+
+  /**
+  * @brief otgfs device controls register, offset:0x804
+  */
+  union
+  {
+    __IO uint32_t dctl;
+    struct
+    {
+      __IO uint32_t rwkupsig                 : 1; /* [0] */
+      __IO uint32_t sftdiscon                : 1; /* [1] */
+      __IO uint32_t gnpinnaksts              : 1; /* [2] */
+      __IO uint32_t goutnaksts               : 1; /* [3] */
+      __IO uint32_t tstctl                   : 3; /* [6:4] */
+      __IO uint32_t sgnpinak                 : 1; /* [7] */
+      __IO uint32_t cgnpinak                 : 1; /* [8] */
+      __IO uint32_t sgoutnak                 : 1; /* [9] */
+      __IO uint32_t cgoutnak                 : 1; /* [10] */
+      __IO uint32_t pwroprgdne               : 1; /* [11] */
+      __IO uint32_t reserved1                : 20; /* [31:12] */
+    } dctl_bit;
+  };
+
+  /**
+  * @brief otgfs device status register, offset:0x80C
+  */
+  union
+  {
+    __IO uint32_t dsts;
+    struct
+    {
+      __IO uint32_t suspsts                  : 1; /* [0] */
+      __IO uint32_t enumspd                  : 2; /* [2:1] */
+      __IO uint32_t eticerr                  : 1; /* [3] */
+      __IO uint32_t reserved1                : 4; /* [7:4] */
+      __IO uint32_t soffn                    : 14; /* [21:8] */
+      __IO uint32_t reserved2                : 10; /* [31:22] */
+    } dsts_bit;
+  };
+
+   __IO uint32_t reserved1;
+  /**
+  * @brief otgfs device in endpoint general interrupt mask register, offset:0x810
+  */
+  union
+  {
+    __IO uint32_t diepmsk;
+    struct
+    {
+      __IO uint32_t xfercmsk                 : 1; /* [0] */
+      __IO uint32_t eptdismsk                : 1; /* [1] */
+      __IO uint32_t reserved1                : 1; /* [2] */
+      __IO uint32_t timeoutmsk               : 1; /* [3] */
+      __IO uint32_t intkntxfempmsk           : 1; /* [4] */
+      __IO uint32_t intkneptmismsk           : 1; /* [5] */
+      __IO uint32_t ineptnakmsk              : 1; /* [6] */
+      __IO uint32_t reserved2                : 1; /* [7] */
+      __IO uint32_t txfifoudrmsk             : 1; /* [8] */
+      __IO uint32_t bnainmsk                 : 1; /* [9] */
+      __IO uint32_t reserved3                : 22; /* [31:10] */
+    } diepmsk_bit;
+  };
+
+  /**
+  * @brief otgfs device out endpoint general interrupt mask register, offset:0x814
+  */
+  union
+  {
+    __IO uint32_t doepmsk;
+    struct
+    {
+      __IO uint32_t xfercmsk                 : 1; /* [0] */
+      __IO uint32_t eptdismsk                : 1; /* [1] */
+      __IO uint32_t reserved1                : 1; /* [2] */
+      __IO uint32_t setupmsk                 : 1; /* [3] */
+      __IO uint32_t outtepdmsk               : 1; /* [4] */
+      __IO uint32_t reserved2                : 1; /* [5] */
+      __IO uint32_t b2bsetupmsk              : 1; /* [6] */
+      __IO uint32_t reserved3                : 1; /* [7] */
+      __IO uint32_t outperrmsk               : 1; /* [8] */
+      __IO uint32_t bnaoutmsk                : 1; /* [9] */
+      __IO uint32_t reserved4                : 22; /* [31:10] */
+    } doepmsk_bit;
+  };
+
+  /**
+  * @brief otgfs device all endpoint interrupt register, offset:0x818
+  */
+  union
+  {
+    __IO uint32_t daint;
+    struct
+    {
+      __IO uint32_t ineptint                 : 16; /* [15:0] */
+      __IO uint32_t outeptint                : 16; /* [31:16] */
+    } daint_bit;
+  };
+
+  /**
+  * @brief otgfs device all endpoint interrupt mask register, offset:0x81C
+  */
+  union
+  {
+    __IO uint32_t daintmsk;
+    struct
+    {
+      __IO uint32_t ineptmsk                 : 16; /* [15:0] */
+      __IO uint32_t outeptmsk                : 16; /* [31:16] */
+    } daintmsk_bit;
+  };
+
+  __IO uint32_t reserved2[5];
+
+  /**
+  * @brief otgfs device in endpoint fifo empty interrupt mask register, offset:0x834
+  */
+  union
+  {
+    __IO uint32_t diepempmsk;
+    struct
+    {
+      __IO uint32_t ineptxfemsk              : 16; /* [15:0] */
+      __IO uint32_t reserved1                : 16; /* [31:16] */
+    } diepempmsk_bit;
+  };
+
+} otg_device_type;
+
+typedef struct
+{
+  /**
+  * @brief otgfs device out endpoint control register, offset:0x900
+  */
+  union
+  {
+    __IO uint32_t diepctl;
+    struct
+    {
+      __IO uint32_t mps                      : 11; /* [10:0] */
+      __IO uint32_t reserved1                : 4; /* [14:11] */
+      __IO uint32_t usbacept                 : 1; /* [15] */
+      __IO uint32_t dpid                     : 1; /* [16] */
+      __IO uint32_t naksts                   : 1; /* [17] */
+      __IO uint32_t eptype                   : 2; /* [19:18] */
+      __IO uint32_t reserved2                : 1; /* [20] */
+      __IO uint32_t stall                    : 1; /* [21] */
+      __IO uint32_t txfnum                   : 4; /* [25:22] */
+      __IO uint32_t cnak                     : 1; /* [26] */
+      __IO uint32_t snak                     : 1; /* [27] */
+      __IO uint32_t setd0pid                 : 1; /* [28] */
+      __IO uint32_t setd1pid                 : 1; /* [29] */
+      __IO uint32_t eptdis                   : 1; /* [30] */
+      __IO uint32_t eptena                   : 1; /* [31] */
+    } diepctl_bit;
+  };
+  __IO uint32_t reserved1;
+
+  /**
+  * @brief otgfs device in endpoint interrupt register, offset:0x908
+  */
+  union
+  {
+    __IO uint32_t diepint;
+    struct
+    {
+      __IO uint32_t xferc                    : 1; /* [0] */
+      __IO uint32_t epdisd                   : 1; /* [1] */
+      __IO uint32_t reserved1                : 1; /* [2] */
+      __IO uint32_t timeout                  : 1; /* [3] */
+      __IO uint32_t intkntxfemp              : 1; /* [4] */
+      __IO uint32_t reserved2                : 1; /* [5] */
+      __IO uint32_t ineptnak                 : 1; /* [6] */
+      __IO uint32_t txfemp                   : 1; /* [7] */
+      __IO uint32_t reserved3                : 24; /* [31:8] */
+    } diepint_bit;
+  };
+  __IO uint32_t reserved2;
+
+  /**
+  * @brief otgfs device in endpoint transfer size register, offset:0x910 + endpoint number * 0x20
+  */
+  union
+  {
+    __IO uint32_t dieptsiz;
+    struct
+    {
+      __IO uint32_t xfersize                 : 19; /* [18:0] */
+      __IO uint32_t pktcnt                   : 10; /* [28:19] */
+      __IO uint32_t mc                       : 2; /* [30:29] */
+      __IO uint32_t reserved1                : 1; /* [31] */
+    } dieptsiz_bit;
+  };
+
+  __IO uint32_t reserved3;
+
+  /**
+  * @brief otgfs device in endpoint tx fifo status register, offset:0x918 + endpoint number * 0x20
+  */
+  union
+  {
+    __IO uint32_t dtxfsts;
+    struct
+    {
+      __IO uint32_t ineptxfsav               : 16; /* [15:0] */
+      __IO uint32_t reserved1                : 16; /* [31:16] */
+    } dtxfsts_bit;
+  };
+
+} otg_eptin_type;
+
+typedef struct
+{
+  /**
+  * @brief otgfs device out endpoint control register, offset:0xb00 + endpoint number * 0x20
+  */
+  union
+  {
+    __IO uint32_t doepctl;
+    struct
+    {
+      __IO uint32_t mps                      : 11; /* [10:0] */
+      __IO uint32_t reserved1                : 4; /* [14:11] */
+      __IO uint32_t usbacept                 : 1; /* [15] */
+      __IO uint32_t dpid                     : 1; /* [16] */
+      __IO uint32_t naksts                   : 1; /* [17] */
+      __IO uint32_t eptype                   : 2; /* [19:18] */
+      __IO uint32_t snpm                     : 1; /* [20] */
+      __IO uint32_t stall                    : 1; /* [21] */
+      __IO uint32_t reserved2                : 4; /* [25:22] */
+      __IO uint32_t cnak                     : 1; /* [26] */
+      __IO uint32_t snak                     : 1; /* [27] */
+      __IO uint32_t setd0pid                 : 1; /* [28] */
+      __IO uint32_t setd1pid                 : 1; /* [29] */
+      __IO uint32_t eptdis                   : 1; /* [30] */
+      __IO uint32_t eptena                   : 1; /* [31] */
+    } doepctl_bit;
+  };
+  __IO uint32_t reserved1;
+
+  /**
+  * @brief otgfs device out endpoint interrupt register, offset:0xb08 + endpoint number * 0x20
+  */
+  union
+  {
+    __IO uint32_t doepint;
+    struct
+    {
+      __IO uint32_t xferc                    : 1; /* [0] */
+      __IO uint32_t epdisd                   : 1; /* [1] */
+      __IO uint32_t reserved1                : 1; /* [2] */
+      __IO uint32_t setup                    : 1; /* [3] */
+      __IO uint32_t outtepd                  : 1; /* [4] */
+      __IO uint32_t reserved2                : 1; /* [5] */
+      __IO uint32_t b2pstup                  : 1; /* [6] */
+      __IO uint32_t reserved3                : 25; /* [31:7] */
+    } doepint_bit;
+  };
+  __IO uint32_t reserved2;
+
+  /**
+  * @brief otgfs device out endpoint transfer size register, offset:0xb10 + endpoint number * 0x20
+  */
+  union
+  {
+    __IO uint32_t doeptsiz;
+    struct
+    {
+      __IO uint32_t xfersize                 : 19; /* [18:0] */
+      __IO uint32_t pktcnt                   : 10; /* [28:19] */
+      __IO uint32_t rxdpid_setupcnt          : 2; /* [30:29] */
+      __IO uint32_t reserved1                : 1; /* [31] */
+    } doeptsiz_bit;
+  };
+} otg_eptout_type;
+
+typedef struct
+{
+  /**
+  * @brief otgfs power and clock gating control registers, offset:0xe00
+  */
+  union
+  {
+    __IO uint32_t pcgcctl;
+    struct
+    {
+      __IO uint32_t stoppclk                 : 1; /* [0] */
+      __IO uint32_t reserved1                : 3; /* [3:1] */
+      __IO uint32_t suspendm                 : 1; /* [4] */
+      __IO uint32_t reserved2                : 27; /* [31:5] */
+    } pcgcctl_bit;
+  };
+} otg_pcgcctl_type;
+
+/**
+  * @}
+  */
+
+/** @defgroup USB_exported_functions
+  * @{
+  */
+
+/**
+  * @brief usb host and device offset address
+  */
+#define OTG_HOST_ADDR_OFFSET             0x400  /*!< usb host register offset address */
+#define OTG_HOST_CHANNEL_ADDR_OFFSET     0x500  /*!< usb host channel register offset address */
+#define OTG_DEVICE_ADDR_OFFSET           0x800  /*!< usb device register offset address */
+#define OTG_DEVICE_EPTIN_ADDR_OFFSET     0x900  /*!< usb device endpoint in register offset address */
+#define OTG_DEVICE_EPTOUT_ADDR_OFFSET    0xB00  /*!< usb device endpoint out register offset address */
+#define OTG_PCGCCTL_ADDR_OFFSET          0xE00  /*!< usb power and clock control register offset address */
+#define OTG_FIFO_ADDR_OFFSET             0x1000 /*!< usb fifo offset address */
+
+/**
+  * @brief usb host and device register define
+  */
+#define OTG1_GLOBAL ((otg_global_type *)(OTGFS1_BASE)) /*!< usb otg1 global register */
+#define OTG_PCGCCTL(usbx) ((otg_pcgcctl_type *)((uint32_t)usbx + OTG_PCGCCTL_ADDR_OFFSET))                             /*!< usb power and clock control register */
+#define OTG_DEVICE(usbx) ((otg_device_type *)((uint32_t)usbx + OTG_DEVICE_ADDR_OFFSET))                                /*!< usb device register */
+#define OTG_HOST(usbx) ((otg_host_type *)((uint32_t)usbx + OTG_HOST_ADDR_OFFSET))                                      /*!< usb host register */
+#define USB_CHL(usbx, n) ((otg_hchannel_type *)((uint32_t)usbx + OTG_HOST_CHANNEL_ADDR_OFFSET + n * 0x20))             /*!< usb channel n register */
+#define USB_INEPT(usbx, eptn) ((otg_eptin_type *)((uint32_t)usbx + OTG_DEVICE_EPTIN_ADDR_OFFSET + eptn * 0x20))        /*!< usb device endpoint in register */
+#define USB_OUTEPT(usbx, eptn) ((otg_eptout_type *)((uint32_t)usbx + OTG_DEVICE_EPTOUT_ADDR_OFFSET + eptn * 0x20))     /*!< usb device endpoint out register */
+#define USB_FIFO(usbx, eptn) *(__IO uint32_t *)((uint32_t)usbx + OTG_FIFO_ADDR_OFFSET + eptn * 0x1000)                 /*!< usb fifo address */
+
+
+
+typedef otg_global_type usb_reg_type;
+
+/** @defgroup USB_exported_functions
+  * @{
+  */
+
+#ifdef OTGFS_USB_GLOBAL
+error_status usb_global_reset(otg_global_type *usbx);
+void usb_global_init(otg_global_type *usbx);
+otg_global_type *usb_global_select_core(uint8_t usb_id);
+void usb_flush_tx_fifo(otg_global_type *usbx, uint32_t fifo_num);
+void usb_flush_rx_fifo(otg_global_type *usbx);
+void usb_global_interrupt_enable(otg_global_type *usbx, uint16_t interrupt, confirm_state new_state);
+uint32_t usb_global_get_all_interrupt(otg_global_type *usbx);
+void usb_global_clear_interrupt(otg_global_type *usbx, uint32_t flag);
+void usb_interrupt_enable(otg_global_type *usbx);
+void usb_interrupt_disable(otg_global_type *usbx);
+void usb_set_rx_fifo(otg_global_type *usbx, uint16_t size);
+void usb_set_tx_fifo(otg_global_type *usbx, uint8_t txfifo, uint16_t size);
+void usb_global_set_mode(otg_global_type *usbx, uint32_t mode);
+void usb_global_power_on(otg_global_type *usbx);
+void usb_write_packet(otg_global_type *usbx, uint8_t *pusr_buf, uint16_t num, uint16_t nbytes);
+void usb_read_packet(otg_global_type *usbx, uint8_t *pusr_buf, uint16_t num, uint16_t nbytes);
+void usb_stop_phy_clk(otg_global_type *usbx);
+void usb_open_phy_clk(otg_global_type *usbx);
+#endif
+
+#ifdef OTGFS_USB_DEVICE
+void usb_ept_open(otg_global_type *usbx, usb_ept_info *ept_info);
+void usb_ept_close(otg_global_type *usbx, usb_ept_info *ept_info);
+void usb_ept_stall(otg_global_type *usbx, usb_ept_info *ept_info);
+void usb_ept_clear_stall(otg_global_type *usbx, usb_ept_info *ept_info);
+uint32_t usb_get_all_out_interrupt(otg_global_type *usbx);
+uint32_t usb_get_all_in_interrupt(otg_global_type *usbx);
+uint32_t usb_ept_out_interrupt(otg_global_type *usbx, uint32_t eptn);
+uint32_t usb_ept_in_interrupt(otg_global_type *usbx, uint32_t eptn);
+void usb_ept_out_clear(otg_global_type *usbx, uint32_t eptn, uint32_t flag);
+void usb_ept_in_clear(otg_global_type *usbx, uint32_t eptn, uint32_t flag);
+void usb_set_address(otg_global_type *usbx, uint8_t address);
+void usb_ept0_start(otg_global_type *usbx);
+void usb_ept0_setup(otg_global_type *usbx);
+void usb_connect(otg_global_type *usbx);
+void usb_disconnect(otg_global_type *usbx);
+void usb_remote_wkup_set(otg_global_type *usbx);
+void usb_remote_wkup_clear(otg_global_type *usbx);
+uint8_t usb_suspend_status_get(otg_global_type *usbx);
+#endif
+
+#ifdef OTGFS_USB_HOST
+void usb_port_power_on(otg_global_type *usbx, confirm_state state);
+uint32_t usbh_get_frame(otg_global_type *usbx);
+void usb_hc_enable(otg_global_type *usbx,
+                   uint8_t chn,
+                   uint8_t ept_num,
+                   uint8_t dev_address,
+                   uint8_t type,
+                   uint16_t maxpacket,
+                   uint8_t speed);
+uint32_t usb_hch_read_interrupt(otg_global_type *usbx);
+void usb_host_disable(otg_global_type *usbx);
+void usb_hch_halt(otg_global_type *usbx, uint8_t chn);
+void usbh_fsls_clksel(otg_global_type *usbx, uint8_t clk);
+#endif
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_wdt.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_wdt.h
@@ -1,0 +1,196 @@
+/**
+  **************************************************************************
+  * @file     at32f423_wdt.h
+  * @brief    at32f423 wdt header file
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __AT32F423_WDT_H
+#define __AT32F423_WDT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "at32f423.h"
+
+/** @addtogroup AT32F423_periph_driver
+  * @{
+  */
+
+/** @addtogroup WDT
+  * @{
+  */
+
+
+/** @defgroup WDT_flags_definition
+  * @brief wdt flag
+  * @{
+  */
+
+#define WDT_DIVF_UPDATE_FLAG             ((uint16_t)0x0001) /*!< wdt division value update complete flag */
+#define WDT_RLDF_UPDATE_FLAG             ((uint16_t)0x0002) /*!< wdt reload value update complete flag */
+#define WDT_WINF_UPDATE_FLAG             ((uint16_t)0x0004) /*!< wdt window value update complete flag */
+
+/**
+  * @}
+  */
+
+/** @defgroup WDT_exported_types
+  * @{
+  */
+
+/**
+  * @brief wdt division value type
+  */
+typedef enum
+{
+  WDT_CLK_DIV_4                          = 0x00, /*!< wdt clock divider value is 4 */
+  WDT_CLK_DIV_8                          = 0x01, /*!< wdt clock divider value is 8 */
+  WDT_CLK_DIV_16                         = 0x02, /*!< wdt clock divider value is 16 */
+  WDT_CLK_DIV_32                         = 0x03, /*!< wdt clock divider value is 32 */
+  WDT_CLK_DIV_64                         = 0x04, /*!< wdt clock divider value is 64 */
+  WDT_CLK_DIV_128                        = 0x05, /*!< wdt clock divider value is 128 */
+  WDT_CLK_DIV_256                        = 0x06  /*!< wdt clock divider value is 256 */
+} wdt_division_type;
+
+/**
+  * @brief wdt cmd value type
+  */
+typedef enum
+{
+  WDT_CMD_LOCK                           = 0x0000, /*!< disable write protection command */
+  WDT_CMD_UNLOCK                         = 0x5555, /*!< enable write protection command */
+  WDT_CMD_ENABLE                         = 0xCCCC, /*!< enable wdt command */
+  WDT_CMD_RELOAD                         = 0xAAAA  /*!< reload command */
+} wdt_cmd_value_type;
+
+/**
+  * @brief type define wdt register all
+  */
+typedef struct
+{
+
+  /**
+    * @brief wdt cmd register, offset:0x00
+    */
+  union
+  {
+    __IO uint32_t cmd;
+    struct
+    {
+      __IO uint32_t cmd                  : 16;/* [15:0] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } cmd_bit;
+  };
+
+  /**
+    * @brief wdt div register, offset:0x04
+    */
+  union
+  {
+    __IO uint32_t div;
+    struct
+    {
+      __IO uint32_t div                  : 3; /* [2:0] */
+      __IO uint32_t reserved1            : 29;/* [31:3] */
+    } div_bit;
+  };
+
+   /**
+    * @brief wdt rld register, offset:0x08
+    */
+  union
+  {
+    __IO uint32_t rld;
+    struct
+    {
+      __IO uint32_t rld                  : 12;/* [11:0] */
+      __IO uint32_t reserved1            : 20;/* [31:12] */
+    } rld_bit;
+  };
+
+  /**
+  * @brief wdt sts register, offset:0x0C
+  */
+  union
+  {
+    __IO uint32_t sts;
+    struct
+    {
+      __IO uint32_t divf                 : 1; /* [0] */
+      __IO uint32_t rldf                 : 1; /* [1] */
+      __IO uint32_t reserved1            : 30;/* [31:2] */
+    } sts_bit;
+  };
+
+  /**
+  * @brief wdt win register, offset:0x10
+  */
+  union
+  {
+    __IO uint32_t win;
+    struct
+    {
+      __IO uint32_t win                  : 12;/* [11:0] */
+      __IO uint32_t reserved1            : 20;/* [31:12] */
+    } win_bit;
+  };
+} wdt_type;
+
+/**
+  * @}
+  */
+
+#define WDT                             ((wdt_type *) WDT_BASE)
+
+/** @defgroup WDT_exported_functions
+  * @{
+  */
+
+void wdt_enable(void);
+void wdt_counter_reload(void);
+void wdt_reload_value_set(uint16_t reload_value);
+void wdt_divider_set(wdt_division_type division);
+void wdt_register_write_enable( confirm_state new_state);
+flag_status wdt_flag_get(uint16_t wdt_flag);
+void wdt_window_counter_set(uint16_t window_cnt);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_wwdt.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_wwdt.h
@@ -1,0 +1,158 @@
+/**
+  **************************************************************************
+  * @file     at32f423_wwdt.h
+  * @brief    at32f423 wwdt header file
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __AT32F423_WWDT_H
+#define __AT32F423_WWDT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "at32f423.h"
+
+/** @addtogroup AT32F423_periph_driver
+  * @{
+  */
+
+/** @addtogroup WWDT
+  * @{
+  */
+
+/** @defgroup WWDT_enable_bit_definition
+  * @brief wwdt enable bit
+  * @{
+  */
+
+#define WWDT_EN_BIT                      ((uint32_t)0x00000080) /*!< wwdt enable bit */
+
+/**
+  * @}
+  */
+
+/** @defgroup WWDT_exported_types
+  * @{
+  */
+
+/**
+  * @brief wwdt division type
+  */
+typedef enum
+{
+  WWDT_PCLK1_DIV_4096                    = 0x00, /*!< wwdt counter clock = (pclk1/4096)/1) */
+  WWDT_PCLK1_DIV_8192                    = 0x01, /*!< wwdt counter clock = (pclk1/4096)/2) */
+  WWDT_PCLK1_DIV_16384                   = 0x02, /*!< wwdt counter clock = (pclk1/4096)/4) */
+  WWDT_PCLK1_DIV_32768                   = 0x03  /*!< wwdt counter clock = (pclk1/4096)/8) */
+} wwdt_division_type;
+
+/**
+  * @brief type define wwdt register all
+  */
+typedef struct
+{
+
+  /**
+    * @brief wwdt ctrl register, offset:0x00
+    */
+  union
+  {
+    __IO uint32_t ctrl;
+    struct
+    {
+      __IO uint32_t cnt                  : 7; /* [6:0] */
+      __IO uint32_t wwdten               : 1; /* [7] */
+      __IO uint32_t reserved1            : 24;/* [31:8] */
+    } ctrl_bit;
+  };
+
+  /**
+    * @brief wwdt cfg register, offset:0x04
+    */
+  union
+  {
+    __IO uint32_t cfg;
+    struct
+    {
+      __IO uint32_t win                  : 7; /* [6:0] */
+      __IO uint32_t div                  : 2; /* [8:7] */
+      __IO uint32_t rldien               : 1; /* [9] */
+      __IO uint32_t reserved1            : 22;/* [31:10] */
+    } cfg_bit;
+  };
+
+  /**
+    * @brief wwdt cfg register, offset:0x08
+    */
+  union
+  {
+    __IO uint32_t sts;
+    struct
+    {
+      __IO uint32_t rldf                 : 1; /* [0] */
+      __IO uint32_t reserved1            : 31;/* [31:1] */
+    } sts_bit;
+  };
+
+} wwdt_type;
+
+/**
+  * @}
+  */
+
+#define WWDT                             ((wwdt_type *) WWDT_BASE)
+
+/** @defgroup WWDT_exported_functions
+  * @{
+  */
+
+void wwdt_reset(void);
+void wwdt_divider_set(wwdt_division_type division);
+void wwdt_flag_clear(void);
+void wwdt_enable(uint8_t wwdt_cnt);
+void wwdt_interrupt_enable(void);
+flag_status wwdt_flag_get(void);
+flag_status wwdt_interrupt_flag_get(void);
+void wwdt_counter_set(uint8_t wwdt_cnt);
+void wwdt_window_counter_set(uint8_t window_cnt);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_xmc.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/at32f423_xmc.h
@@ -1,0 +1,391 @@
+/**
+  **************************************************************************
+  * @file     at32f423_xmc.h
+  * @brief    at32f423 xmc header file
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+/* Define to prevent recursive inclusion -------------------------------------*/
+#ifndef __AT32F423_XMC_H
+#define __AT32F423_XMC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/* Includes ------------------------------------------------------------------*/
+#include "at32f423.h"
+
+/** @addtogroup AT32F423_periph_driver
+  * @{
+  */
+
+/** @addtogroup XMC
+  * @{
+  */
+
+/** @defgroup XMC_exported_types
+  * @{
+  */
+
+/**
+  * @brief xmc data address bus multiplexing type
+  */
+typedef enum
+{
+  XMC_DATA_ADDR_MUX_DISABLE              = 0x00000000, /*!< xmc address/data multiplexing disable */
+  XMC_DATA_ADDR_MUX_ENABLE               = 0x00000002  /*!< xmc address/data multiplexing enable */
+} xmc_data_addr_mux_type;
+
+/**
+  * @brief xmc burst access mode type
+  */
+typedef enum
+{
+  XMC_BURST_MODE_DISABLE                 = 0x00000000, /*!< xmc burst mode disable */
+  XMC_BURST_MODE_ENABLE                  = 0x00000100  /*!< xmc burst mode enable */
+} xmc_burst_access_mode_type;
+
+/**
+  * @brief xmc asynchronous wait type
+  */
+typedef enum
+{
+  XMC_ASYN_WAIT_DISABLE                  = 0x00000000, /*!< xmc wait signal during asynchronous transfers disbale */
+  XMC_ASYN_WAIT_ENABLE                   = 0x00008000  /*!< xmc wait signal during asynchronous transfers enable */
+} xmc_asyn_wait_type;
+
+/**
+  * @brief xmc wrapped mode type
+  */
+typedef enum
+{
+  XMC_WRAPPED_MODE_DISABLE               = 0x00000000, /*!< xmc direct wrapped burst is disbale */
+  XMC_WRAPPED_MODE_ENABLE                = 0x00000400  /*!< xmc direct wrapped burst is enable */
+} xmc_wrap_mode_type;
+
+/**
+  * @brief xmc write operation type
+  */
+typedef enum
+{
+  XMC_WRITE_OPERATION_DISABLE            = 0x00000000, /*!< xmc write operations is disable */
+  XMC_WRITE_OPERATION_ENABLE             = 0x00001000  /*!< xmc write operations is enable */
+} xmc_write_operation_type;
+
+/**
+  * @brief xmc wait signal type
+  */
+typedef enum
+{
+  XMC_WAIT_SIGNAL_DISABLE                = 0x00000000, /*!< xmc nwait signal is disable */
+  XMC_WAIT_SIGNAL_ENABLE                 = 0x00002000  /*!< xmc nwait signal is enable */
+} xmc_wait_signal_type;
+
+/**
+  * @brief xmc write burst type
+  */
+typedef enum
+{
+  XMC_WRITE_BURST_SYN_DISABLE            = 0x00000000, /*!< xmc write operations are always performed in asynchronous mode */
+  XMC_WRITE_BURST_SYN_ENABLE             = 0x00080000  /*!< xmc write operations are performed in synchronous mode */
+} xmc_write_burst_type;
+
+/**
+  * @brief xmc extended mode type
+  */
+typedef enum
+{
+  XMC_WRITE_TIMING_DISABLE               = 0x00000000, /*!< xmc write timing disable */
+  XMC_WRITE_TIMING_ENABLE                = 0x00004000  /*!< xmc write timing enable */
+} xmc_extended_mode_type;
+
+/**
+  * @brief xmc pccard wait type
+  */
+typedef enum
+{
+  XMC_WAIT_OPERATION_DISABLE             = 0x00000000, /*!< xmc wait operation for the pc card/nand flash memory bank disable */
+  XMC_WAIT_OPERATION_ENABLE              = 0x00000002  /*!< xmc wait operation for the pc card/nand flash memory bank enable */
+} xmc_nand_pccard_wait_type;
+
+/**
+  * @brief xmc ecc enable type
+  */
+typedef enum
+{
+  XMC_ECC_OPERATION_DISABLE              = 0x00000000, /*!< xmc ecc module disable */
+  XMC_ECC_OPERATION_ENABLE               = 0x00000040  /*!< xmc ecc module enable */
+} xmc_ecc_enable_type;
+
+/**
+  * @brief xmc nor/sram subbank type
+  */
+typedef enum
+{
+  XMC_BANK1_NOR_SRAM1                    = 0x00000000, /*!< xmc nor/sram subbank1 */
+  XMC_BANK1_NOR_SRAM2                    = 0x00000001, /*!< xmc nor/sram subbank2 */
+  XMC_BANK1_NOR_SRAM3                    = 0x00000002, /*!< xmc nor/sram subbank3 */
+  XMC_BANK1_NOR_SRAM4                    = 0x00000003  /*!< xmc nor/sram subbank4 */
+} xmc_nor_sram_subbank_type;
+
+/**
+  * @brief xmc memory type
+  */
+typedef enum
+{
+  XMC_DEVICE_SRAM                        = 0x00000000, /*!< xmc device choice sram */
+  XMC_DEVICE_PSRAM                       = 0x00000004, /*!< xmc device choice psram */
+  XMC_DEVICE_NOR                         = 0x00000008  /*!< xmc device choice nor flash */
+} xmc_memory_type;
+
+/**
+  * @brief xmc data width type
+  */
+typedef enum
+{
+  XMC_BUSTYPE_8_BITS                     = 0x00000000, /*!< xmc databuss width 8bits */
+  XMC_BUSTYPE_16_BITS                    = 0x00000010  /*!< xmc databuss width 16bits */
+} xmc_data_width_type;
+
+/**
+  * @brief xmc wait signal polarity type
+  */
+typedef enum
+{
+  XMC_WAIT_SIGNAL_LEVEL_LOW              = 0x00000000, /*!< xmc nwait active low */
+  XMC_WAIT_SIGNAL_LEVEL_HIGH             = 0x00000200  /*!< xmc nwait active high */
+} xmc_wait_signal_polarity_type;
+
+/**
+  * @brief xmc wait timing type
+  */
+typedef enum
+{
+  XMC_WAIT_SIGNAL_SYN_BEFORE             = 0x00000000, /*!< xmc nwait signal is active one data cycle before wait state */
+  XMC_WAIT_SIGNAL_SYN_DURING             = 0x00000800  /*!< xmc nwait signal is active during wait state */
+} xmc_wait_timing_type;
+
+/**
+  * @brief xmc access mode type
+  */
+typedef enum
+{
+  XMC_ACCESS_MODE_A                      = 0x00000000, /*!< xmc access mode A */
+  XMC_ACCESS_MODE_B                      = 0x10000000, /*!< xmc access mode B */
+  XMC_ACCESS_MODE_C                      = 0x20000000, /*!< xmc access mode C */
+  XMC_ACCESS_MODE_D                      = 0x30000000  /*!< xmc access mode D */
+} xmc_access_mode_type;
+
+/**
+  * @brief   nor/sram banks timing parameters
+  */
+typedef struct
+{
+  xmc_nor_sram_subbank_type              subbank;             /*!< xmc nor/sram subbank */
+  xmc_extended_mode_type                 write_timing_enable; /*!< xmc nor/sram write timing enable */
+  uint32_t                               addr_setup_time;     /*!< xmc nor/sram address setup time */
+  uint32_t                               addr_hold_time;      /*!< xmc nor/sram address hold time */
+  uint32_t                               data_setup_time;     /*!< xmc nor/sram data setup time */
+  uint32_t                               bus_latency_time;    /*!< xmc nor/sram bus latency time */
+  uint32_t                               clk_psc;             /*!< xmc nor/sram clock prescale */
+  uint32_t                               data_latency_time;   /*!< xmc nor/sram data latency time */
+  xmc_access_mode_type                   mode;                /*!< xmc nor/sram access mode */
+} xmc_norsram_timing_init_type;
+
+/**
+  * @brief  xmc nor/sram init structure definition
+  */
+typedef struct
+{
+  xmc_nor_sram_subbank_type              subbank;             /*!< xmc nor/sram subbank */
+  xmc_data_addr_mux_type                 data_addr_multiplex; /*!< xmc nor/sram address/data multiplexing enable */
+  xmc_memory_type                        device;              /*!< xmc nor/sram memory device */
+  xmc_data_width_type                    bus_type;            /*!< xmc nor/sram data bus width */
+  xmc_burst_access_mode_type             burst_mode_enable;   /*!< xmc nor/sram burst mode enable */
+  xmc_asyn_wait_type                     asynwait_enable;     /*!< xmc nor/sram nwait in asynchronous transfer enable */
+  xmc_wait_signal_polarity_type          wait_signal_lv;      /*!< xmc nor/sram nwait polarity */
+  xmc_wrap_mode_type                     wrapped_mode_enable; /*!< xmc nor/sram wrapped enable */
+  xmc_wait_timing_type                   wait_signal_config;  /*!< xmc nor/sram nwait timing configuration */
+  xmc_write_operation_type               write_enable;        /*!< xmc nor/sram write enable */
+  xmc_wait_signal_type                   wait_signal_enable;  /*!< xmc nor/sram nwait in synchronous transfer enable */
+  xmc_extended_mode_type                 write_timing_enable; /*!< xmc nor/sram read-write timing different */
+  xmc_write_burst_type                   write_burst_syn;     /*!< xmc nor/sram memory write mode control */
+} xmc_norsram_init_type;
+
+typedef struct
+{
+  /**
+    * @brief xmc bank1 bk1ctrl register, offset:0x00+0x08*(x-1) x= 1...4
+    */
+  union
+  {
+    __IO uint32_t bk1ctrl;
+    struct
+    {
+      __IO uint32_t en                   : 1; /* [0] */
+      __IO uint32_t admuxen              : 1; /* [1] */
+      __IO uint32_t dev                  : 2; /* [3:2] */
+      __IO uint32_t extmdbw              : 2; /* [5:4] */
+      __IO uint32_t noren                : 1; /* [6] */
+      __IO uint32_t reserved1            : 1; /* [7] */
+      __IO uint32_t syncben              : 1; /* [8] */
+      __IO uint32_t nwpol                : 1; /* [9] */
+      __IO uint32_t wrapen               : 1; /* [10] */
+      __IO uint32_t nwtcfg               : 1; /* [11] */
+      __IO uint32_t wen                  : 1; /* [12] */
+      __IO uint32_t nwsen                : 1; /* [13] */
+      __IO uint32_t rwtd                 : 1; /* [14] */
+      __IO uint32_t nwasen               : 1; /* [15] */
+      __IO uint32_t crpgs                : 3; /* [18:16] */
+      __IO uint32_t mwmc                 : 1; /* [19] */
+      __IO uint32_t reserved2            : 12;/* [31:20] */
+    } bk1ctrl_bit;
+  };
+
+  /**
+    * @brief xmc bank1 bk1tmg register, offset:0x04+0x08*(x-1) x= 1...4
+    */
+  union
+  {
+    __IO uint32_t bk1tmg;
+    struct
+    {
+      __IO uint32_t addrst               : 4; /* [3:0] */
+      __IO uint32_t addrht               : 4; /* [7:4] */
+      __IO uint32_t dtst                 : 8; /* [15:8] */
+      __IO uint32_t buslat               : 4; /* [19:16] */
+      __IO uint32_t clkpsc               : 4; /* [23:20] */
+      __IO uint32_t dtlat                : 4; /* [27:24] */
+      __IO uint32_t asyncm               : 2; /* [29:28] */
+      __IO uint32_t reserved1            : 2; /* [31:30] */
+    } bk1tmg_bit;
+  };
+
+} xmc_bank1_ctrl_tmg_reg_type;
+
+typedef struct
+{
+  /**
+    * @brief xmc bank1 bk1tmgwr register, offset:0x104+0x08*(x-1) x= 1...4
+    */
+  union
+  {
+    __IO uint32_t bk1tmgwr;
+    struct
+    {
+      __IO uint32_t addrst               : 4; /* [3:0] */
+      __IO uint32_t addrht               : 4; /* [7:4] */
+      __IO uint32_t dtst                 : 8; /* [15:8] */
+      __IO uint32_t buslat               : 4; /* [19:16] */
+      __IO uint32_t reserved1            : 8; /* [27:20] */
+      __IO uint32_t asyncm               : 2; /* [29:28] */
+      __IO uint32_t reserved2            : 2; /* [31:30] */
+    } bk1tmgwr_bit;
+  };
+
+  /**
+    * @brief xmc bank1 reserved register
+    */
+  __IO uint32_t reserved1;
+
+} xmc_bank1_tmgwr_reg_type;
+
+/**
+  * @brief xmc bank1 registers
+  */
+typedef struct
+{
+  /**
+    * @brief xmc bank1 ctrl and tmg register, offset:0x00~0x1C
+    */
+  xmc_bank1_ctrl_tmg_reg_type ctrl_tmg_group[4];
+
+  /**
+    * @brief xmc bank1 reserved register, offset:0x20~0x100
+    */
+  __IO uint32_t reserved1[57];
+
+ /**
+    * @brief xmc bank1 tmgwr register, offset:0x104~0x11C
+    */
+  xmc_bank1_tmgwr_reg_type tmgwr_group[4];
+
+  /**
+    * @brief xmc bank1 reserved register, offset:0x120~0x220
+    */
+  __IO uint32_t reserved2[63];
+
+  /**
+    * @brief xmc bank1 ext register, offset:0x220~0x22C
+    */
+  union
+  {
+    __IO uint32_t ext[4];
+    struct
+    {
+      __IO uint32_t buslatw2w            : 8; /* [7:0] */
+      __IO uint32_t buslatr2r            : 8; /* [15:8] */
+      __IO uint32_t reserved1            : 16;/* [31:16] */
+    } ext_bit[4];
+  };
+
+} xmc_bank1_type;
+
+/**
+  * @}
+  */
+
+#define XMC_BANK1                        ((xmc_bank1_type *) XMC_BANK1_REG_BASE)
+
+/** @defgroup XMC_exported_functions
+  * @{
+  */
+
+void xmc_nor_sram_reset(xmc_nor_sram_subbank_type xmc_subbank);
+void xmc_nor_sram_init(xmc_norsram_init_type* xmc_norsram_init_struct);
+void xmc_nor_sram_timing_config(xmc_norsram_timing_init_type* xmc_rw_timing_struct,
+                                xmc_norsram_timing_init_type* xmc_w_timing_struct);
+void xmc_norsram_default_para_init(xmc_norsram_init_type* xmc_nor_sram_init_struct);
+void xmc_norsram_timing_default_para_init(xmc_norsram_timing_init_type* xmc_rw_timing_struct,
+                                          xmc_norsram_timing_init_type* xmc_w_timing_struct);
+void xmc_nor_sram_enable(xmc_nor_sram_subbank_type xmc_subbank, confirm_state new_state);
+void xmc_ext_timing_config(volatile xmc_nor_sram_subbank_type xmc_sub_bank, uint16_t w2w_timing, uint16_t r2r_timing);
+
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/system_at32f423.h
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Include/system_at32f423.h
@@ -1,0 +1,77 @@
+/**
+  **************************************************************************
+  * @file     system_at32f423.h
+  * @brief    cmsis cortex-m4 system header file.
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+#ifndef __SYSTEM_AT32F423_H
+#define __SYSTEM_AT32F423_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** @addtogroup CMSIS
+  * @{
+  */
+
+/** @addtogroup AT32F423_system
+  * @{
+  */
+
+#define SystemCoreClock                  system_core_clock
+
+/** @defgroup AT32F423_system_exported_variables
+  * @{
+  */
+extern unsigned int system_core_clock; /*!< system clock frequency (core clock) */
+
+/**
+  * @}
+  */
+
+/** @defgroup AT32F423_system_exported_functions
+  * @{
+  */
+
+extern void SystemInit(void);
+extern void system_core_clock_update(void);
+extern void wait_for_power_stable(void);
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Source/system_at32f423.c
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Source/system_at32f423.c
@@ -1,0 +1,205 @@
+/**
+  **************************************************************************
+  * @file     system_at32f423.c
+  * @brief    contains all the functions for cmsis cortex-m4 system source file
+  **************************************************************************
+  *
+  * Copyright (c) 2025, Artery Technology, All rights reserved.
+  *
+  * The software Board Support Package (BSP) that is made available to
+  * download from Artery official website is the copyrighted work of Artery.
+  * Artery authorizes customers to use, copy, and distribute the BSP
+  * software and its related documentation for the purpose of design and
+  * development in conjunction with Artery microcontrollers. Use of the
+  * software is governed by this copyright notice and the following disclaimer.
+  *
+  * THIS SOFTWARE IS PROVIDED ON "AS IS" BASIS WITHOUT WARRANTIES,
+  * GUARANTEES OR REPRESENTATIONS OF ANY KIND. ARTERY EXPRESSLY DISCLAIMS,
+  * TO THE FULLEST EXTENT PERMITTED BY LAW, ALL EXPRESS, IMPLIED OR
+  * STATUTORY OR OTHER WARRANTIES, GUARANTEES OR REPRESENTATIONS,
+  * INCLUDING BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE, OR NON-INFRINGEMENT.
+  *
+  **************************************************************************
+  */
+
+/** @addtogroup CMSIS
+  * @{
+  */
+
+/** @addtogroup AT32F423_system
+  * @{
+  */
+
+#include "at32f423.h"
+
+/** @addtogroup AT32F423_system_private_defines
+  * @{
+  */
+#define VECT_TAB_OFFSET                  0x0 /*!< vector table base offset field. this value must be a multiple of 0x200. */
+/**
+  * @}
+  */
+
+/** @addtogroup AT32F423_system_private_variables
+  * @{
+  */
+unsigned int system_core_clock           = HICK_VALUE; /*!< system clock frequency (core clock) */
+/**
+  * @}
+  */
+
+/** @addtogroup AT32F423_system_private_functions
+  * @{
+  */
+
+/**
+  * @brief  setup the microcontroller system
+  *         initialize the flash interface.
+  * @note   this function should be used only after reset.
+  * @param  none
+  * @retval none
+  */
+void SystemInit (void)
+{
+#if defined (__FPU_USED) && (__FPU_USED == 1U)
+  SCB->CPACR |= ((3U << 10U * 2U) |         /* set cp10 full access */
+                 (3U << 11U * 2U)  );       /* set cp11 full access */
+#endif
+
+  /* reset the crm clock configuration to the default reset state(for debug purpose) */
+  /* enable auto step mode */
+  crm_auto_step_mode_enable(TRUE);
+
+  /* set hicken bit */
+  CRM->ctrl_bit.hicken = TRUE;
+
+  /* wait hick stable */
+  while(CRM->ctrl_bit.hickstbl != SET);
+
+  /* hick used as system clock */
+  CRM->cfg_bit.sclksel = CRM_SCLK_HICK;
+
+  /* wait sclk switch status */
+  while(CRM->cfg_bit.sclksts != CRM_SCLK_HICK);
+
+  /* reset hexten, hextbyps, cfden and pllen bits */
+  CRM->ctrl &= ~(0x010D0000U);
+
+  /* reset cfg register, include sclk switch, ahbdiv, apb1div, apb2div, adcdiv, clkout bits */
+  CRM->cfg = 0x40000000U;
+
+  /* reset pllms pllns pllfr pllrcs bits */
+  CRM->pllcfg = 0x00033002U;
+
+  /* reset clkout_sel, clkoutdiv, pllclk_to_adc, hick_to_usb */
+  CRM->misc1 &= 0x00005000U;
+  CRM->misc1 |= 0x000F0000U;
+
+  /* disable all interrupts enable and clear pending bits  */
+  CRM->clkint = 0x009F0000U;
+
+  /* disable auto step mode */
+  crm_auto_step_mode_enable(FALSE);
+
+#ifdef VECT_TAB_SRAM
+  SCB->VTOR = SRAM_BASE  | VECT_TAB_OFFSET;  /* vector table relocation in internal sram. */
+#else
+  SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET;  /* vector table relocation in internal flash. */
+#endif
+}
+
+/**
+  * @brief  update system_core_clock variable according to clock register values.
+  *         the system_core_clock variable contains the core clock (hclk), it can
+  *         be used by the user application to setup the systick timer or configure
+  *         other parameters.
+  * @param  none
+  * @retval none
+  */
+void system_core_clock_update(void)
+{
+  uint32_t pll_ns = 0, pll_ms = 0, pll_fr = 0, pll_clock_source = 0, pllrcsfreq = 0;
+  uint32_t temp = 0, div_value = 0, psc = 0;
+  crm_sclk_type sclk_source;
+
+  static const uint8_t sys_ahb_div_table[16] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 6, 7, 8, 9};
+  static const uint8_t pll_fr_table[6] = {1, 2, 4, 8, 16, 32};
+
+  /* get sclk source */
+  sclk_source = crm_sysclk_switch_status_get();
+
+  switch(sclk_source)
+  {
+    case CRM_SCLK_HICK:
+      if(((CRM->misc1_bit.hick_to_sclk) != RESET) && ((CRM->misc1_bit.hickdiv) != RESET))
+        system_core_clock = HICK_VALUE * 6;
+      else
+        system_core_clock = HICK_VALUE;
+
+      psc = CRM->misc2_bit.hick_to_sclk_div;
+      system_core_clock = system_core_clock >> psc;
+      break;
+    case CRM_SCLK_HEXT:
+      system_core_clock = HEXT_VALUE;
+      psc = CRM->misc2_bit.hext_to_sclk_div;
+      system_core_clock = system_core_clock >> psc;
+      break;
+    case CRM_SCLK_PLL:
+      /* get pll clock source */
+      pll_clock_source = CRM->pllcfg_bit.pllrcs;
+
+      /* get multiplication factor */
+      pll_ns = CRM->pllcfg_bit.pllns;
+      pll_ms = CRM->pllcfg_bit.pllms;
+      pll_fr = pll_fr_table[CRM->pllcfg_bit.pllfr];
+
+      if(pll_clock_source == CRM_PLL_SOURCE_HICK)
+      {
+        /* hick selected as pll clock entry */
+        pllrcsfreq = HICK_VALUE;
+      }
+      else
+      {
+        /* hext selected as pll clock entry */
+        pllrcsfreq = HEXT_VALUE;
+      }
+
+      system_core_clock = (uint32_t)(((uint64_t)pllrcsfreq * pll_ns) / (pll_ms * pll_fr) / 2);
+      break;
+    default:
+      system_core_clock = HICK_VALUE;
+      break;
+  }
+
+  /* compute sclk, ahbclk frequency */
+  /* get ahb division */
+  temp = CRM->cfg_bit.ahbdiv;
+  div_value = sys_ahb_div_table[temp];
+  /* ahbclk frequency */
+  system_core_clock = system_core_clock >> div_value;
+}
+
+/**
+  * @brief  take some delay for waiting power stable, delay is about 60ms with frequency 8MHz.
+  * @param  none
+  * @retval none
+  */
+void wait_for_power_stable(void)
+{
+  volatile uint32_t delay = 0;
+  for(delay = 0; delay < 50000; delay++);
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Source/system_at32f423.c
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Source/system_at32f423.c
@@ -54,6 +54,45 @@ extern uint32_t __Vectors[];
   * @{
   */
 
+/** @addtogroup AT32F421_system_private_functions
+  * @{
+  */
+static void SetSysClock()
+{
+    FLASH->psr = flash_psr_set(FLASH_WAIT_CYCLE_4); /* Three wait cycles, prefetch enabled */
+
+    CRM_REG(CRM_PWC_PERIPH_CLOCK) |= (CRM_REG_BIT(TRUE));
+
+    pwc_ldo_output_voltage_set(PWC_LDO_OUTPUT_1V3);
+
+    CRM->ctrl_bit.hicken = TRUE;
+    while (CRM->ctrl_bit.hickstbl == 0) ;
+
+    CRM->pllcfg_bit.pllrcs = CRM_PLL_SOURCE_HICK;
+    CRM->pllcfg_bit.pllns = 72;
+    CRM->pllcfg_bit.pllms = 1;
+    CRM->pllcfg_bit.pllfr = CRM_PLL_FR_2;
+
+    CRM->ctrl_bit.pllen = 1;                        /* Start PLL and wait until is stable  */
+    while (CRM->ctrl_bit.pllstbl == 0) ;
+
+    CRM->misc2_bit.auto_step_en = CRM_AUTO_STEP_MODE_ENABLE;
+    CRM->cfg_bit.ahbdiv = CRM_AHB_DIV_1;
+    CRM->misc2_bit.auto_step_en = CRM_AUTO_STEP_MODE_DISABLE;
+
+    CRM->cfg_bit.apb2div = CRM_APB2_DIV_1;
+
+    CRM->cfg_bit.apb1div = CRM_APB1_DIV_2;
+
+    CRM->misc2_bit.auto_step_en = CRM_AUTO_STEP_MODE_ENABLE;
+    CRM->cfg_bit.sclksel = CRM_SCLK_PLL;            /* Switch to PLL clock                 */
+    CRM->misc2_bit.auto_step_en = CRM_AUTO_STEP_MODE_DISABLE;
+    while (CRM->cfg_bit.sclksts != CRM_SCLK_PLL) ;
+
+    CRM->misc2_bit.auto_step_en = CRM_AUTO_STEP_MODE_DISABLE;
+}
+
+
 /**
   * @brief  setup the microcontroller system
   *         initialize the flash interface.
@@ -67,6 +106,8 @@ void SystemInit (void)
   SCB->CPACR |= ((3U << 10U * 2U) |         /* set cp10 full access */
                  (3U << 11U * 2U)  );       /* set cp11 full access */
 #endif
+
+  CRM->misc2_bit.auto_step_en = CRM_AUTO_STEP_MODE_ENABLE;
 
   /* set hicken bit */
   CRM->ctrl_bit.hicken = TRUE;
@@ -120,7 +161,7 @@ void system_core_clock_update(void)
   static const uint8_t pll_fr_table[6] = {1, 2, 4, 8, 16, 32};
 
   /* get sclk source */
-  sclk_source = crm_sysclk_switch_status_get();
+  sclk_source = CRM->cfg_bit.sclksts;
 
   switch(sclk_source)
   {

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Source/system_at32f423.c
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Source/system_at32f423.c
@@ -67,10 +67,6 @@ void SystemInit (void)
                  (3U << 11U * 2U)  );       /* set cp11 full access */
 #endif
 
-  /* reset the crm clock configuration to the default reset state(for debug purpose) */
-  /* enable auto step mode */
-  crm_auto_step_mode_enable(TRUE);
-
   /* set hicken bit */
   CRM->ctrl_bit.hicken = TRUE;
 
@@ -98,9 +94,6 @@ void SystemInit (void)
 
   /* disable all interrupts enable and clear pending bits  */
   CRM->clkint = 0x009F0000U;
-
-  /* disable auto step mode */
-  crm_auto_step_mode_enable(FALSE);
 
 #ifdef VECT_TAB_SRAM
   SCB->VTOR = SRAM_BASE  | VECT_TAB_OFFSET;  /* vector table relocation in internal sram. */

--- a/platform/mcu/CMSIS/Device/Artery/AT32F423/Source/system_at32f423.c
+++ b/platform/mcu/CMSIS/Device/Artery/AT32F423/Source/system_at32f423.c
@@ -44,7 +44,8 @@
 /** @addtogroup AT32F423_system_private_variables
   * @{
   */
-unsigned int system_core_clock           = HICK_VALUE; /*!< system clock frequency (core clock) */
+unsigned int system_core_clock           = 144000000; /*!< system clock frequency (core clock) */
+extern uint32_t __Vectors[];
 /**
   * @}
   */
@@ -95,11 +96,10 @@ void SystemInit (void)
   /* disable all interrupts enable and clear pending bits  */
   CRM->clkint = 0x009F0000U;
 
-#ifdef VECT_TAB_SRAM
-  SCB->VTOR = SRAM_BASE  | VECT_TAB_OFFSET;  /* vector table relocation in internal sram. */
-#else
-  SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET;  /* vector table relocation in internal flash. */
-#endif
+  SetSysClock();
+  wait_for_power_stable();
+
+  SCB->VTOR = (uint32_t)(&__Vectors[0]);
 }
 
 /**


### PR DESCRIPTION
This merge request adds support for the Artery AT32F423.

This MCU is used in the Radtel RT-4D.
A merge request with basic support for the device will come later.