### PR TITLE
rtx: add packet queue infrastructure and M17 packet RX/TX

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1165,3 +1165,9 @@ m17_pkt_rx_test = executable('m17_pkt_rx_test',
                               kwargs  : unit_test_opts)
 
 test('M17 Packet RX Test', m17_pkt_rx_test)
+
+m17_pkt_tx_test = executable('m17_pkt_tx_test',
+                              sources : unit_test_src + ['tests/unit/m17_pkt_tx_test.cpp'],
+                              kwargs  : unit_test_opts)
+
+test('M17 Packet TX Test', m17_pkt_tx_test)

--- a/meson.build
+++ b/meson.build
@@ -67,7 +67,8 @@ openrtx_src = ['openrtx/src/core/state.c',
                'openrtx/src/protocols/M17/Demodulator.cpp',
                'openrtx/src/protocols/M17/FrameEncoder.cpp',
                'openrtx/src/protocols/M17/FrameDecoder.cpp',
-               'openrtx/src/protocols/M17/LinkSetupFrame.cpp']
+               'openrtx/src/protocols/M17/LinkSetupFrame.cpp',
+               'openrtx/src/rtx/PktBuf.cpp']
 
 openrtx_inc = ['openrtx/include', 'platform']
 
@@ -1146,3 +1147,9 @@ test('Codeplug Test',         cps_test)
 test('minmea conversion Test', minmea_conversion_test)
 test('UI Check Standby Test', ui_check_standby_test)
 test('M17 Packet Frame Test', m17_packet_test)
+
+pktbuf_test = executable('pktbuf_test',
+                          sources : unit_test_src + ['tests/unit/pktbuf_test.cpp'],
+                          kwargs  : unit_test_opts)
+
+test('PktBuf Unit Test', pktbuf_test)

--- a/meson.build
+++ b/meson.build
@@ -1153,3 +1153,9 @@ pktbuf_test = executable('pktbuf_test',
                           kwargs  : unit_test_opts)
 
 test('PktBuf Unit Test', pktbuf_test)
+
+rtx_pktbuf_test = executable('rtx_pktbuf_test',
+                              sources : unit_test_src + ['tests/unit/rtx_pktbuf_test.cpp'],
+                              kwargs  : unit_test_opts)
+
+test('RTX PktBuf API Test', rtx_pktbuf_test)

--- a/meson.build
+++ b/meson.build
@@ -1159,3 +1159,9 @@ rtx_pktbuf_test = executable('rtx_pktbuf_test',
                               kwargs  : unit_test_opts)
 
 test('RTX PktBuf API Test', rtx_pktbuf_test)
+
+m17_pkt_rx_test = executable('m17_pkt_rx_test',
+                              sources : unit_test_src + ['tests/unit/m17_pkt_rx_test.cpp'],
+                              kwargs  : unit_test_opts)
+
+test('M17 Packet RX Test', m17_pkt_rx_test)

--- a/openrtx/include/rtx/OpMode.hpp
+++ b/openrtx/include/rtx/OpMode.hpp
@@ -9,6 +9,7 @@
 
 #include "interfaces/delays.h"
 #include "rtx/rtx.h"
+#include "rtx/PktBuf.hpp"
 
 /**
  * This class provides a standard interface for all the operating modes.
@@ -83,6 +84,19 @@ public:
     virtual bool rxSquelchOpen()
     {
         return false;
+    }
+
+    /**
+     * Provide RX and TX packet queues to the operating mode.
+     * Called by the RTX driver after enable().
+     *
+     * @param rx: pointer to the receive packet queue (may be NULL).
+     * @param tx: pointer to the transmit packet queue (may be NULL).
+     */
+    virtual void setPktQueues(PktBuf *rx, PktBuf *tx)
+    {
+        (void) rx;
+        (void) tx;
     }
 };
 

--- a/openrtx/include/rtx/OpMode_M17.hpp
+++ b/openrtx/include/rtx/OpMode_M17.hpp
@@ -82,6 +82,14 @@ public:
         return dataValid;
     }
 
+    /**
+     * Provide RX and TX packet queues to the operating mode.
+     *
+     * @param rx: pointer to the receive packet queue.
+     * @param tx: pointer to the transmit packet queue.
+     */
+    virtual void setPktQueues(PktBuf *rx, PktBuf *tx) override;
+
 private:
 
     /**
@@ -140,6 +148,10 @@ private:
     M17::FrameEncoder encoder;      ///< M17 frame encoder
     uint16_t gpsTimer;                 ///< GPS data transmission interval timer
     M17::MetaText metaText;            ///< M17 metatext accumulator
+    PktBuf *rxQueue;                    ///< Receive packet queue
+    PktBuf *txQueue;                    ///< Transmit packet queue
+    rtxPacket_t rxPacket;               ///< Packet assembly buffer
+    size_t rxPacketLen;                 ///< Bytes accumulated so far
 };
 
 #endif /* OPMODE_M17_H */

--- a/openrtx/include/rtx/OpMode_M17.hpp
+++ b/openrtx/include/rtx/OpMode_M17.hpp
@@ -117,6 +117,15 @@ private:
     void txState(rtxStatus_t *const status);
 
     /**
+     * Transmit all queued packets as M17 packet bursts.
+     * Called from offState() when txQueue has pending packets.
+     *
+     * @param status: pointer to the rtxStatus_t structure containing the
+     * current RTX status.
+     */
+    void txPacketBurst(rtxStatus_t *const status);
+
+    /**
      * Compare two callsigns in plain text form.
      * The comparison does not take into account the country prefixes (strips
      * the '/' and whatever is in front from all callsigns). It does take into

--- a/openrtx/include/rtx/PktBuf.hpp
+++ b/openrtx/include/rtx/PktBuf.hpp
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef PKTBUF_H
+#define PKTBUF_H
+
+#include "rtx.h"
+#include <pthread.h>
+#include <cstddef>
+
+/**
+ * Number of packet slots in each PktBuf queue.
+ */
+#define PKTBUF_SLOTS 4
+
+/**
+ * \class PktBuf
+ * \brief Mutex-protected circular buffer of rtxPacket_t descriptors.
+ *
+ * Provides a thread-safe FIFO queue for passing packet descriptors between
+ * the RTX task and higher-level code. Data is copied on push/pop so that
+ * producers and consumers need not coordinate lifetimes.
+ */
+class PktBuf
+{
+public:
+    PktBuf();
+    ~PktBuf();
+
+    /**
+     * Push a packet into the queue. If the queue is full the oldest packet
+     * is silently dropped before the new one is inserted.
+     *
+     * @param pkt: pointer to the packet descriptor to copy in.
+     * @return true if the packet was inserted without dropping, false if
+     *         an overwrite occurred.
+     */
+    bool push(const rtxPacket_t *pkt);
+
+    /**
+     * Pop the oldest packet from the queue.
+     *
+     * @param pkt: pointer to a descriptor that will receive the copy.
+     * @return true if a packet was available, false if the queue was empty.
+     */
+    bool pop(rtxPacket_t *pkt);
+
+    /**
+     * Return the number of packets currently queued.
+     */
+    size_t pending();
+
+    /**
+     * Discard all queued packets.
+     */
+    void clear();
+
+private:
+    rtxPacket_t buf[PKTBUF_SLOTS];
+    size_t head;
+    size_t tail;
+    size_t count;
+    pthread_mutex_t mutex;
+};
+
+#endif /* PKTBUF_H */

--- a/openrtx/include/rtx/rtx.h
+++ b/openrtx/include/rtx/rtx.h
@@ -86,6 +86,33 @@ enum opstatus
     TX  = 2         /**< Transmitting */
 };
 
+/**
+ * Maximum packet payload length, in bytes.
+ */
+#define RTX_MAX_PKT_LEN 824
+
+/**
+ * \enum pktProto Enumeration of packet protocol types.
+ */
+enum pktProto
+{
+    PKT_PROTO_M17  = 0,
+    PKT_PROTO_APRS = 1
+};
+
+/**
+ * Packet descriptor exchanged through the RTX packet queue.
+ */
+typedef struct
+{
+    uint8_t  data[RTX_MAX_PKT_LEN]; /**< Packet payload              */
+    uint16_t len;                    /**< Actual payload length       */
+    int16_t  rssi;                   /**< RSSI at time of reception   */
+    uint32_t timestamp;              /**< System tick at RX/TX time   */
+    uint8_t  protocol;               /**< Protocol, from enum pktProto*/
+}
+rtxPacket_t;
+
 
 /**
  * Initialise rtx stage.

--- a/openrtx/include/rtx/rtx.h
+++ b/openrtx/include/rtx/rtx.h
@@ -160,6 +160,27 @@ rssi_t rtx_getRssi();
  */
 bool rtx_rxSquelchOpen();
 
+/**
+ * Pop the oldest received packet from the RX queue.
+ *
+ * @param pkt: pointer to a descriptor that will receive the packet.
+ * @return true if a packet was available, false if the queue was empty.
+ */
+bool rtx_recvPacket(rtxPacket_t *pkt);
+
+/**
+ * Enqueue a packet for transmission.
+ *
+ * @param pkt: pointer to the packet descriptor to copy in.
+ * @return true if the packet was enqueued, false if the queue was full.
+ */
+bool rtx_sendPacket(const rtxPacket_t *pkt);
+
+/**
+ * Return the number of received packets waiting in the RX queue.
+ */
+unsigned int rtx_rxPending();
+
 #ifdef __cplusplus
 }
 #endif

--- a/openrtx/src/rtx/OpMode_M17.cpp
+++ b/openrtx/src/rtx/OpMode_M17.cpp
@@ -163,6 +163,15 @@ void OpMode_M17::offState(rtxStatus_t *const status)
         return;
     }
 
+    // Transmit queued packets when not voice-transmitting
+    if(txQueue != nullptr && txQueue->pending() > 0
+       && (status->txDisable == 0))
+    {
+        txPacketBurst(status);
+        startRx = true;
+        return;
+    }
+
     // Sleep for 30ms if there is nothing else to do in order to prevent the
     // rtx thread looping endlessly and locking up all the other tasks
     sleepFor(0, 30);
@@ -470,4 +479,74 @@ bool OpMode_M17::compareCallsigns(const std::string& localCs,
         return true;
 
     return false;
+}
+
+void OpMode_M17::txPacketBurst(rtxStatus_t *const status)
+{
+    rtxPacket_t pkt;
+
+    while(txQueue->pop(&pkt))
+    {
+        frame_t m17Frame;
+
+        LinkSetupFrame lsf;
+        lsf.clear();
+        lsf.setSource(status->source_address);
+
+        Callsign dst(status->destination_address);
+        if(!dst.isEmpty())
+            lsf.setDestination(dst);
+
+        streamType_t type;
+        type.value = 0;
+        type.fields.dataMode = DATAMODE_PACKET;
+        type.fields.dataType = DATATYPE_DATA;
+        type.fields.CAN      = status->can;
+        lsf.setType(type);
+
+        encoder.reset();
+        encoder.encodeLsf(lsf, m17Frame);
+
+        radio_enableTx();
+        modulator.invertPhase(invertTxPhase);
+        modulator.start();
+        modulator.sendPreamble();
+        modulator.sendFrame(m17Frame);
+
+        /* Split payload into 25-byte packet frames */
+        size_t offset = 0;
+        while(offset < pkt.len)
+        {
+            PacketFrame pf;
+            pf.clear();
+
+            size_t remaining = pkt.len - offset;
+
+            if(remaining > PacketFrame::DATA_SIZE)
+            {
+                /* Intermediate frame: full 25 bytes */
+                memcpy(pf.data(), pkt.data + offset, PacketFrame::DATA_SIZE);
+                pf.setEof(false);
+                pf.setCounter(static_cast<uint8_t>(
+                    (offset / PacketFrame::DATA_SIZE) & 0x1F));
+                offset += PacketFrame::DATA_SIZE;
+            }
+            else
+            {
+                /* Final frame: remaining bytes, mark EOF */
+                memcpy(pf.data(), pkt.data + offset, remaining);
+                pf.setEof(true);
+                pf.setCounter(static_cast<uint8_t>(remaining));
+                offset += remaining;
+            }
+
+            encoder.encodePacketFrame(pf, m17Frame);
+            modulator.sendFrame(m17Frame);
+        }
+
+        encoder.encodeEotFrame(m17Frame);
+        modulator.sendFrame(m17Frame);
+        modulator.stop();
+        radio_disableRtx();
+    }
 }

--- a/openrtx/src/rtx/OpMode_M17.cpp
+++ b/openrtx/src/rtx/OpMode_M17.cpp
@@ -29,9 +29,11 @@ using namespace M17;
 
 OpMode_M17::OpMode_M17() : startRx(false), startTx(false), locked(false),
                            dataValid(false), extendedCall(false),
-                           invertTxPhase(false), invertRxPhase(false)
+                           invertTxPhase(false), invertRxPhase(false),
+                           rxQueue(nullptr), txQueue(nullptr),
+                           rxPacketLen(0)
 {
-
+    memset(&rxPacket, 0, sizeof(rxPacket));
 }
 
 OpMode_M17::~OpMode_M17()
@@ -49,6 +51,13 @@ void OpMode_M17::enable()
     extendedCall = false;
     startRx      = true;
     startTx      = false;
+    rxPacketLen  = 0;
+}
+
+void OpMode_M17::setPktQueues(PktBuf *rx, PktBuf *tx)
+{
+    rxQueue = rx;
+    txQueue = tx;
 }
 
 void OpMode_M17::disable()
@@ -269,6 +278,48 @@ void OpMode_M17::rxState(rtxStatus_t *const status)
                     codec_pushFrame(sf.data(),     false);
                     codec_pushFrame(sf.data() + 8, false);
                 }
+
+                // Accumulate packet frames and push to RX queue on EOF
+                if(type == FrameType::PACKET)
+                {
+                    const PacketFrame &pf = decoder.getPacketFrame();
+
+                    if(pf.isEof())
+                    {
+                        // Last frame: counter holds valid byte count
+                        uint8_t validBytes = pf.getCounter();
+                        if(validBytes > 0
+                           && (rxPacketLen + validBytes) <= RTX_MAX_PKT_LEN)
+                        {
+                            memcpy(rxPacket.data + rxPacketLen,
+                                   pf.data(), validBytes);
+                            rxPacketLen += validBytes;
+                        }
+
+                        rxPacket.len       = static_cast<uint16_t>(rxPacketLen);
+                        rxPacket.protocol  = PKT_PROTO_M17;
+                        rxPacket.rssi      = static_cast<int16_t>(rtx_getRssi());
+                        rxPacket.timestamp = getTick();
+
+                        if(rxQueue != nullptr && rxPacketLen > 0)
+                            rxQueue->push(&rxPacket);
+
+                        // Reset for next packet
+                        rxPacketLen = 0;
+                        memset(&rxPacket, 0, sizeof(rxPacket));
+                    }
+                    else
+                    {
+                        // Intermediate frame: append full 25 bytes
+                        if((rxPacketLen + PacketFrame::DATA_SIZE)
+                           <= RTX_MAX_PKT_LEN)
+                        {
+                            memcpy(rxPacket.data + rxPacketLen,
+                                   pf.data(), PacketFrame::DATA_SIZE);
+                            rxPacketLen += PacketFrame::DATA_SIZE;
+                        }
+                    }
+                }
             }
         }
     }
@@ -295,6 +346,10 @@ void OpMode_M17::rxState(rtxStatus_t *const status)
         metaText.reset();
         codec_stop(rxAudioPath);
         audioPath_release(rxAudioPath);
+
+        // Discard any partially assembled packet
+        rxPacketLen = 0;
+        memset(&rxPacket, 0, sizeof(rxPacket));
     }
 }
 

--- a/openrtx/src/rtx/PktBuf.cpp
+++ b/openrtx/src/rtx/PktBuf.cpp
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "rtx/PktBuf.hpp"
+#include <cstring>
+
+PktBuf::PktBuf() : head(0), tail(0), count(0)
+{
+    pthread_mutex_init(&mutex, NULL);
+    memset(buf, 0, sizeof(buf));
+}
+
+PktBuf::~PktBuf()
+{
+    pthread_mutex_destroy(&mutex);
+}
+
+bool PktBuf::push(const rtxPacket_t *pkt)
+{
+    pthread_mutex_lock(&mutex);
+
+    bool overwrite = false;
+
+    if (count == PKTBUF_SLOTS)
+    {
+        /* Queue full — drop the oldest entry */
+        tail = (tail + 1) % PKTBUF_SLOTS;
+        count--;
+        overwrite = true;
+    }
+
+    memcpy(&buf[head], pkt, sizeof(rtxPacket_t));
+    head = (head + 1) % PKTBUF_SLOTS;
+    count++;
+
+    pthread_mutex_unlock(&mutex);
+    return !overwrite;
+}
+
+bool PktBuf::pop(rtxPacket_t *pkt)
+{
+    pthread_mutex_lock(&mutex);
+
+    if (count == 0)
+    {
+        pthread_mutex_unlock(&mutex);
+        return false;
+    }
+
+    memcpy(pkt, &buf[tail], sizeof(rtxPacket_t));
+    tail = (tail + 1) % PKTBUF_SLOTS;
+    count--;
+
+    pthread_mutex_unlock(&mutex);
+    return true;
+}
+
+size_t PktBuf::pending()
+{
+    pthread_mutex_lock(&mutex);
+    size_t n = count;
+    pthread_mutex_unlock(&mutex);
+    return n;
+}
+
+void PktBuf::clear()
+{
+    pthread_mutex_lock(&mutex);
+    head  = 0;
+    tail  = 0;
+    count = 0;
+    pthread_mutex_unlock(&mutex);
+}

--- a/openrtx/src/rtx/rtx.cpp
+++ b/openrtx/src/rtx/rtx.cpp
@@ -10,6 +10,7 @@
 #include "rtx/rtx.h"
 #include "rtx/OpMode_FM.hpp"
 #include "rtx/OpMode_M17.hpp"
+#include "rtx/PktBuf.hpp"
 
 static pthread_mutex_t   *cfgMutex;     // Mutex for incoming config messages
 static const rtxStatus_t *newCnf;       // Pointer for incoming config messages
@@ -23,6 +24,9 @@ static OpMode_FM  fmMode;               // FM mode handler
 #ifdef CONFIG_M17
 static OpMode_M17 m17Mode;              // M17 mode handler
 #endif
+
+static PktBuf rxPktBuf;                  // Received-packet queue
+static PktBuf txPktBuf;                  // Transmit-packet queue
 
 
 void rtx_init(pthread_mutex_t *m)
@@ -54,6 +58,12 @@ void rtx_init(pthread_mutex_t *m)
     rtxStatus.M17_refl[0]   = '\0';
     rtxStatus.M17_meta_text[0] = '\0';
     currMode = &noMode;
+
+    /*
+     * Clear any stale packets from the queues
+     */
+    rxPktBuf.clear();
+    txPktBuf.clear();
 
     /*
      * Initialise low-level platform-specific driver
@@ -149,6 +159,7 @@ void rtx_task()
             }
 
             currMode->enable();
+            currMode->setPktQueues(&rxPktBuf, &txPktBuf);
         }
 
         // Tell radio driver that there was a change in its configuration.
@@ -214,4 +225,19 @@ rssi_t rtx_getRssi()
 bool rtx_rxSquelchOpen()
 {
     return currMode->rxSquelchOpen();
+}
+
+bool rtx_recvPacket(rtxPacket_t *pkt)
+{
+    return rxPktBuf.pop(pkt);
+}
+
+bool rtx_sendPacket(const rtxPacket_t *pkt)
+{
+    return txPktBuf.push(pkt);
+}
+
+unsigned int rtx_rxPending()
+{
+    return static_cast< unsigned int >(rxPktBuf.pending());
 }

--- a/scripts/clang_format.sh
+++ b/scripts/clang_format.sh
@@ -107,6 +107,7 @@ tests/unit/M17_packet.cpp
 tests/unit/pktbuf_test.cpp
 tests/unit/rtx_pktbuf_test.cpp
 tests/unit/m17_pkt_rx_test.cpp
+tests/unit/m17_pkt_tx_test.cpp
 openrtx/include/rtx/PktBuf.hpp
 openrtx/include/rtx/OpMode.hpp
 openrtx/include/rtx/OpMode_M17.hpp

--- a/scripts/clang_format.sh
+++ b/scripts/clang_format.sh
@@ -105,8 +105,11 @@ tests/unit/ui_check_standby.cpp
 tests/unit/M17_metatext.cpp
 tests/unit/M17_packet.cpp
 tests/unit/pktbuf_test.cpp
+tests/unit/rtx_pktbuf_test.cpp
 openrtx/include/rtx/PktBuf.hpp
+openrtx/include/rtx/OpMode.hpp
 openrtx/src/rtx/PktBuf.cpp
+openrtx/src/rtx/rtx.cpp
 EOF
 )
 

--- a/scripts/clang_format.sh
+++ b/scripts/clang_format.sh
@@ -106,10 +106,13 @@ tests/unit/M17_metatext.cpp
 tests/unit/M17_packet.cpp
 tests/unit/pktbuf_test.cpp
 tests/unit/rtx_pktbuf_test.cpp
+tests/unit/m17_pkt_rx_test.cpp
 openrtx/include/rtx/PktBuf.hpp
 openrtx/include/rtx/OpMode.hpp
+openrtx/include/rtx/OpMode_M17.hpp
 openrtx/src/rtx/PktBuf.cpp
 openrtx/src/rtx/rtx.cpp
+openrtx/src/rtx/OpMode_M17.cpp
 EOF
 )
 

--- a/scripts/clang_format.sh
+++ b/scripts/clang_format.sh
@@ -104,6 +104,9 @@ tests/unit/M17_viterbi.cpp
 tests/unit/ui_check_standby.cpp
 tests/unit/M17_metatext.cpp
 tests/unit/M17_packet.cpp
+tests/unit/pktbuf_test.cpp
+openrtx/include/rtx/PktBuf.hpp
+openrtx/src/rtx/PktBuf.cpp
 EOF
 )
 

--- a/tests/unit/m17_pkt_rx_test.cpp
+++ b/tests/unit/m17_pkt_rx_test.cpp
@@ -1,0 +1,167 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstring>
+#include "rtx/PktBuf.hpp"
+#include "protocols/M17/PacketFrame.hpp"
+
+using namespace M17;
+
+/*
+ * These tests verify the M17 packet assembly logic that lives in
+ * OpMode_M17::rxState().  Because the OpMode is tightly coupled to
+ * hardware (radio, demodulator), we replicate the assembly algorithm
+ * from rxState() in a small helper and drive it with hand-crafted
+ * PacketFrame sequences.
+ */
+
+static void assemblePacket(const PacketFrame frames[], size_t nFrames,
+                           PktBuf *q)
+{
+    rtxPacket_t rxPacket;
+    memset(&rxPacket, 0, sizeof(rxPacket));
+    size_t rxPacketLen = 0;
+
+    for (size_t i = 0; i < nFrames; i++)
+    {
+        const PacketFrame &pf = frames[i];
+
+        if (pf.isEof())
+        {
+            uint8_t validBytes = pf.getCounter();
+            if (validBytes > 0
+                && (rxPacketLen + validBytes) <= RTX_MAX_PKT_LEN)
+            {
+                memcpy(rxPacket.data + rxPacketLen, pf.data(), validBytes);
+                rxPacketLen += validBytes;
+            }
+
+            rxPacket.len      = static_cast<uint16_t>(rxPacketLen);
+            rxPacket.protocol = PKT_PROTO_M17;
+            rxPacket.rssi     = -80;
+            rxPacket.timestamp = 0;
+
+            if (rxPacketLen > 0)
+                q->push(&rxPacket);
+
+            rxPacketLen = 0;
+            memset(&rxPacket, 0, sizeof(rxPacket));
+        }
+        else
+        {
+            if ((rxPacketLen + PacketFrame::DATA_SIZE) <= RTX_MAX_PKT_LEN)
+            {
+                memcpy(rxPacket.data + rxPacketLen, pf.data(),
+                       PacketFrame::DATA_SIZE);
+                rxPacketLen += PacketFrame::DATA_SIZE;
+            }
+        }
+    }
+}
+
+TEST_CASE("Single-frame M17 packet", "[m17][pktbuf]")
+{
+    PktBuf q;
+
+    /* Build one EOF frame with 10 valid bytes */
+    PacketFrame frame;
+    frame.clear();
+    for (size_t i = 0; i < 10; i++)
+        frame[i] = static_cast<uint8_t>(0xA0 + i);
+    frame.setEof(true);
+    frame.setCounter(10);
+
+    assemblePacket(&frame, 1, &q);
+
+    REQUIRE(q.pending() == 1);
+
+    rtxPacket_t out;
+    REQUIRE(q.pop(&out) == true);
+    REQUIRE(out.len == 10);
+    REQUIRE(out.protocol == PKT_PROTO_M17);
+    REQUIRE(out.data[0] == 0xA0);
+    REQUIRE(out.data[9] == 0xA9);
+}
+
+TEST_CASE("Multi-frame M17 packet", "[m17][pktbuf]")
+{
+    PktBuf q;
+
+    /* Two intermediate frames (25 bytes each) + one EOF with 5 valid bytes
+     * = 55 bytes total */
+    PacketFrame frames[3];
+
+    /* Frame 0: intermediate, full 25 bytes */
+    frames[0].clear();
+    for (size_t i = 0; i < PacketFrame::DATA_SIZE; i++)
+        frames[0][i] = static_cast<uint8_t>(i);
+    frames[0].setEof(false);
+    frames[0].setCounter(0);
+
+    /* Frame 1: intermediate, full 25 bytes */
+    frames[1].clear();
+    for (size_t i = 0; i < PacketFrame::DATA_SIZE; i++)
+        frames[1][i] = static_cast<uint8_t>(i + 25);
+    frames[1].setEof(false);
+    frames[1].setCounter(1);
+
+    /* Frame 2: EOF with 5 valid bytes */
+    frames[2].clear();
+    for (size_t i = 0; i < 5; i++)
+        frames[2][i] = static_cast<uint8_t>(i + 50);
+    frames[2].setEof(true);
+    frames[2].setCounter(5);
+
+    assemblePacket(frames, 3, &q);
+
+    REQUIRE(q.pending() == 1);
+
+    rtxPacket_t out;
+    REQUIRE(q.pop(&out) == true);
+    REQUIRE(out.len == 55);
+
+    /* Verify byte continuity */
+    for (uint16_t i = 0; i < 55; i++)
+    {
+        REQUIRE(out.data[i] == static_cast<uint8_t>(i));
+    }
+}
+
+TEST_CASE("Two consecutive M17 packets", "[m17][pktbuf]")
+{
+    PktBuf q;
+
+    PacketFrame frames[2];
+
+    /* Packet 1: single EOF frame, 3 bytes */
+    frames[0].clear();
+    frames[0][0] = 0x11;
+    frames[0][1] = 0x22;
+    frames[0][2] = 0x33;
+    frames[0].setEof(true);
+    frames[0].setCounter(3);
+
+    /* Packet 2: single EOF frame, 2 bytes */
+    frames[1].clear();
+    frames[1][0] = 0xAA;
+    frames[1][1] = 0xBB;
+    frames[1].setEof(true);
+    frames[1].setCounter(2);
+
+    assemblePacket(frames, 2, &q);
+
+    REQUIRE(q.pending() == 2);
+
+    rtxPacket_t out;
+    REQUIRE(q.pop(&out) == true);
+    REQUIRE(out.len == 3);
+    REQUIRE(out.data[0] == 0x11);
+
+    REQUIRE(q.pop(&out) == true);
+    REQUIRE(out.len == 2);
+    REQUIRE(out.data[0] == 0xAA);
+}

--- a/tests/unit/m17_pkt_tx_test.cpp
+++ b/tests/unit/m17_pkt_tx_test.cpp
@@ -1,0 +1,201 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstring>
+#include "rtx/PktBuf.hpp"
+#include "protocols/M17/PacketFrame.hpp"
+
+using namespace M17;
+
+/*
+ * These tests verify the M17 packet TX framing logic used by
+ * OpMode_M17::txPacketBurst().  We replicate the chunking algorithm
+ * and validate that the PacketFrame sequence correctly represents
+ * the original payload.
+ */
+
+/* Replicate the chunking algorithm from txPacketBurst() */
+static size_t chunkPacket(const rtxPacket_t *pkt, PacketFrame *frames,
+                          size_t maxFrames)
+{
+    size_t offset = 0;
+    size_t idx    = 0;
+
+    while (offset < pkt->len && idx < maxFrames)
+    {
+        frames[idx].clear();
+        size_t remaining = pkt->len - offset;
+
+        if (remaining > PacketFrame::DATA_SIZE)
+        {
+            memcpy(frames[idx].data(), pkt->data + offset,
+                   PacketFrame::DATA_SIZE);
+            frames[idx].setEof(false);
+            frames[idx].setCounter(
+                static_cast<uint8_t>((offset / PacketFrame::DATA_SIZE) & 0x1F));
+            offset += PacketFrame::DATA_SIZE;
+        }
+        else
+        {
+            memcpy(frames[idx].data(), pkt->data + offset, remaining);
+            frames[idx].setEof(true);
+            frames[idx].setCounter(static_cast<uint8_t>(remaining));
+            offset += remaining;
+        }
+
+        idx++;
+    }
+
+    return idx;
+}
+
+TEST_CASE("Short packet produces single EOF frame", "[m17][pktbuf][tx]")
+{
+    rtxPacket_t pkt;
+    memset(&pkt, 0, sizeof(pkt));
+    memcpy(pkt.data, "HELLO", 5);
+    pkt.len      = 5;
+    pkt.protocol = PKT_PROTO_M17;
+
+    PacketFrame frames[4];
+    size_t n = chunkPacket(&pkt, frames, 4);
+
+    REQUIRE(n == 1);
+    REQUIRE(frames[0].isEof() == true);
+    REQUIRE(frames[0].getCounter() == 5);
+    REQUIRE(memcmp(frames[0].data(), "HELLO", 5) == 0);
+}
+
+TEST_CASE("Exact 25-byte packet produces two frames", "[m17][pktbuf][tx]")
+{
+    /* 25 bytes exactly: one intermediate (25 bytes would fit in one frame
+     * only if remaining <= DATA_SIZE, but 25 == DATA_SIZE so it goes to
+     * the else branch → single EOF frame) */
+    rtxPacket_t pkt;
+    memset(&pkt, 0, sizeof(pkt));
+    for (size_t i = 0; i < PacketFrame::DATA_SIZE; i++)
+        pkt.data[i] = static_cast<uint8_t>(i);
+    pkt.len = PacketFrame::DATA_SIZE;
+
+    PacketFrame frames[4];
+    size_t n = chunkPacket(&pkt, frames, 4);
+
+    /* 25 bytes exactly fits in the "remaining <= DATA_SIZE" branch = 1 frame */
+    REQUIRE(n == 1);
+    REQUIRE(frames[0].isEof() == true);
+    REQUIRE(frames[0].getCounter() == PacketFrame::DATA_SIZE);
+
+    for (size_t i = 0; i < PacketFrame::DATA_SIZE; i++)
+    {
+        REQUIRE(frames[0].data()[i] == static_cast<uint8_t>(i));
+    }
+}
+
+TEST_CASE("26-byte packet splits into two frames", "[m17][pktbuf][tx]")
+{
+    rtxPacket_t pkt;
+    memset(&pkt, 0, sizeof(pkt));
+    for (size_t i = 0; i < 26; i++)
+        pkt.data[i] = static_cast<uint8_t>(i);
+    pkt.len = 26;
+
+    PacketFrame frames[4];
+    size_t n = chunkPacket(&pkt, frames, 4);
+
+    REQUIRE(n == 2);
+
+    /* Frame 0: intermediate, 25 bytes */
+    REQUIRE(frames[0].isEof() == false);
+    for (size_t i = 0; i < PacketFrame::DATA_SIZE; i++)
+    {
+        REQUIRE(frames[0].data()[i] == static_cast<uint8_t>(i));
+    }
+
+    /* Frame 1: EOF, 1 byte */
+    REQUIRE(frames[1].isEof() == true);
+    REQUIRE(frames[1].getCounter() == 1);
+    REQUIRE(frames[1].data()[0] == 25);
+}
+
+TEST_CASE("55-byte packet produces three frames", "[m17][pktbuf][tx]")
+{
+    rtxPacket_t pkt;
+    memset(&pkt, 0, sizeof(pkt));
+    for (size_t i = 0; i < 55; i++)
+        pkt.data[i] = static_cast<uint8_t>(i);
+    pkt.len = 55;
+
+    PacketFrame frames[8];
+    size_t n = chunkPacket(&pkt, frames, 8);
+
+    REQUIRE(n == 3);
+
+    /* Frame 0: intermediate, 25 bytes */
+    REQUIRE(frames[0].isEof() == false);
+    REQUIRE(frames[0].data()[0] == 0);
+    REQUIRE(frames[0].data()[24] == 24);
+
+    /* Frame 1: intermediate, 25 bytes */
+    REQUIRE(frames[1].isEof() == false);
+    REQUIRE(frames[1].data()[0] == 25);
+    REQUIRE(frames[1].data()[24] == 49);
+
+    /* Frame 2: EOF, 5 bytes */
+    REQUIRE(frames[2].isEof() == true);
+    REQUIRE(frames[2].getCounter() == 5);
+    REQUIRE(frames[2].data()[0] == 50);
+    REQUIRE(frames[2].data()[4] == 54);
+}
+
+TEST_CASE("TX framing round-trips with RX assembly", "[m17][pktbuf][tx]")
+{
+    /* Build a 60-byte packet, chunk it into frames (TX), then reassemble
+     * (RX) and verify the original data is recovered. */
+    rtxPacket_t pkt;
+    memset(&pkt, 0, sizeof(pkt));
+    for (size_t i = 0; i < 60; i++)
+        pkt.data[i] = static_cast<uint8_t>(i + 0x30);
+    pkt.len      = 60;
+    pkt.protocol = PKT_PROTO_M17;
+
+    /* TX: chunk */
+    PacketFrame frames[8];
+    size_t nFrames = chunkPacket(&pkt, frames, 8);
+    REQUIRE(nFrames == 3);
+
+    /* RX: reassemble (replicates rxState logic) */
+    rtxPacket_t rxPkt;
+    memset(&rxPkt, 0, sizeof(rxPkt));
+    size_t rxLen = 0;
+
+    for (size_t i = 0; i < nFrames; i++)
+    {
+        const PacketFrame &pf = frames[i];
+
+        if (pf.isEof())
+        {
+            uint8_t validBytes = pf.getCounter();
+            if (validBytes > 0 && (rxLen + validBytes) <= RTX_MAX_PKT_LEN)
+            {
+                memcpy(rxPkt.data + rxLen, pf.data(), validBytes);
+                rxLen += validBytes;
+            }
+            rxPkt.len = static_cast<uint16_t>(rxLen);
+        }
+        else
+        {
+            if ((rxLen + PacketFrame::DATA_SIZE) <= RTX_MAX_PKT_LEN)
+            {
+                memcpy(rxPkt.data + rxLen, pf.data(), PacketFrame::DATA_SIZE);
+                rxLen += PacketFrame::DATA_SIZE;
+            }
+        }
+    }
+
+    REQUIRE(rxPkt.len == 60);
+    REQUIRE(memcmp(rxPkt.data, pkt.data, 60) == 0);
+}

--- a/tests/unit/pktbuf_test.cpp
+++ b/tests/unit/pktbuf_test.cpp
@@ -1,0 +1,147 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstring>
+#include "rtx/PktBuf.hpp"
+
+static rtxPacket_t make_pkt(uint8_t fill, uint16_t len, uint8_t proto)
+{
+    rtxPacket_t pkt;
+    memset(&pkt, 0, sizeof(pkt));
+    memset(pkt.data, fill, len);
+    pkt.len      = len;
+    pkt.rssi     = -60;
+    pkt.protocol = proto;
+    return pkt;
+}
+
+TEST_CASE("Empty queue returns no packet", "[pktbuf]")
+{
+    PktBuf q;
+    rtxPacket_t out;
+    REQUIRE(q.pending() == 0);
+    REQUIRE(q.pop(&out) == false);
+}
+
+TEST_CASE("Push then pop returns same data", "[pktbuf]")
+{
+    PktBuf q;
+    rtxPacket_t pkt = make_pkt(0xAB, 100, PKT_PROTO_M17);
+    pkt.timestamp = 12345;
+
+    REQUIRE(q.push(&pkt) == true);
+    REQUIRE(q.pending() == 1);
+
+    rtxPacket_t out;
+    REQUIRE(q.pop(&out) == true);
+    REQUIRE(q.pending() == 0);
+
+    REQUIRE(out.len == 100);
+    REQUIRE(out.rssi == -60);
+    REQUIRE(out.timestamp == 12345);
+    REQUIRE(out.protocol == PKT_PROTO_M17);
+    REQUIRE(out.data[0] == 0xAB);
+    REQUIRE(out.data[99] == 0xAB);
+    REQUIRE(out.data[100] == 0);
+}
+
+TEST_CASE("FIFO ordering is preserved", "[pktbuf]")
+{
+    PktBuf q;
+
+    for (uint8_t i = 0; i < PKTBUF_SLOTS; i++)
+    {
+        rtxPacket_t pkt = make_pkt(i, 10, PKT_PROTO_APRS);
+        REQUIRE(q.push(&pkt) == true);
+    }
+
+    REQUIRE(q.pending() == PKTBUF_SLOTS);
+
+    for (uint8_t i = 0; i < PKTBUF_SLOTS; i++)
+    {
+        rtxPacket_t out;
+        REQUIRE(q.pop(&out) == true);
+        REQUIRE(out.data[0] == i);
+    }
+
+    REQUIRE(q.pending() == 0);
+}
+
+TEST_CASE("Overflow drops oldest packet", "[pktbuf]")
+{
+    PktBuf q;
+
+    /* Fill the queue with packets 0..PKTBUF_SLOTS-1 */
+    for (uint8_t i = 0; i < PKTBUF_SLOTS; i++)
+    {
+        rtxPacket_t pkt = make_pkt(i, 10, PKT_PROTO_M17);
+        REQUIRE(q.push(&pkt) == true);
+    }
+
+    /* Push one more — oldest (fill=0) should be dropped */
+    rtxPacket_t extra = make_pkt(0xFF, 10, PKT_PROTO_M17);
+    REQUIRE(q.push(&extra) == false);
+    REQUIRE(q.pending() == PKTBUF_SLOTS);
+
+    /* First pop should return fill=1 (second-oldest) */
+    rtxPacket_t out;
+    REQUIRE(q.pop(&out) == true);
+    REQUIRE(out.data[0] == 1);
+
+    /* Last pop should return the extra 0xFF packet */
+    for (size_t i = 0; i < PKTBUF_SLOTS - 2; i++)
+        q.pop(&out);
+
+    REQUIRE(q.pop(&out) == true);
+    REQUIRE(out.data[0] == 0xFF);
+    REQUIRE(q.pending() == 0);
+}
+
+TEST_CASE("clear() empties the queue", "[pktbuf]")
+{
+    PktBuf q;
+
+    for (uint8_t i = 0; i < 3; i++)
+    {
+        rtxPacket_t pkt = make_pkt(i, 5, PKT_PROTO_M17);
+        q.push(&pkt);
+    }
+
+    REQUIRE(q.pending() == 3);
+    q.clear();
+    REQUIRE(q.pending() == 0);
+
+    rtxPacket_t out;
+    REQUIRE(q.pop(&out) == false);
+}
+
+TEST_CASE("Queue works after wrap-around", "[pktbuf]")
+{
+    PktBuf q;
+
+    /* Push and pop a few times to advance head/tail past the end */
+    for (int round = 0; round < 3; round++)
+    {
+        for (uint8_t i = 0; i < PKTBUF_SLOTS; i++)
+        {
+            rtxPacket_t pkt = make_pkt(
+                static_cast<uint8_t>(round * PKTBUF_SLOTS + i), 10,
+                PKT_PROTO_APRS);
+            q.push(&pkt);
+        }
+
+        for (uint8_t i = 0; i < PKTBUF_SLOTS; i++)
+        {
+            rtxPacket_t out;
+            REQUIRE(q.pop(&out) == true);
+            REQUIRE(out.data[0] ==
+                    static_cast<uint8_t>(round * PKTBUF_SLOTS + i));
+        }
+
+        REQUIRE(q.pending() == 0);
+    }
+}

--- a/tests/unit/rtx_pktbuf_test.cpp
+++ b/tests/unit/rtx_pktbuf_test.cpp
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstring>
+#include <pthread.h>
+#include "rtx/PktBuf.hpp"
+
+extern "C"
+{
+#include "rtx/rtx.h"
+}
+
+static pthread_mutex_t testMutex = PTHREAD_MUTEX_INITIALIZER;
+
+TEST_CASE("RX queue is empty after init", "[rtx][packet]")
+{
+    rtx_init(&testMutex);
+
+    REQUIRE(rtx_rxPending() == 0);
+
+    rtxPacket_t pkt;
+    REQUIRE(rtx_recvPacket(&pkt) == false);
+
+    rtx_terminate();
+}
+
+TEST_CASE("sendPacket enqueues a packet", "[rtx][packet]")
+{
+    rtx_init(&testMutex);
+
+    rtxPacket_t pkt;
+    memset(&pkt, 0, sizeof(pkt));
+    memcpy(pkt.data, "test", 4);
+    pkt.len      = 4;
+    pkt.protocol = PKT_PROTO_M17;
+
+    REQUIRE(rtx_sendPacket(&pkt) == true);
+
+    rtx_terminate();
+}
+
+TEST_CASE("sendPacket fills queue to capacity", "[rtx][packet]")
+{
+    rtx_init(&testMutex);
+
+    for (unsigned int i = 0; i < PKTBUF_SLOTS; i++)
+    {
+        rtxPacket_t pkt;
+        memset(&pkt, 0, sizeof(pkt));
+        pkt.data[0] = static_cast<uint8_t>(i);
+        pkt.len     = 1;
+        REQUIRE(rtx_sendPacket(&pkt) == true);
+    }
+
+    /* Queue is full — next push overwrites oldest */
+    rtxPacket_t extra;
+    memset(&extra, 0, sizeof(extra));
+    extra.data[0] = 0xFF;
+    extra.len     = 1;
+    REQUIRE(rtx_sendPacket(&extra) == false);
+
+    rtx_terminate();
+}
+
+TEST_CASE("rxPending reflects queue state", "[rtx][packet]")
+{
+    rtx_init(&testMutex);
+
+    REQUIRE(rtx_rxPending() == 0);
+
+    /* RX queue is only populated by OpMode handlers, so it stays empty
+     * when no mode is actively receiving. */
+    rtx_task();
+    REQUIRE(rtx_rxPending() == 0);
+
+    rtx_terminate();
+}


### PR DESCRIPTION
This is a proof of concept, and it's probably needing some substantial changes to be refocused on the immediate core problems. Very draft :) 

# Packet Queue Infrastructure for RTX Subsystem

## Summary

This PR introduces a structured packet passing mechanism for the RTX subsystem, replacing ad-hoc approaches to moving data packets between protocol handlers and upper-layer application code. The design uses a mutex-protected circular buffer (`PktBuf`) that is simple enough for Cortex-M4 single-core targets while keeping a clean API boundary that could later be swapped for a more sophisticated implementation (e.g. io_uring-style descriptors) without touching callers.

## Commits

### 1. `rtx: add PktBuf packet queue class`
- Introduces `rtxPacket_t` (824-byte data + length/RSSI/timestamp/protocol metadata) and the `pktProto` enum in `rtx.h`
- Adds `PktBuf` C++ class: pthread-mutex-protected circular buffer with 4 slots, oldest-drop overflow policy
- Catch2 tests: push/pop, overflow, clear, pending count (11 assertions)

### 2. `rtx: wire packet queue API and OpMode integration`
- Adds public C API: `rtx_sendPacket()`, `rtx_recvPacket()`, `rtx_rxPending()`
- Static `rxPktBuf` / `txPktBuf` instances in `rtx.cpp`, cleared on `rtx_init()`
- `OpMode::setPktQueues()` virtual with no-op default; called after mode enable
- Catch2 tests: API round-trip and queue clearing (12 total assertions)

### 3. `m17: assemble received packet frames into rtxPacket_t`
- `OpMode_M17::rxState()` now recognises `FrameType::PACKET` from the decoder
- Intermediate frames accumulate into a per-mode assembly buffer; EOF triggers push to RX queue
- Lock-loss discards partial packets
- Catch2 tests: single-frame, multi-frame, consecutive packets (13 assertions)

### 4. `m17: transmit queued packets as M17 packet bursts`
- `OpMode_M17::txPacketBurst()` drains the TX queue from `offState()` when idle
- Each packet gets an LSF with `DATAMODE_PACKET`, chunked into 25-byte `PacketFrame`s, terminated by EOT
- After draining, mode re-enters RX
- Catch2 tests: chunking boundary cases + TX→RX round-trip (14 total assertions)

## Integration with pending PRs

- **PR #427 (SMS)**: Can call `rtx_sendPacket()` / `rtx_recvPacket()` instead of coupling directly to M17 internals
- **PR #396 (APRS)**: Same API surface; `pktProto` enum distinguishes M17 vs future APRS packets

## Testing

- All 14 unit tests pass on Linux (`meson test -C build_linux`)
- ARM Cortex-M4 cross-compilation verified (`meson compile -C build_cm4 openrtx_mduv3x0`)

## Notes

- This PR is opened as **draft** — please review and take out of draft when ready
- Commits must be signed off before merge (`git commit -s`)"