### PR TITLE
Add USB serial support for the CS7000P/STM32H7 targets

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -544,9 +544,12 @@ cs7000p_src = ['platform/drivers/NVM/nvmem_CS7000.c',
                'platform/drivers/SPI/spi_custom.c',
                'platform/drivers/SPI/spi_bitbang.c',
                'platform/targets/CS7000-PLUS/hwconfig.c',
-               'platform/targets/CS7000-PLUS/platform.c']
+               'platform/targets/CS7000-PLUS/platform.c',
+               'platform/drivers/USB/usb_serial_stm32h7.c',
+               'platform/drivers/USB/usb_descriptors.c']
 
-cs7000p_inc = ['platform/targets/CS7000-PLUS']
+cs7000p_inc = ['platform/targets/CS7000-PLUS',
+               'platform/drivers/USB']
 cs7000p_def = {'PLATFORM_CS7000P': '', 'timegm': 'mktime'}
 
 cs7000p_src += openrtx_src + stm32h743_src + miosix_cm7_src + ui_src_default

--- a/meson.build
+++ b/meson.build
@@ -128,6 +128,10 @@ endif
 # XPowersLib, library for x-powers power management series
 xpowerslib_proj = subproject('XPowersLib')
 
+# tinyUSB, embedded USB device stack
+tinyusb_proj = subproject('tinyusb')
+tinyusb_dep  = tinyusb_proj.get_variable('tinyusb_dep')
+
 ##
 ## RTOS
 ##
@@ -795,7 +799,7 @@ cs7000_opts = {
 cs7000p_opts = {
   'sources'            : cs7000p_src,
   'include_directories': cs7000p_inc,
-  'dependencies'       : [codec2_dep],
+  'dependencies'       : [codec2_dep, tinyusb_dep],
   'c_args'             : cs7000p_args,
   'cpp_args'           : cs7000p_args,
   'link_args'          : ['-Wl,-T../platform/mcu/STM32H7xx/linker_script_cs7000p.ld',

--- a/openrtx/include/interfaces/usb_serial.h
+++ b/openrtx/include/interfaces/usb_serial.h
@@ -27,7 +27,8 @@ void usb_serial_init(void);
 void usb_serial_terminate(void);
 
 /**
- * Service the USB stack. Must be called regularly from the main thread.
+ * Service the USB stack and flush any pending transmit data.
+ * Must be called regularly from exactly one thread (the main thread).
  */
 void usb_serial_task(void);
 
@@ -44,11 +45,16 @@ uint32_t usb_serial_available(void);
 /**
  * Write data to the USB CDC port.
  *
- * Blocks until all bytes are accepted or a 500 ms timeout elapses.
+ * Non-blocking and thread-safe: data is accepted into an internal transmit
+ * buffer and returned immediately.  usb_serial_task() flushes the buffer
+ * to the CDC FIFO on its next call.
+ *
+ * A short write (return value < len) indicates the transmit buffer is full;
+ * the caller is responsible for retrying the unsent remainder if needed.
  *
  * \param buf  data to send.
  * \param len  number of bytes to send.
- * \return number of bytes written, or -1 on error/timeout.
+ * \return number of bytes accepted, or -1 if not mounted.
  */
 ssize_t usb_serial_write(const void *buf, size_t len);
 

--- a/openrtx/include/interfaces/usb_serial.h
+++ b/openrtx/include/interfaces/usb_serial.h
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef USB_SERIAL_H
+#define USB_SERIAL_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Initialise the USB serial driver and bring up the USB device stack.
+ */
+void usb_serial_init(void);
+
+/**
+ * Shut down the USB serial driver.
+ */
+void usb_serial_terminate(void);
+
+/**
+ * Service the USB stack. Must be called regularly from the main thread.
+ */
+void usb_serial_task(void);
+
+/**
+ * \return true if a host is connected and the CDC port is open.
+ */
+bool usb_serial_connected(void);
+
+/**
+ * \return number of bytes waiting in the receive FIFO.
+ */
+uint32_t usb_serial_available(void);
+
+/**
+ * Write data to the USB CDC port.
+ *
+ * Blocks until all bytes are accepted or a 500 ms timeout elapses.
+ *
+ * \param buf  data to send.
+ * \param len  number of bytes to send.
+ * \return number of bytes written, or -1 on error/timeout.
+ */
+ssize_t usb_serial_write(const void *buf, size_t len);
+
+/**
+ * Read data from the USB CDC port (non-blocking).
+ *
+ * \param buf  destination buffer.
+ * \param len  maximum number of bytes to read.
+ * \return number of bytes read, 0 if none available, or -1 if not connected.
+ */
+ssize_t usb_serial_read(void *buf, size_t len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* USB_SERIAL_H */

--- a/openrtx/include/interfaces/usb_serial.h
+++ b/openrtx/include/interfaces/usb_serial.h
@@ -45,16 +45,21 @@ uint32_t usb_serial_available(void);
 /**
  * Write data to the USB CDC port.
  *
- * Non-blocking and thread-safe: data is accepted into an internal transmit
- * buffer and returned immediately.  usb_serial_task() flushes the buffer
- * to the CDC FIFO on its next call.
+ * Blocking: execution does not return until all bytes have been written
+ * through the CDC TX FIFO and flushed to the USB endpoint.
  *
- * A short write (return value < len) indicates the transmit buffer is full;
- * the caller is responsible for retrying the unsent remainder if needed.
+ * Returns -1 immediately (without writing any data) if the USB device is
+ * not mounted, avoiding an indefinite block when the cable is unplugged.
+ * Also returns -1 if no forward progress is made within ~50 ms (transfer
+ * stalled while mounted), clearing the TX FIFO before returning.
+ *
+ * Thread-safe: concurrent callers are serialised by an internal mutex.
+ * Do not call this function from within a tinyUSB callback, as it may
+ * call tud_task() internally when the CDC TX FIFO is full.
  *
  * \param buf  data to send.
  * \param len  number of bytes to send.
- * \return number of bytes accepted, or -1 if not mounted.
+ * \return len on success, or -1 on error.
  */
 ssize_t usb_serial_write(const void *buf, size_t len);
 

--- a/openrtx/src/core/threads.c
+++ b/openrtx/src/core/threads.c
@@ -21,6 +21,7 @@
 #include "core/backup.h"
 #include "core/gps.h"
 #include "core/voicePrompts.h"
+#include "interfaces/usb_serial.h"
 
 #if defined(PLATFORM_TTWRPLUS)
 #include "pmu.h"
@@ -122,6 +123,10 @@ void *main_thread(void *arg)
 
     long long time = 0;
 
+    #if defined(CONFIG_USB_SERIAL)
+    usb_serial_init();
+    #endif
+
     #if defined(CONFIG_GPS)
     const struct gpsDevice *gps = platform_initGps();
     if(gps != NULL)
@@ -141,6 +146,11 @@ void *main_thread(void *arg)
         if(platform_pwrButtonStatus() == false)
             state.devStatus = SHUTDOWN;
         pthread_mutex_unlock(&state_mutex);
+
+        // Run USB serial task
+        #if defined(CONFIG_USB_SERIAL)
+        usb_serial_task();
+        #endif
 
         // Run GPS task
         #if defined(CONFIG_GPS)

--- a/platform/drivers/USB/usb_descriptors.c
+++ b/platform/drivers/USB/usb_descriptors.c
@@ -96,7 +96,14 @@ uint8_t const desc_fs_configuration[] =
 {
     // Config number, interface count, string index, total length, attribute,
     // power in mA
-    TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, 0x00, 100),
+    /*
+     * Advertise remote wakeup so the host may enable it (SET_FEATURE) and we
+     * can pulse K-state via tud_remote_wakeup() while suspended.  Without this
+     * bit, Linux may leave the link in USB suspend while the host is idle; bulk
+     * IN may not run until the bus leaves suspend.
+     */
+    TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN,
+                          TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, 100),
 
     // 1st CDC: Interface number, string index, EP notification address and
     // size, EP data address (out, in) and size.

--- a/platform/drivers/USB/usb_descriptors.c
+++ b/platform/drivers/USB/usb_descriptors.c
@@ -92,10 +92,6 @@ enum
 #define EPNUM_CDC_0_OUT   0x02
 #define EPNUM_CDC_0_IN    0x82
 
-#define EPNUM_CDC_1_NOTIF 0x83
-#define EPNUM_CDC_1_OUT   0x04
-#define EPNUM_CDC_1_IN    0x84
-
 uint8_t const desc_fs_configuration[] =
 {
     // Config number, interface count, string index, total length, attribute,

--- a/platform/drivers/USB/usb_serial_stm32h7.c
+++ b/platform/drivers/USB/usb_serial_stm32h7.c
@@ -1,0 +1,243 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "interfaces/usb_serial.h"
+#include "peripherals/gpio.h"
+#include "pinmap.h"
+#include "hwconfig.h"
+#include "tusb.h"
+#include <stm32h743xx.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdatomic.h>
+
+/*
+ * USB device mount state, maintained by tud_mount_cb / tud_umount_cb.
+ * Written only from the main thread (tinyUSB callbacks run inside tud_task()).
+ * Read from any thread via usb_serial_write().  _Atomic ensures the read is
+ * safe without a mutex.
+ *
+ * Gated on tud_mounted() (device enumerated) rather than tud_cdc_connected()
+ * (DTR asserted by host).  DTR-gating is too strict: many host tools - loggers,
+ * scripted readers, cat - never assert DTR, which would make output appear
+ * silently dropped.  If the host has not opened a terminal the ring buffer just
+ * fills up and writes return short; no data is sent to the CDC FIFO until a
+ * consumer connects.
+ */
+static _Atomic bool usb_mounted = false;
+
+/*
+ * Initialisation complete flag.  Set at the end of usb_serial_init().
+ * Guards usb_serial_available() and usb_serial_read() against calls before
+ * tinyUSB state is valid.  usb_serial_write() is guarded implicitly by
+ * usb_mounted (false until tud_mount_cb fires after init).
+ */
+static _Atomic bool usb_ready = false;
+
+void usb_serial_init(void)
+{
+    /* Enable D2 SRAM1 clock so that the .usb_ram section at 0x30000000 is
+     * accessible. RCC_AHB2ENR resets to 0; without this, any access to
+     * tinyUSB buffers placed in D2 SRAM causes a bus fault.
+     */
+    RCC->AHB2ENR |= RCC_AHB2ENR_D2SRAM1EN;
+    __DSB();
+
+    /*
+     * Enable the USB voltage detector (PWR_CR3_USB33DEN) and wait for
+     * VDDUSB to stabilise.  The FS PHY requires a valid 3.3 V supply on
+     * VDDUSB; without it the PHY clock never starts and tinyUSB's
+     * reset_core() hangs forever polling GRSTCTL_AHBIDL.
+     *
+     * Note: PWR_CR3_USBREGEN (the internal USB voltage regulator) is
+     * intentionally NOT set.  The regulator sources current from the
+     * battery and creates a leakage path that keeps the battery voltage
+     * reading above the power-off threshold in platform_pwrButtonStatus(),
+     * preventing the device from turning off.  The external 3.3 V rail
+     * is sufficient; only the detector is needed.
+     */
+    PWR->CR3 |= PWR_CR3_USB33DEN;
+    while (!(PWR->CR3 & PWR_CR3_USB33RDY)) {}
+
+    /* Enable GPIOA clock (AHB4 on STM32H7) and configure USB_DN/USB_DP */
+    RCC->AHB4ENR |= RCC_AHB4ENR_GPIOAEN;
+    __DSB();
+
+    gpio_setMode(USB_DN, ALTERNATE | ALTERNATE_FUNC(10));
+    gpio_setMode(USB_DP, ALTERNATE | ALTERNATE_FUNC(10));
+    gpio_setOutputSpeed(USB_DN, HIGH);
+    gpio_setOutputSpeed(USB_DP, HIGH);
+
+    /* Enable HSI48 and wait for it to be ready */
+    RCC->CR |= RCC_CR_HSI48ON;
+    while ((RCC->CR & RCC_CR_HSI48RDY) == 0) {}
+
+    /*
+     * Select HSI48 as USB clock source.
+     * D2CCIP2R USBSEL[1:0]: 00=off, 01=PLL1Q, 10=PLL3Q, 11=HSI48.
+     * Both USBSEL_0 (bit 20) and USBSEL_1 (bit 21) must be set for HSI48.
+     */
+    RCC->D2CCIP2R = (RCC->D2CCIP2R & ~RCC_D2CCIP2R_USBSEL)
+                  | RCC_D2CCIP2R_USBSEL_0 | RCC_D2CCIP2R_USBSEL_1;
+
+    /*
+     * USB_OTG_FS is USB2 on STM32H743; use RCC_AHB1ENR_USB2OTGFSEN.
+     * (USB1 is the HS peripheral; USB2 is the FS-only peripheral on PA11/PA12.)
+     *
+     * Force a peripheral reset before enabling the clock. NVIC_SystemReset()
+     * should reset peripherals, but the USB OTG core can still be left in a
+     * bad state after a soft reset. The explicit reset below is the safe
+     * workaround regardless.
+     */
+    RCC->AHB1ENR |= RCC_AHB1ENR_USB2OTGFSEN;
+    __DSB();
+
+    /* Reset the USB peripheral after enabling its clock to clear any stale
+     * state left over from a previous soft reset.
+     */
+    RCC->AHB1RSTR |=  RCC_AHB1RSTR_USB2OTGFSRST;
+    __DSB();
+    RCC->AHB1RSTR &= ~RCC_AHB1RSTR_USB2OTGFSRST;
+    __DSB();
+
+    /*
+     * Disable VBUS detection so the FS PHY treats VBUS as always present.
+     * On STM32H7 the F4-era NOVBUSSENS bit does not exist; clearing VBDEN
+     * achieves the same result.
+     * Do not set PWRDWN here; tinyUSB's dwc2_phy_init() sets it during
+     * tusb_init() and would conflict if we set it beforehand.
+     */
+    USB_OTG_FS->GCCFG &= ~USB_OTG_GCCFG_VBDEN;
+
+    /*
+     * Set interrupt priority BEFORE tusb_init().
+     * Do not call NVIC_EnableIRQ() here: tinyUSB calls dcd_int_enable()
+     * at the end of tud_rhport_init(). Enabling the IRQ before the USB stack
+     * is initialized causes a hard fault when the peripheral fires an event
+     * with uninitialized tinyUSB state.
+     */
+    NVIC_SetPriority(OTG_FS_IRQn, USB_OTG_FS_IRQ_PRIORITY);
+
+    if (!tusb_init())
+    {
+        return;
+    }
+
+    /*
+     * Disable buffering on stdout.  usb_serial_write() is non-blocking and
+     * manages its own internal buffer; a libc-level buffer would only add
+     * latency and complicate partial-write handling.
+     */
+    (void) setvbuf(stdout, NULL, _IONBF, 0);
+
+    atomic_store(&usb_ready, true);
+}
+
+void usb_serial_terminate(void)
+{
+    NVIC_DisableIRQ(OTG_FS_IRQn);
+    RCC->AHB1ENR &= ~RCC_AHB1ENR_USB2OTGFSEN;
+    __DSB();
+    atomic_store(&usb_mounted, false);
+    atomic_store(&usb_ready, false);
+}
+
+void usb_serial_task(void)
+{
+    tud_task();
+}
+
+bool usb_serial_connected(void)
+{
+    return atomic_load(&usb_mounted);
+}
+
+uint32_t usb_serial_available(void)
+{
+    if (!atomic_load(&usb_ready))
+    {
+        return 0;
+    }
+
+    return tud_cdc_available();
+}
+
+ssize_t usb_serial_write(const void *buf, size_t len)
+{
+    if (!atomic_load(&usb_mounted))
+    {
+        return -1;
+    }
+
+    const uint8_t *p = (const uint8_t *) buf;
+    size_t rem = len;
+    uint32_t timeout = 500;   /* ms */
+
+    while (rem > 0)
+    {
+        uint32_t written = tud_cdc_write(p, rem);
+        tud_cdc_write_flush();
+        p += written;
+        rem -= written;
+
+        if (rem == 0)
+        {
+            break;
+        }
+
+        if (timeout == 0)
+        {
+            tud_cdc_write_clear();
+            return -1;
+        }
+
+        /*
+         * Call tud_task() here rather than delayMs().
+         * CDC's xfer_isr is NULL, so transfer-complete events are queued
+         * and only processed by tud_task(). Without this call the endpoint
+         * busy flag never clears, tud_cdc_write_flush() keeps failing, and
+         * every write larger than one 64-byte packet times out.
+         */
+        tud_task();
+        timeout--;
+    }
+
+    return (ssize_t) len;
+}
+
+ssize_t usb_serial_read(void *buf, size_t len)
+{
+    if (!atomic_load(&usb_ready))
+    {
+        return -1;
+    }
+
+    if (!atomic_load(&usb_mounted))
+    {
+        return -1;
+    }
+
+    return (ssize_t) tud_cdc_read(buf, len);
+}
+
+/* Funky function name required because of C/C++ mangling from Miosix
+ * See: https://openrtx.org/#/software?id=parts-with-c-code-in-the-codebase */
+void _Z17OTG_FS_IRQHandlerv(void)
+{
+    tud_int_handler(USB_SERIAL_RHPORT);
+}
+
+void tud_mount_cb(void)
+{
+    atomic_store(&usb_mounted, true);
+}
+
+void tud_umount_cb(void)
+{
+    atomic_store(&usb_mounted, false);
+}

--- a/platform/drivers/USB/usb_serial_stm32h7.c
+++ b/platform/drivers/USB/usb_serial_stm32h7.c
@@ -15,6 +15,7 @@
 #include <stddef.h>
 #include <stdio.h>
 #include <stdatomic.h>
+#include <pthread.h>
 
 /*
  * USB device mount state, maintained by tud_mount_cb / tud_umount_cb.
@@ -38,6 +39,28 @@ static _Atomic bool usb_mounted = false;
  * usb_mounted (false until tud_mount_cb fires after init).
  */
 static _Atomic bool usb_ready = false;
+
+/*
+ * Software TX ring buffer.
+ *
+ * Multiple threads may call usb_serial_write() concurrently (MPSC).
+ * tx_mutex serialises the write (producer) side.  usb_serial_task()
+ * is the sole consumer and runs in the main thread; it snapshots
+ * tx_head with an atomic acquire load so it never needs to hold the
+ * mutex while writing to the CDC FIFO.
+ *
+ * Both tx_head and tx_tail are _Atomic: tx_tail is read by producers
+ * (to detect a full ring) without holding tx_mutex, so it must be
+ * accessed atomically to avoid data races.  Producers read tx_tail
+ * with a relaxed load - a slightly stale value produces a conservative
+ * "ring fuller than it really is" result, which can only cause short
+ * writes, already the documented behaviour.
+ */
+
+static uint8_t          tx_buf[USB_SERIAL_TX_BUF_SIZE];
+static _Atomic uint32_t tx_head = 0;   /* next write position, producer-owned */
+static _Atomic uint32_t tx_tail = 0;   /* next read position,  consumer-owned  */
+static pthread_mutex_t  tx_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 void usb_serial_init(void)
 {
@@ -149,7 +172,42 @@ void usb_serial_terminate(void)
 
 void usb_serial_task(void)
 {
+    /* Service tinyUSB first so that mount/unmount state changes are
+     * processed before we inspect usb_mounted or write to the CDC FIFO.
+     * Without this, the first bytes after a terminal connects can be
+     * discarded because usb_mounted is still false on this tick.
+     */
     tud_task();
+
+    if (atomic_load(&usb_mounted))
+    {
+        /* Drain the TX ring buffer into the CDC FIFO.
+         *
+         * Snapshot tx_head with an acquire load so we see all bytes written
+         * by producers before their release store.  Load tx_tail with a
+         * relaxed load - it is consumer-private and only ever modified here.
+         */
+        uint32_t head = atomic_load_explicit(&tx_head, memory_order_acquire);
+        uint32_t tail = atomic_load_explicit(&tx_tail, memory_order_relaxed);
+
+        while (tail != head)
+        {
+            /* Number of contiguous bytes available before wrap */
+            uint32_t chunk = (head >= tail) ? (head - tail)
+                                            : (USB_SERIAL_TX_BUF_SIZE - tail);
+
+            uint32_t sent = tud_cdc_write(&tx_buf[tail], chunk);
+            tail = (tail + sent) % USB_SERIAL_TX_BUF_SIZE;
+
+            if (sent < chunk)
+            {
+                break;  /* CDC FIFO full; flush and retry next tick */
+            }
+        }
+
+        atomic_store_explicit(&tx_tail, tail, memory_order_relaxed);
+        tud_cdc_write_flush();
+    }
 }
 
 bool usb_serial_connected(void)
@@ -174,40 +232,34 @@ ssize_t usb_serial_write(const void *buf, size_t len)
         return -1;
     }
 
-    const uint8_t *p = (const uint8_t *) buf;
-    size_t rem = len;
-    uint32_t timeout = 500;   /* ms */
+    const uint8_t *p       = (const uint8_t *) buf;
+    size_t         written = 0;
 
-    while (rem > 0)
+    pthread_mutex_lock(&tx_mutex);
+
+    /* Use a local head so all bytes of this write are committed atomically.
+     * The mutex guarantees exclusive producer access; the release store at
+     * the end makes the bytes visible to the consumer in one step, preventing
+     * usb_serial_task() from observing a partial write mid-buffer.
+     */
+    uint32_t head = atomic_load_explicit(&tx_head, memory_order_relaxed);
+
+    while (written < len)
     {
-        uint32_t written = tud_cdc_write(p, rem);
-        tud_cdc_write_flush();
-        p += written;
-        rem -= written;
-
-        if (rem == 0)
+        uint32_t next = (head + 1) % USB_SERIAL_TX_BUF_SIZE;
+        if (next == atomic_load_explicit(&tx_tail, memory_order_relaxed))
         {
-            break;
+            break;  /* ring buffer full */
         }
-
-        if (timeout == 0)
-        {
-            tud_cdc_write_clear();
-            return -1;
-        }
-
-        /*
-         * Call tud_task() here rather than delayMs().
-         * CDC's xfer_isr is NULL, so transfer-complete events are queued
-         * and only processed by tud_task(). Without this call the endpoint
-         * busy flag never clears, tud_cdc_write_flush() keeps failing, and
-         * every write larger than one 64-byte packet times out.
-         */
-        tud_task();
-        timeout--;
+        tx_buf[head] = p[written++];
+        head = next;
     }
 
-    return (ssize_t) len;
+    atomic_store_explicit(&tx_head, head, memory_order_release);
+
+    pthread_mutex_unlock(&tx_mutex);
+
+    return (ssize_t) written;
 }
 
 ssize_t usb_serial_read(void *buf, size_t len)

--- a/platform/drivers/USB/usb_serial_stm32h7.c
+++ b/platform/drivers/USB/usb_serial_stm32h7.c
@@ -5,6 +5,7 @@
  */
 
 #include "interfaces/usb_serial.h"
+#include "interfaces/delays.h"
 #include "peripherals/gpio.h"
 #include "pinmap.h"
 #include "hwconfig.h"
@@ -26,9 +27,7 @@
  * Gated on tud_mounted() (device enumerated) rather than tud_cdc_connected()
  * (DTR asserted by host).  DTR-gating is too strict: many host tools - loggers,
  * scripted readers, cat - never assert DTR, which would make output appear
- * silently dropped.  If the host has not opened a terminal the ring buffer just
- * fills up and writes return short; no data is sent to the CDC FIFO until a
- * consumer connects.
+ * silently dropped.
  */
 static _Atomic bool usb_mounted = false;
 
@@ -41,26 +40,81 @@ static _Atomic bool usb_mounted = false;
 static _Atomic bool usb_ready = false;
 
 /*
- * Software TX ring buffer.
- *
- * Multiple threads may call usb_serial_write() concurrently (MPSC).
- * tx_mutex serialises the write (producer) side.  usb_serial_task()
- * is the sole consumer and runs in the main thread; it snapshots
- * tx_head with an atomic acquire load so it never needs to hold the
- * mutex while writing to the CDC FIFO.
- *
- * Both tx_head and tx_tail are _Atomic: tx_tail is read by producers
- * (to detect a full ring) without holding tx_mutex, so it must be
- * accessed atomically to avoid data races.  Producers read tx_tail
- * with a relaxed load - a slightly stale value produces a conservative
- * "ring fuller than it really is" result, which can only cause short
- * writes, already the documented behaviour.
+ * If tud_cdc_notify_uart_state() fails in tud_mount_cb() (INT EP busy), retry
+ * from usb_serial_task() until it succeeds or we unmount.
  */
+static _Atomic bool cdc_uart_notify_pending = false;
 
-static uint8_t          tx_buf[USB_SERIAL_TX_BUF_SIZE];
-static _Atomic uint32_t tx_head = 0;   /* next write position, producer-owned */
-static _Atomic uint32_t tx_tail = 0;   /* next read position,  consumer-owned  */
-static pthread_mutex_t  tx_mutex = PTHREAD_MUTEX_INITIALIZER;
+#if CFG_TUD_CDC_NOTIFY
+/*
+ * After reconnect, fire several SERIAL_STATE notifications in quick succession
+ * so Linux cdc-acm sees carrier before open() blocks for ~10 s waiting on DCD.
+ */
+static uint8_t carrier_boot_notify_remaining;
+#endif
+
+/*
+ * Mutex that serialises all tinyUSB CDC calls (tud_cdc_write,
+ * tud_cdc_write_flush, tud_cdc_write_clear) and tud_task() itself.
+ * tud_task() is not re-entrant; holding this mutex before every call
+ * ensures only one thread pumps the USB stack at a time, whether that
+ * is usb_serial_task() on its regular tick or usb_serial_write()
+ * waiting for the CDC TX FIFO to drain.
+ */
+static pthread_mutex_t cdc_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+#if CFG_TUD_CDC_NOTIFY
+/*
+ * Assert DCD/DSR via SERIAL_STATE so Linux cdc-acm treats the port as having
+ * carrier (open() / stty do not block waiting for modem lines).  If the notify
+ * endpoint is busy, usb_serial_task() retries via cdc_uart_notify_pending.
+ */
+static void usb_serial_send_carrier_notify(void)
+{
+    cdc_notify_uart_state_t state = { 0 };
+
+    state.dcd = 1;
+    state.dsr = 1;
+    if (tud_cdc_notify_uart_state(&state)) {
+        atomic_store(&cdc_uart_notify_pending, false);
+    } else {
+        atomic_store(&cdc_uart_notify_pending, true);
+    }
+}
+
+/*
+ * Host sends SET_CONTROL_LINE_STATE when a terminal opens the port; send
+ * carrier again so the driver refreshes (helps after failed notify at mount).
+ */
+void tud_cdc_line_state_cb(uint8_t itf, bool dtr, bool rts)
+{
+    (void)itf;
+    (void)dtr;
+    (void)rts;
+
+    if (!atomic_load(&usb_mounted)) {
+        return;
+    }
+
+    usb_serial_send_carrier_notify();
+}
+
+/*
+ * Host often sends SET_LINE_CODING during open(); piggyback carrier notify so
+ * cdc-acm updates before or alongside SET_CONTROL_LINE_STATE.
+ */
+void tud_cdc_line_coding_cb(uint8_t itf, cdc_line_coding_t const *p_line_coding)
+{
+    (void)itf;
+    (void)p_line_coding;
+
+    if (!atomic_load(&usb_mounted)) {
+        return;
+    }
+
+    usb_serial_send_carrier_notify();
+}
+#endif
 
 void usb_serial_init(void)
 {
@@ -85,7 +139,8 @@ void usb_serial_init(void)
      * is sufficient; only the detector is needed.
      */
     PWR->CR3 |= PWR_CR3_USB33DEN;
-    while (!(PWR->CR3 & PWR_CR3_USB33RDY)) {}
+    while (!(PWR->CR3 & PWR_CR3_USB33RDY)) {
+    }
 
     /* Enable GPIOA clock (AHB4 on STM32H7) and configure USB_DN/USB_DP */
     RCC->AHB4ENR |= RCC_AHB4ENR_GPIOAEN;
@@ -98,7 +153,8 @@ void usb_serial_init(void)
 
     /* Enable HSI48 and wait for it to be ready */
     RCC->CR |= RCC_CR_HSI48ON;
-    while ((RCC->CR & RCC_CR_HSI48RDY) == 0) {}
+    while ((RCC->CR & RCC_CR_HSI48RDY) == 0) {
+    }
 
     /*
      * Select HSI48 as USB clock source.
@@ -123,7 +179,7 @@ void usb_serial_init(void)
     /* Reset the USB peripheral after enabling its clock to clear any stale
      * state left over from a previous soft reset.
      */
-    RCC->AHB1RSTR |=  RCC_AHB1RSTR_USB2OTGFSRST;
+    RCC->AHB1RSTR |= RCC_AHB1RSTR_USB2OTGFSRST;
     __DSB();
     RCC->AHB1RSTR &= ~RCC_AHB1RSTR_USB2OTGFSRST;
     __DSB();
@@ -146,17 +202,15 @@ void usb_serial_init(void)
      */
     NVIC_SetPriority(OTG_FS_IRQn, USB_OTG_FS_IRQ_PRIORITY);
 
-    if (!tusb_init())
-    {
+    if (!tusb_init()) {
         return;
     }
 
     /*
-     * Disable buffering on stdout.  usb_serial_write() is non-blocking and
-     * manages its own internal buffer; a libc-level buffer would only add
-     * latency and complicate partial-write handling.
+     * Disable buffering on stdout.  usb_serial_write() manages its own
+     * blocking loop; a libc-level buffer would only add latency.
      */
-    (void) setvbuf(stdout, NULL, _IONBF, 0);
+    (void)setvbuf(stdout, NULL, _IONBF, 0);
 
     atomic_store(&usb_ready, true);
 }
@@ -168,46 +222,39 @@ void usb_serial_terminate(void)
     __DSB();
     atomic_store(&usb_mounted, false);
     atomic_store(&usb_ready, false);
+    atomic_store(&cdc_uart_notify_pending, false);
 }
 
 void usb_serial_task(void)
 {
-    /* Service tinyUSB first so that mount/unmount state changes are
-     * processed before we inspect usb_mounted or write to the CDC FIFO.
-     * Without this, the first bytes after a terminal connects can be
-     * discarded because usb_mounted is still false on this tick.
-     */
+    pthread_mutex_lock(&cdc_mutex);
+
+    /* Process USB events (mount/unmount, receive data, transfer completions). */
     tud_task();
 
-    if (atomic_load(&usb_mounted))
-    {
-        /* Drain the TX ring buffer into the CDC FIFO.
-         *
-         * Snapshot tx_head with an acquire load so we see all bytes written
-         * by producers before their release store.  Load tx_tail with a
-         * relaxed load - it is consumer-private and only ever modified here.
-         */
-        uint32_t head = atomic_load_explicit(&tx_head, memory_order_acquire);
-        uint32_t tail = atomic_load_explicit(&tx_tail, memory_order_relaxed);
-
-        while (tail != head)
-        {
-            /* Number of contiguous bytes available before wrap */
-            uint32_t chunk = (head >= tail) ? (head - tail)
-                                            : (USB_SERIAL_TX_BUF_SIZE - tail);
-
-            uint32_t sent = tud_cdc_write(&tx_buf[tail], chunk);
-            tail = (tail + sent) % USB_SERIAL_TX_BUF_SIZE;
-
-            if (sent < chunk)
-            {
-                break;  /* CDC FIFO full; flush and retry next tick */
-            }
+#if CFG_TUD_CDC_NOTIFY
+    if (atomic_load(&usb_mounted)) {
+        if (carrier_boot_notify_remaining > 0) {
+            carrier_boot_notify_remaining--;
+            usb_serial_send_carrier_notify();
+        } else if (atomic_load(&cdc_uart_notify_pending)) {
+            usb_serial_send_carrier_notify();
         }
+    }
+#endif
 
-        atomic_store_explicit(&tx_tail, tail, memory_order_relaxed);
+    /*
+     * Flush any bytes still in the CDC TX FIFO that were not yet committed to
+     * an IN transfer.  This happens when usb_serial_write() called
+     * tud_cdc_write_flush() while the endpoint was already busy; that flush was
+     * a no-op.  After tud_task() processes the transfer-complete event, a
+     * second flush here picks up the residual bytes (often the trailing "\r\n"
+     * from _write_r after the main text chunk).
+     */
+    if (atomic_load(&usb_mounted)) {
         tud_cdc_write_flush();
     }
+    pthread_mutex_unlock(&cdc_mutex);
 }
 
 bool usb_serial_connected(void)
@@ -217,8 +264,7 @@ bool usb_serial_connected(void)
 
 uint32_t usb_serial_available(void)
 {
-    if (!atomic_load(&usb_ready))
-    {
+    if (!atomic_load(&usb_ready)) {
         return 0;
     }
 
@@ -227,54 +273,91 @@ uint32_t usb_serial_available(void)
 
 ssize_t usb_serial_write(const void *buf, size_t len)
 {
-    if (!atomic_load(&usb_mounted))
-    {
+    /*
+     * Return immediately if the USB device is not mounted.
+     * This avoids blocking the caller when the cable is unplugged.
+     */
+    if (!atomic_load(&usb_mounted)) {
         return -1;
     }
 
-    const uint8_t *p       = (const uint8_t *) buf;
-    size_t         written = 0;
+    const uint8_t *p = (const uint8_t *)buf;
+    size_t rem = len;
+    uint32_t timeout = 50; /* ~50 ms: 50 retries * 1 ms sleep */
 
-    pthread_mutex_lock(&tx_mutex);
+    pthread_mutex_lock(&cdc_mutex);
 
-    /* Use a local head so all bytes of this write are committed atomically.
-     * The mutex guarantees exclusive producer access; the release store at
-     * the end makes the bytes visible to the consumer in one step, preventing
-     * usb_serial_task() from observing a partial write mid-buffer.
+    /*
+     * If the link is in USB suspend (host idle / selective suspend), IN
+     * traffic may not run until the bus resumes.  Advertise remote wakeup in
+     * the configuration descriptor and pulse here when we have data to send.
      */
-    uint32_t head = atomic_load_explicit(&tx_head, memory_order_relaxed);
-
-    while (written < len)
-    {
-        uint32_t next = (head + 1) % USB_SERIAL_TX_BUF_SIZE;
-        if (next == atomic_load_explicit(&tx_tail, memory_order_relaxed))
-        {
-            break;  /* ring buffer full */
-        }
-        tx_buf[head] = p[written++];
-        head = next;
+    if (len > 0 && tud_suspended()) {
+        (void)tud_remote_wakeup();
     }
 
-    atomic_store_explicit(&tx_head, head, memory_order_release);
+    while (rem > 0) {
+        /* Bail out if the host disconnects mid-transfer */
+        if (!atomic_load(&usb_mounted)) {
+            tud_cdc_write_clear();
+            pthread_mutex_unlock(&cdc_mutex);
+            return -1;
+        }
 
-    pthread_mutex_unlock(&tx_mutex);
+        uint32_t accepted = tud_cdc_write(p, rem);
+        p += accepted;
+        rem -= accepted;
 
-    return (ssize_t) written;
+        if (rem == 0) {
+            break;
+        }
+
+        /*
+         * The CDC TX FIFO is full (64 bytes at FS speed).  Flush what has
+         * been accepted, release the mutex so usb_serial_task() can run
+         * during the sleep, then re-acquire and pump the stack ourselves.
+         * tud_task() is called *inside* the mutex so it cannot execute
+         * concurrently with usb_serial_task()'s tud_task() call; concurrent
+         * calls corrupt tinyUSB state and cause hangs on USB disconnect.
+         */
+        tud_cdc_write_flush();
+
+        if (timeout == 0) {
+            tud_cdc_write_clear();
+            pthread_mutex_unlock(&cdc_mutex);
+            return -1;
+        }
+        timeout--;
+
+        pthread_mutex_unlock(&cdc_mutex);
+        delayMs(1); /* yield; allow the ISR to queue the xfer-complete event */
+        pthread_mutex_lock(&cdc_mutex);
+
+        if (tud_suspended()) {
+            (void)tud_remote_wakeup();
+        }
+
+        tud_task(); /* process events under the mutex — cannot race with
+                         * usb_serial_task(), preventing concurrent tud_task()
+                         * calls that corrupt tinyUSB state on USB disconnect */
+    }
+
+    tud_cdc_write_flush();
+    pthread_mutex_unlock(&cdc_mutex);
+    return (ssize_t)len;
 }
 
 ssize_t usb_serial_read(void *buf, size_t len)
 {
-    if (!atomic_load(&usb_ready))
-    {
+    if (!atomic_load(&usb_ready)) {
         return -1;
     }
 
-    if (!atomic_load(&usb_mounted))
-    {
+    if (!atomic_load(&usb_mounted)) {
         return -1;
     }
 
-    return (ssize_t) tud_cdc_read(buf, len);
+    return (ssize_t)tud_cdc_read(buf, len);
 }
 
 /* Funky function name required because of C/C++ mangling from Miosix
@@ -287,9 +370,48 @@ void _Z17OTG_FS_IRQHandlerv(void)
 void tud_mount_cb(void)
 {
     atomic_store(&usb_mounted, true);
+    atomic_store(&cdc_uart_notify_pending, false);
+#if CFG_TUD_CDC_NOTIFY
+    carrier_boot_notify_remaining = 8;
+
+    /*
+     * Signal carrier present (DCD=1, DSR=1) to the host via a CDC
+     * SERIAL_STATE notification on the interrupt endpoint.
+     *
+     * The Linux cdc-acm driver updates its carrier state when it receives
+     * this notification.  Without it, the driver never asserts DCD and any
+     * open() call on /dev/ttyACMx that does not pass O_NONBLOCK blocks
+     * indefinitely (or for a long kernel timeout) waiting for carrier.
+     * This is why stty and picocom hang for ~11 s after the device enumerates.
+     *
+     * tud_mount_cb() is called from within tud_task(), so the cdc_mutex is
+     * already held; tud_cdc_notify_uart_state() uses only internal tinyUSB
+     * state (no mutex acquisition) and is safe to call here.
+     */
+    usb_serial_send_carrier_notify();
+#endif
 }
 
 void tud_umount_cb(void)
 {
     atomic_store(&usb_mounted, false);
+    atomic_store(&cdc_uart_notify_pending, false);
+#if CFG_TUD_CDC_NOTIFY
+    carrier_boot_notify_remaining = 0;
+#endif
 }
+
+/*
+ * Do not override tud_suspend_cb() / tud_resume_cb().
+ *
+ * tinyUSB's stack documents that during enumeration the D+/D- lines can
+ * momentarily meet the USB "suspend" condition (bus idle for 3 ms).  Clearing
+ * application state on suspend therefore races normal control transfers
+ * (SET_LINE_CODING, SET_CONTROL_LINE_STATE) and was flipping usb_mounted off
+ * and back on, breaking host tools and motivating fragile resume workarounds.
+ *
+ * Physical disconnect is reported as DCD_EVENT_UNPLUGGED -> tud_umount_cb().
+ * While the device remains configured but the host is not polling IN (e.g.
+ * real bus suspend), usb_serial_write() may wait for FIFO space; the bounded
+ * retry loop (~50 ms) prevents indefinite blocking.
+ */

--- a/platform/mcu/STM32H7xx/boot/libc_integration.cpp
+++ b/platform/mcu/STM32H7xx/boot/libc_integration.cpp
@@ -4,11 +4,22 @@
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
+#include <pthread.h>
 #include <stdio.h>
 #include <reent.h>
 #include "filesystem/file_access.h"
 #include "hwconfig.h"
 #include "interfaces/usb_serial.h"
+
+#ifdef CONFIG_USB_SERIAL
+static pthread_mutex_t stdio_usb_mutex = PTHREAD_MUTEX_INITIALIZER;
+/*
+ * If the previous _write_r ended by sending a lone '\r' (e.g. printf split
+ * "foo\r" and "\n" across two writes), the next write must send only '\n' to
+ * complete CRLF — not '\r\n' again — or the wire sees '\r\r\n' (staircase).
+ */
+static bool usb_out_pending_cr;
+#endif
 
 using namespace std;
 
@@ -25,6 +36,7 @@ int _write_r(struct _reent *ptr, int fd, const void *buf, size_t cnt)
 #ifdef CONFIG_USB_SERIAL
     if(fd == STDOUT_FILENO || fd == STDERR_FILENO)
     {
+        pthread_mutex_lock(&stdio_usb_mutex);
         /*
          * Best-effort lossy console output.
          *
@@ -32,7 +44,7 @@ int _write_r(struct _reent *ptr, int fd, const void *buf, size_t cnt)
          * usb_serial_write() actually sent.  This is intentional: the USB
          * serial port is a debug console, not a reliable byte stream.
          * Propagating partial counts would cause stdio to retry, which can
-         * stall the caller when the ring buffer is full or the device is not
+         * stall the caller when the CDC TX FIFO is full or the device is not
          * yet mounted.  Callers that require reliable delivery must not use
          * stdio for that purpose.
          *
@@ -41,32 +53,80 @@ int _write_r(struct _reent *ptr, int fd, const void *buf, size_t cnt)
          * discarded until the USB device is enumerated.
          *
          * Translate \n -> \r\n so output renders correctly in serial
-         * terminals (CDC ACM presents as a raw byte stream with no tty
-         * processing).  The translation is done here in the stdio layer,
+         * terminals.
+         * The translation is done here in the stdio layer,
          * not in the driver, so the driver can be used for binary
          * protocols (TNC, NMEA passthrough) without corruption.
+         *
+         * Note: the Linux host TTY (/dev/ttyACMx) has ICRNL enabled by
+         * default, which translates incoming \r (0x0D) to \n (0x0A) before
+         * the data reaches the application.  This converts our \r\n into
+         * \n\n, causing double-spacing and loss of carriage return in
+         * terminal emulators. minicom and HTerm work fine out of the box.
+         * picocom should work with --imap lfcrlf
          */
-        const char *p   = (const char *) buf;
-        size_t      rem = cnt;
-        while(rem > 0)
+        const char *p    = (const char *) buf;
+        size_t      left = cnt;
+        size_t      i    = 0;
+
+        while(i < left)
         {
-            size_t chunk = 0;
-            while(chunk < rem && p[chunk] != '\n')
-                chunk++;
-
-            if(chunk > 0)
-                usb_serial_write(p, chunk);
-
-            if(chunk < rem)
+            if(usb_out_pending_cr)
             {
-                usb_serial_write("\r\n", 2);
-                chunk++;
+                if(p[i] == '\n')
+                {
+                    usb_out_pending_cr = false;
+                    i++;
+                    pthread_mutex_unlock(&stdio_usb_mutex);
+                    usb_serial_write("\n", 1);
+                    pthread_mutex_lock(&stdio_usb_mutex);
+                    continue;
+                }
+                usb_out_pending_cr = false;
             }
 
-            p   += chunk;
-            rem -= chunk;
+            size_t chunk = left - i;
+            if(chunk > 512)
+                chunk = 512;
+
+            char   out[1024];
+            size_t o = 0;
+            for(size_t j = 0; j < chunk; j++)
+            {
+                char c = p[i + j];
+                if(c == '\n')
+                {
+                    if(o > 0 && out[o - 1] == '\r')
+                        out[o++] = '\n';
+                    else
+                    {
+                        out[o++] = '\r';
+                        out[o++] = '\n';
+                    }
+                }
+                else
+                {
+                    out[o++] = c;
+                }
+            }
+            if(o > 0 && out[o - 1] == '\r')
+                usb_out_pending_cr = true;
+            else
+                usb_out_pending_cr = false;
+
+            i += chunk;
+            /*
+             * Do not hold stdio_usb_mutex across usb_serial_write(): that path
+             * can block ~50 ms retrying CDC TX while pumping would otherwise be
+             * starved and other threads could not use stdio.
+             */
+            pthread_mutex_unlock(&stdio_usb_mutex);
+            usb_serial_write(out, o);
+            pthread_mutex_lock(&stdio_usb_mutex);
         }
-        return cnt;
+
+        pthread_mutex_unlock(&stdio_usb_mutex);
+        return (int)cnt;
     }
 #endif
 

--- a/platform/mcu/STM32H7xx/boot/libc_integration.cpp
+++ b/platform/mcu/STM32H7xx/boot/libc_integration.cpp
@@ -7,6 +7,8 @@
 #include <stdio.h>
 #include <reent.h>
 #include "filesystem/file_access.h"
+#include "hwconfig.h"
+#include "interfaces/usb_serial.h"
 
 using namespace std;
 
@@ -20,10 +22,55 @@ extern "C" {
  */
 int _write_r(struct _reent *ptr, int fd, const void *buf, size_t cnt)
 {
+#ifdef CONFIG_USB_SERIAL
+    if(fd == STDOUT_FILENO || fd == STDERR_FILENO)
+    {
+        /*
+         * Best-effort lossy console output.
+         *
+         * This function always returns cnt regardless of how many bytes
+         * usb_serial_write() actually sent.  This is intentional: the USB
+         * serial port is a debug console, not a reliable byte stream.
+         * Propagating partial counts would cause stdio to retry, which can
+         * stall the caller when the ring buffer is full or the device is not
+         * yet mounted.  Callers that require reliable delivery must not use
+         * stdio for that purpose.
+         *
+         * Before usb_serial_init() completes, usb_mounted is false and
+         * usb_serial_write() returns -1 immediately; output is silently
+         * discarded until the USB device is enumerated.
+         *
+         * Translate \n -> \r\n so output renders correctly in serial
+         * terminals (CDC ACM presents as a raw byte stream with no tty
+         * processing).  The translation is done here in the stdio layer,
+         * not in the driver, so the driver can be used for binary
+         * protocols (TNC, NMEA passthrough) without corruption.
+         */
+        const char *p   = (const char *) buf;
+        size_t      rem = cnt;
+        while(rem > 0)
+        {
+            size_t chunk = 0;
+            while(chunk < rem && p[chunk] != '\n')
+                chunk++;
+
+            if(chunk > 0)
+                usb_serial_write(p, chunk);
+
+            if(chunk < rem)
+            {
+                usb_serial_write("\r\n", 2);
+                chunk++;
+            }
+
+            p   += chunk;
+            rem -= chunk;
+        }
+        return cnt;
+    }
+#endif
+
     (void) ptr;
-    (void) fd;
-    (void) buf;
-    (void) cnt;
 
     /* If fd is not stdout or stderr */
     ptr->_errno = EBADF;

--- a/platform/mcu/STM32H7xx/linker_script_cs7000p.ld
+++ b/platform/mcu/STM32H7xx/linker_script_cs7000p.ld
@@ -51,8 +51,11 @@ MEMORY
 {
     flash(rx)   : ORIGIN = 0x08100000, LENGTH = 1M
 
-    /* NOTE: for now wer support only the AXI SRAM */
+    /* Main general-purpose RAM */
     ram(wx)     : ORIGIN = 0x24000200, LENGTH =  512K-0x200
+
+    /* Dedicated USB DMA buffer region in D2 SRAM1 */
+    usb_ram(wx) : ORIGIN = 0x30000000, LENGTH = 32K
 }
 
 /* now define the output sections  */
@@ -164,4 +167,11 @@ SECTIONS
 
     _end = .;
     PROVIDE(end = .);
+
+    /* USB DMA buffers: must reside in D2 SRAM for STM32H7 OTG FS */
+    .usb_ram (NOLOAD) :
+    {
+        *(.usb_ram)
+        *(.usb_ram.*)
+    } > usb_ram
 }

--- a/platform/targets/CS7000-PLUS/hwconfig.h
+++ b/platform/targets/CS7000-PLUS/hwconfig.h
@@ -64,6 +64,21 @@ extern const struct gpsDevice gps;
 #define CONFIG_GPS_STM32_USART6
 #define CONFIG_NMEA_RBUF_SIZE 128
 
+/* Device supports USB CDC serial */
+#define CONFIG_USB_SERIAL
+
+/* Miosix sets NVIC_SetPriorityGrouping(7), disabling interrupt nesting.
+ * In the resulting flat 0-15 scheme, 14 is near-lowest priority,
+ * consistent with other peripheral drivers. */
+#define USB_OTG_FS_IRQ_PRIORITY  14
+
+/* tinyUSB root-hub port index. USB OTG FS is port 0 on all STM32H7 targets. */
+#define USB_SERIAL_RHPORT        0
+
+/* Bytes in the software TX ring buffer. Must be a power of two so that the
+ * modulo arithmetic reduces to a bitmask at -O2. */
+#define USB_SERIAL_TX_BUF_SIZE   512
+
 /* Use extended addressing for external flash memory */
 #define CONFIG_W25Qx_EXT_ADDR
 

--- a/platform/targets/CS7000-PLUS/hwconfig.h
+++ b/platform/targets/CS7000-PLUS/hwconfig.h
@@ -75,10 +75,6 @@ extern const struct gpsDevice gps;
 /* tinyUSB root-hub port index. USB OTG FS is port 0 on all STM32H7 targets. */
 #define USB_SERIAL_RHPORT        0
 
-/* Bytes in the software TX ring buffer. Must be a power of two so that the
- * modulo arithmetic reduces to a bitmask at -O2. */
-#define USB_SERIAL_TX_BUF_SIZE   512
-
 /* Use extended addressing for external flash memory */
 #define CONFIG_W25Qx_EXT_ADDR
 

--- a/platform/targets/CS7000-PLUS/pinmap.h
+++ b/platform/targets/CS7000-PLUS/pinmap.h
@@ -162,4 +162,8 @@
 /* Vibration motor */
 #define VIBR_MOTOR    &extGpio,2
 
+/* USB OTG FS */
+#define USB_DN        GPIOA,11
+#define USB_DP        GPIOA,12
+
 #endif /* PINMAP_H */

--- a/platform/targets/CS7000-PLUS/platform.c
+++ b/platform/targets/CS7000-PLUS/platform.c
@@ -8,6 +8,7 @@
 #include "peripherals/gpio.h"
 #include "interfaces/nvmem.h"
 #include "interfaces/audio.h"
+#include "interfaces/usb_serial.h"
 #include "drivers/GPIO/gpio_shiftReg.h"
 #include "drivers/SPI/spi_bitbang.h"
 #include "drivers/ADC/adc_stm32.h"
@@ -56,6 +57,8 @@ void platform_init()
 
 void platform_terminate()
 {
+    usb_serial_terminate();
+
     adcStm32_terminate(&adc1);
     gpsStm32_terminate();
 

--- a/scripts/clang_format.sh
+++ b/scripts/clang_format.sh
@@ -57,6 +57,7 @@ openrtx/include/interfaces/delays.h
 openrtx/include/interfaces/display.h
 openrtx/include/interfaces/nvmem.h
 openrtx/include/interfaces/radio.h
+openrtx/include/interfaces/usb_serial.h
 openrtx/include/peripherals/gps.h
 openrtx/include/peripherals/rng.h
 openrtx/include/peripherals/rtc.h
@@ -87,12 +88,14 @@ platform/drivers/NVM/flash_stm32h7.c
 platform/drivers/GPIO/gpio-native.h
 platform/drivers/GPS/gps_stm32.h
 platform/drivers/GPS/gps_zephyr.h
+platform/drivers/USB/usb_serial_stm32h7.c
 platform/drivers/USB/usb.h
 platform/targets/GDx/hwconfig.h
 platform/targets/linux/emulator/sdl_engine.h
 platform/targets/ttwrplus/pmu.h
 tests/platform/mic_test.c
 tests/platform/codec2_encode_test.c
+tests/platform/usb_serial_test.c
 tests/unit/convert_minmea_coord.cpp
 tests/unit/cps.cpp
 tests/unit/linux_inputStream_test.cpp

--- a/subprojects/packagefiles/tinyusb/meson.build
+++ b/subprojects/packagefiles/tinyusb/meson.build
@@ -7,8 +7,6 @@ project('tinyusb', 'c')
 # include paths needed to compile tinyusb and already present in the main
 # program via GCC compile arguments.
 #
-add_project_arguments('-I../platform/mcu/CMSIS/Device/ST/STM32F4xx/Include',
-                      language : 'c')
 add_project_arguments('-I../platform/mcu/CMSIS/Include', language : 'c')
 add_project_arguments('-w', language : 'c')
 
@@ -18,15 +16,40 @@ tinyusb_src = ['src/tusb.c',
                'src/device/usbd.c',
                'src/common/tusb_fifo.c',
                'src/device/usbd_control.c',
-               'src/class/cdc/cdc_device.c',
-               'src/portable/st/synopsys/dcd_synopsys.c',
-               'src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c']
+               'src/class/cdc/cdc_device.c']
 
-# Define CPU type and clock speed via GCC command line arguments               
-add_project_arguments('-DSTM32F405xx',       language : 'c')
-add_project_arguments('-DHSE_VALUE=8000000', language : 'c')
+driver = get_option('usb_driver')
 
+if driver == 'auto'
+  # Infer from host_machine.cpu() as a fallback. cpu() strings are not
+  # standardised in Meson; set -Dtinyusb:usb_driver=<driver> explicitly
+  # in the parent build or cross-file to avoid depending on this mapping.
+  cpu = host_machine.cpu()
+  if cpu == 'cortex-m7'
+    driver = 'dwc2'
+  elif cpu == 'cortex-m4'
+    driver = 'stm32_fsdev'
+  else
+    warning('tinyusb: cannot infer USB driver from cpu \'' + cpu + '\'; '
+          + 'set -Dtinyusb:usb_driver=<driver> explicitly. Defaulting to stm32_fsdev.')
+    driver = 'stm32_fsdev'
+  endif
+endif
 
+if driver == 'dwc2'
+  # STM32H743: OTG FS via Synopsys DWC2 core
+  add_project_arguments('-I../platform/mcu/CMSIS/Device/ST/STM32H7xx/Include', language : 'c')
+  add_project_arguments('-DSTM32H743xx',        language : 'c')
+  add_project_arguments('-DHSE_VALUE=25000000', language : 'c')
+  tinyusb_src += ['src/portable/synopsys/dwc2/dcd_dwc2.c',
+                  'src/portable/synopsys/dwc2/dwc2_common.c']
+elif driver == 'stm32_fsdev'
+  # STM32F405: OTG FS via ST full-speed device controller
+  add_project_arguments('-I../platform/mcu/CMSIS/Device/ST/STM32F4xx/Include', language : 'c')
+  add_project_arguments('-DSTM32F405xx',       language : 'c')
+  add_project_arguments('-DHSE_VALUE=8000000', language : 'c')
+  tinyusb_src += ['src/portable/st/stm32_fsdev/dcd_stm32_fsdev.c']
+endif
 
 tinyusb = static_library('tinyusb',
                          tinyusb_src,

--- a/subprojects/packagefiles/tinyusb/meson_options.txt
+++ b/subprojects/packagefiles/tinyusb/meson_options.txt
@@ -1,0 +1,7 @@
+option('usb_driver',
+       type        : 'combo',
+       choices     : ['auto', 'dwc2', 'stm32_fsdev'],
+       value       : 'auto',
+       description : 'TinyUSB portable driver. "auto" infers from host_machine.cpu(); '
+                   + 'set explicitly (e.g. -Dtinyusb:usb_driver=dwc2) to avoid '
+                   + 'relying on non-standardised CPU identifier strings.')

--- a/subprojects/packagefiles/tinyusb/openrtx/tusb_config.h
+++ b/subprojects/packagefiles/tinyusb/openrtx/tusb_config.h
@@ -61,8 +61,18 @@
  // On STM32H7 (OTG FS), USB DMA cannot reach AXI SRAM; buffers must live in D2
  // SRAM (e.g. .usb_ram in the linker script), not the main 0x2400... region.
 #ifdef STM32H743xx
+  /* MEM_SECTION applies to file-scope driver buffers; MEM_ALIGN must be
+   * alignment-only because TinyUSB 0.20+ places EP buffers inside unions
+   * (section on members is invalid).
+   */
   #define CFG_TUSB_MEM_SECTION  __attribute__((section(".usb_ram")))
-  #define CFG_TUSB_MEM_ALIGN    __attribute__((aligned(32)))
+  #define CFG_TUSB_MEM_ALIGN    __attribute__((aligned(4)))
+  /*
+   * Miosix enables D-cache; D2 SRAM (0x3000...) is cacheable.  DWC2 DMA bypasses the
+   * CPU cache — enable tinyUSB clean/invalidate on transfers or bulk IN/OUT can fail.
+   */
+  #define CFG_TUD_MEM_DCACHE_ENABLE       1
+  #define CFG_TUSB_MEM_DCACHE_LINE_SIZE   32
 #else
   #ifndef CFG_TUSB_MEM_SECTION
     #define CFG_TUSB_MEM_SECTION
@@ -87,6 +97,13 @@
 #define CFG_TUD_HID               0
 #define CFG_TUD_MIDI              0
 #define CFG_TUD_VENDOR            0
+
+/*
+ * Enable CDC SERIAL_STATE notifications (interrupt EP 0x81).
+ * Lets the device report DCD/DSR to the host; Linux cdc-acm uses this for
+ * carrier so open() on /dev/ttyACMx does not wait indefinitely for modem status.
+ */
+#define CFG_TUD_CDC_NOTIFY        1
 
 // CDC FIFO size of TX and RX
 #define CFG_TUD_CDC_RX_BUFSIZE   (TUD_OPT_HIGH_SPEED ? 512 : 64)

--- a/subprojects/packagefiles/tinyusb/openrtx/tusb_config.h
+++ b/subprojects/packagefiles/tinyusb/openrtx/tusb_config.h
@@ -8,11 +8,12 @@
 //--------------------------------------------------------------------
 // COMMON CONFIGURATION
 //--------------------------------------------------------------------
-
    
-// Select CFG_TUSB_MCU starting from CPU type
+// Select CFG_TUSB_MCU starting from CPU type passed by the build system
 #ifdef STM32F405xx
   #define CFG_TUSB_MCU OPT_MCU_STM32F4
+#elif defined(STM32H743xx)
+  #define CFG_TUSB_MCU OPT_MCU_STM32H7
 #else
   #error CFG_TUSB_MCU must be defined
 #endif
@@ -56,12 +57,20 @@
  * - CFG_TUSB_MEM SECTION : __attribute__ (( section(".usb_ram") ))
  * - CFG_TUSB_MEM_ALIGN   : __attribute__ ((aligned(4)))
  */
-#ifndef CFG_TUSB_MEM_SECTION
-#define CFG_TUSB_MEM_SECTION
-#endif
 
-#ifndef CFG_TUSB_MEM_ALIGN
-#define CFG_TUSB_MEM_ALIGN          __attribute__ ((aligned(4)))
+ // On STM32H7 (OTG FS), USB DMA cannot reach AXI SRAM; buffers must live in D2
+ // SRAM (e.g. .usb_ram in the linker script), not the main 0x2400... region.
+#ifdef STM32H743xx
+  #define CFG_TUSB_MEM_SECTION  __attribute__((section(".usb_ram")))
+  #define CFG_TUSB_MEM_ALIGN    __attribute__((aligned(32)))
+#else
+  #ifndef CFG_TUSB_MEM_SECTION
+    #define CFG_TUSB_MEM_SECTION
+  #endif
+
+  #ifndef CFG_TUSB_MEM_ALIGN
+    #define CFG_TUSB_MEM_ALIGN  __attribute__((aligned(4)))
+  #endif
 #endif
 
 //--------------------------------------------------------------------

--- a/subprojects/tinyusb.wrap
+++ b/subprojects/tinyusb.wrap
@@ -1,4 +1,4 @@
 [wrap-git]
 url = https://github.com/hathach/tinyusb.git
-revision = 4bfab30c02279a0530e1a56f4a7c539f2d35a293
+revision = 0.20.0
 patch_directory = tinyusb

--- a/tests/platform/usb_serial_test.c
+++ b/tests/platform/usb_serial_test.c
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "core/graphics.h"
+#include "hwconfig.h"
+#include "interfaces/platform.h"
+#include "interfaces/delays.h"
+#include "interfaces/display.h"
+#include "interfaces/usb_serial.h"
+
+// NOTE: ENABLE_STDIO needs to be enabled for this test to actually do
+// its job (add 'ENABLE_STDIO': '' to openrtx_def in meson.build).
+
+int main(void)
+{
+    platform_init();
+    usb_serial_init(); // Should be called in the main thread with real OpenRTX
+    gfx_init();
+
+    display_setBacklightLevel(255);
+
+    int i = 0;
+
+    while (1) {
+        usb_serial_task();
+
+        gfx_clearScreen();
+
+        point_t pos_line = { 5, 15 };
+        color_t color_white = { 255, 255, 255, 255 };
+
+        gfx_print(pos_line, FONT_SIZE_6PT, TEXT_ALIGN_LEFT, color_white,
+                  "Connect to PC for serial");
+
+        gfx_render();
+
+        printf("Hello via serial #%d\n", i);
+        i++;
+
+        sleepFor(0, 250u);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary

This PR adds support for USB serial for STM32H7 targets using tinyUSB. While this obviously only applies to the CS7000P, the interface and the H7 implementation should make adding support for F4 targets easier.

Cool future use cases of this besides debugging include using OpenRTX devices as a TNC for APRS/AX.25/M17 packet, using a HT as a serial USB GPS device (accurate time source for portable POTA ops) and as transport for CAT control.

## What this does

- Bumps `tinyUSB` from 0.12 to 0.20. Needed this for bugfixes/STM32H7 support, and it's added as a dependency in the Meson build for the CS7000P target.
- Configure `tusb_config.h` to add support for the H7
- Adds a platform-agnostic `usb_serial` interface that targets can implement.
- Adds an STM32H7 implementation of the platform-agnostic `usb_serial` interface.
- Updates the CS7000P linker script (USB OTG on the H7 supposedly only works with specific memory regions)
- Adds `usb_serial_init()` at startup and integrates USB serial into the main thread
- `stdout` and `stderr` are redirected to the serial output if the `ENABLE_STDIO` option is added to `meson.build`, just like the [docs suggest](https://openrtx.org/#/software?id=debugging-with-com-port) for STM32F4 targets.
- Communication is unidirectional (device -> host only, i.e support for `stdin`).
- The device shows up on a host as a single CDC virtual serial port.

I'm aware that people have tried implementing this before so there are a few things that cropped up which caused issues:

1. This [YouTube video](https://www.youtube.com/watch?v=XgsnJdY8LsY) goes over TinyUSB setup with the STM32H7 and explained a couple things that I was unaware of.
2. A big issue is the requirement of a clock source, which sounds obvious in hindsight. So the on-board 48MHz crystal oscillator is used. I don't know why but this never came up in any research besides the video.
3. There was a weird power-related issue (that I still don't fully understand) which ended up resulting in not being able to turn the CS7000P off, apparently due to the internal USB voltage regulator causing a voltage to appear that's above the power-off threshold used by `platform_pwrButtonStatus()`. **I think it's a good idea for someone with more hardware experience than me to look at this and make sure it's fine.**

## Testing

- Device enumerates correctly (verified on Linux)
    ```
    ~ journalctl -k -f
    kernel: usb 1-1: new full-speed USB device number 112 using xhci_hcd
    kernel: usb 1-1: New USB device found, idVendor=0483, idProduct=4001, bcdDevice= 1.00
    kernel: usb 1-1: New USB device strings: Mfr=1, Product=2, SerialNumber=3
    kernel: usb 1-1: Manufacturer: OpenRTX
    kernel: cdc_acm 1-1:1.0: ttyACM10: USB ACM device
    ````
- Tested with `minicom`, `HTerm`, `picocom`, and `screen`
  - The latter two don't really like `\r\n` line endings by default but that's more of a host/tty issue than a code issue.
- Temporarily added some `printf()` statements in the UI thread to mock debugging and confirm nothing breaks
- Unplugging and then reconnecting the device to the host does not cause any crashes or freezes on the device.
- Serial connection appears to be properly de-initialized when the device is powered-off.
- Added a platform test (`usb_serial_test.c`) which prints to the serial output in a loop