### PR TITLE
Swap KEY_MONI and KEY_F1 behaviours

### DIFF
--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -1411,24 +1411,24 @@ void ui_updateFSM(bool *sync_rtx)
         bool f1Handled = false;
         vpQueueFlags_t queueFlags = vp_getVoiceLevelQueueFlags();
         // If we get out of standby, we ignore the kdb event
-        // unless is the MONI key for the MACRO functions
-        if (_ui_exitStandby(now) && !(msg.keys & KEY_MONI))
+        // unless is the F1 key for the MACRO functions
+        if (_ui_exitStandby(now) && !(msg.keys & KEY_F1))
             return;
-        // If MONI is pressed, activate MACRO functions
-        bool moniPressed = msg.keys & KEY_MONI;
-        if(moniPressed || macro_latched)
+        // If the F1 key is pressed, activate MACRO functions
+        bool f1Pressed = msg.keys & KEY_F1;
+        if(f1Pressed || macro_latched)
         {
             macro_menu = true;
 
             if(state.settings.macroMenuLatch == 1)
             {
-                // long press moni on its own latches function.
-                if (moniPressed && msg.long_press && !macro_latched)
+                // long press KEY_F1 on its own latches function.
+                if (f1Pressed && msg.long_press && !macro_latched)
                 {
                     macro_latched = true;
                     vp_beep(BEEP_FUNCTION_LATCH_ON, LONG_BEEP);
                 }
-                else if (moniPressed && macro_latched)
+                else if (f1Pressed && macro_latched)
                 {
                     macro_latched = false;
                     vp_beep(BEEP_FUNCTION_LATCH_OFF, LONG_BEEP);
@@ -1443,7 +1443,7 @@ void ui_updateFSM(bool *sync_rtx)
             macro_menu = false;
         }
 #if defined(PLATFORM_TTWRPLUS)
-        // T-TWR Plus has no KEY_MONI, using KEY_VOLDOWN long press instead
+        // T-TWR Plus has no KEY_F1, using KEY_VOLDOWN long press instead
         if ((msg.keys & KEY_VOLDOWN) && msg.long_press)
         {
             macro_menu = true;

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -1422,24 +1422,24 @@ void ui_updateFSM(bool *sync_rtx)
         bool f1Handled = false;
         enum vpQueueFlags queueFlags = vp_getVoiceLevelQueueFlags();
         // If we get out of standby, we ignore the kdb event
-        // unless is the MONI key for the MACRO functions
-        if (_ui_exitStandby(now) && !(msg.keys & KEY_MONI))
+        // unless is the F1 key for the MACRO functions
+        if (_ui_exitStandby(now) && !(msg.keys & KEY_F1))
             return;
-        // If MONI is pressed, activate MACRO functions
-        bool moniPressed = msg.keys & KEY_MONI;
-        if(moniPressed || macro_latched)
+        // If the F1 key is pressed, activate MACRO functions
+        bool f1Pressed = msg.keys & KEY_F1;
+        if(f1Pressed || macro_latched)
         {
             macro_menu = true;
 
             if(state.settings.macroMenuLatch == 1)
             {
-                // long press moni on its own latches function.
-                if (moniPressed && msg.long_press && !macro_latched)
+                // long press KEY_F1 on its own latches function.
+                if (f1Pressed && msg.long_press && !macro_latched)
                 {
                     macro_latched = true;
                     vp_beep(BEEP_FUNCTION_LATCH_ON, LONG_BEEP);
                 }
-                else if (moniPressed && macro_latched)
+                else if (f1Pressed && macro_latched)
                 {
                     macro_latched = false;
                     vp_beep(BEEP_FUNCTION_LATCH_OFF, LONG_BEEP);
@@ -1454,7 +1454,7 @@ void ui_updateFSM(bool *sync_rtx)
             macro_menu = false;
         }
 #if defined(PLATFORM_TTWRPLUS)
-        // T-TWR Plus has no KEY_MONI, using KEY_VOLDOWN long press instead
+        // T-TWR Plus has no KEY_F1, using KEY_VOLDOWN long press instead
         if ((msg.keys & KEY_VOLDOWN) && msg.long_press)
         {
             macro_menu = true;
@@ -1602,7 +1602,7 @@ void ui_updateFSM(bool *sync_rtx)
                                                    queueFlags);
                         }
                     }
-                    else if(msg.keys & KEY_F1)
+                    else if(msg.keys & KEY_MONI)
                     {
                         if (state.settings.vpLevel > vpBeep)
                         {// quick press repeat vp, long press summary.


### PR DESCRIPTION
This PR is a prerequisite for addressing issue [#797](https://tasks.openrtx.org/project/openrtx/issue/797) / user story [#804](https://tasks.openrtx.org/project/openrtx/us/804). In order to add functionality that opens the squelch when the MONI key is held, the MONI key first needs to be unbound as it is currently used for the macro menu.

## Current behaviour

- `KEY_MONI` activates the macro menu for as long as it is held. If the accessibility option **Macro Latch** is selected, then the macro menu will stay open after `KEY_MONI` has been held for a certain amount of time. Pressing `KEY_MONI` again will hide the macro menu. 
- `KEY_F1` when momentary pressed will replay the last voice prompt, if voice prompts are enabled.
  - Short-pressing `KEY_F1` again while a voice prompt is playing will stop the voice prompt playback.

## Proposed behaviour:
(Based on discussion from OpenRTX office hours April 2026)

- `KEY_F1` activates the macro menu for as long as it is held. If the accessibility option **Macro Latch** is selected, then the macro menu will stay open aftey `KEY_F1` has been held for a certain amount of time. Pressing `KEY_F1` again will hide the macro menu.
- A short press of `KEY_MONI` will replay the last voice prompt, if voice prompts are enabled.
  - Short-pressing `KEY_MONI` again while a voice prompt is playing will stop the voice prompt playback. 

## To-Do

- [x] Remap the macro menu to `KEY_F1`
- [x] Remap the "replay last voice prompt" feature to `KEY_MONI` (only for short presses and only when voice prompts are enabled).
- [ ] Device testing