### PR TITLE
core/dsp.h: add string.h

### DIFF
--- a/openrtx/include/core/dsp.h
+++ b/openrtx/include/core/dsp.h
@@ -10,6 +10,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
dsp_resetState() uses memset, but string.h was not included. This adds an include for string.h at the top of core/dsp.h fixing issue #423.