### PR TITLE
add subproject/catch2 to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ subprojects/radio_tool
 subprojects/codec2
 subprojects/tinyusb
 subprojects/XPowersLib
+subprojects/catch2
 
 # ignore log files
 *.log


### PR DESCRIPTION
This follows the convention used for other subprojects in this repository and makes it a little easier to track while files have changed when committing.