### PR TITLE
Add basic vibrate support for CS7000P

### DIFF
--- a/openrtx/include/interfaces/platform.h
+++ b/openrtx/include/interfaces/platform.h
@@ -164,6 +164,18 @@ const hwInfo_t *platform_getHwInfo();
 const struct gpsDevice *platform_initGps();
 #endif
 
+#ifdef CONFIG_VIBRATION
+/**
+ * This function turns on the vibration motor.
+ */
+void platform_vibrateOn();
+
+/**
+ * This function turns off the vibration motor.
+ */
+void platform_vibrateOff();
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/platform/targets/CS7000-PLUS/hwconfig.h
+++ b/platform/targets/CS7000-PLUS/hwconfig.h
@@ -66,6 +66,9 @@ extern const struct gpsDevice gps;
 /* Use extended addressing for external flash memory */
 #define CONFIG_W25Qx_EXT_ADDR
 
+/* Device has a vibration motor */
+#define CONFIG_VIBRATION
+
 #ifdef __cplusplus
 }
 #endif

--- a/platform/targets/CS7000-PLUS/pinmap.h
+++ b/platform/targets/CS7000-PLUS/pinmap.h
@@ -159,4 +159,7 @@
 #define ALPU_SDA      GPIOB,9
 #define ALPU_SCL      GPIOB,8
 
+/* Vibration motor */
+#define VIBR_MOTOR    &extGpio,2
+
 #endif /* PINMAP_H */

--- a/platform/targets/CS7000-PLUS/platform.c
+++ b/platform/targets/CS7000-PLUS/platform.c
@@ -206,3 +206,13 @@ const struct gpsDevice *platform_initGps()
 
     return &gps;
 }
+
+void platform_vibrateOn()
+{
+    gpioDev_set(VIBR_MOTOR);
+}
+
+void platform_vibrateOff()
+{
+    gpioDev_clear(VIBR_MOTOR);
+}


### PR DESCRIPTION
This PR adds vibrate/rumble support for the CS7000P (the only OpenRTX target which has such a feature AFAIK). It exposes `platform_vibrateOn()` and `platform_vibrateOff()` functions which enable and disable the vibration motor respectively. A basic platform test is included as well.

Useful applications could include device vibration when receiving SMS over M17, APRS packets, misc. alerts, or haptic feedback which may also be beneficial for accessibility.

This is my first PR that isn't documentation-related, I _think_ this is implemented correctly from a conventions/architecture standpoint, however any feedback is very welcome! 