### PR TITLE
Mic oversampling

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1135,6 +1135,10 @@ m17_packet_test = executable('m17_packet_test',
                               sources : unit_test_src + ['tests/unit/M17_packet.cpp'],
                               kwargs  : unit_test_opts)
 
+dsp_oversampling_test = executable('dsp_oversampling_test',
+                                    sources : unit_test_src + ['tests/unit/dsp_oversampling.cpp'],
+                                    kwargs  : unit_test_opts)
+
 test('M17 Golay Unit Test',   m17_golay_test)
 test('M17 Viterbi Unit Test', m17_viterbi_test)
 test('M17 Demodulator Test',  m17_demodulator_test)
@@ -1146,3 +1150,4 @@ test('Codeplug Test',         cps_test)
 test('minmea conversion Test', minmea_conversion_test)
 test('UI Check Standby Test', ui_check_standby_test)
 test('M17 Packet Frame Test', m17_packet_test)
+test('DSP Oversampling Test', dsp_oversampling_test)

--- a/openrtx/include/core/dsp.h
+++ b/openrtx/include/core/dsp.h
@@ -11,6 +11,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
+#include "interfaces/audio.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -59,6 +60,42 @@ static inline void dsp_removeDcOffset(struct dcBlock *dcb, int16_t *buffer,
     for (size_t i = 0; i < length; i++)
         buffer[i] = dsp_dcBlockFilter(dcb, buffer[i]);
 }
+
+/**
+ * Data structure holding the internal state of an oversampling filter.
+ */
+struct oversamplingBlock {
+    uint8_t oversampling;
+    uint8_t count;
+    uint32_t accumulator;
+};
+
+/**
+ * @brief Set the oversampling factor for a decimation filter.
+ *
+ * @param oversamplingBlock: pointer to the oversampling filter state.
+ * @param oversampling: oversampling factor, must be >= 1.
+ */
+void dsp_oversamplingSetOversampling(
+    struct oversamplingBlock *oversamplingBlock, uint8_t oversampling);
+
+/**
+ * @brief Run a single step of the oversampling decimation filter.
+ *
+ * Accumulates input samples and returns their truncated integer average
+ * once the oversampling factor number of samples have been collected.
+ *
+ * Input samples are treated as unsigned values for accumulation. Callers
+ * must ensure that the samples are non-negative (e.g. raw ADC readings)
+ * before the DC offset has been removed.
+ *
+ * @param oversamplingBlock: pointer to the oversampling filter state.
+ * @param sample: pointer to the input sample; overwritten with the
+ * decimated output when the function returns true.
+ * @return true when a decimated sample is ready, false otherwise.
+ */
+bool dsp_oversamplingDecimate(struct oversamplingBlock *oversamplingBlock,
+                              stream_sample_t *sample);
 
 #ifdef __cplusplus
 }

--- a/openrtx/src/core/audio_codec.c
+++ b/openrtx/src/core/audio_codec.c
@@ -22,6 +22,12 @@
 #include "hwconfig.h"
 
 #define BUF_SIZE 4
+#define CODEC2_FRAME_SAMPLES 160 /* Samples per codec2 3200-mode frame */
+#define DMA_BUF_SAMPLES (CODEC2_FRAME_SAMPLES * 2) /* Double-buffered DMA */
+
+#ifndef CONFIG_MIC_OVERSAMPLE
+#define CONFIG_MIC_OVERSAMPLE 1
+#endif
 
 static pathId audioPath;
 
@@ -161,45 +167,65 @@ static void *encodeFunc(void *arg)
 {
     streamId iStream;
     pathId iPath = *((pathId *)arg);
-    stream_sample_t audioBuf[320];
+    // Allocate on the heap, as the stack isn't big enough for oversampling
+    // above 2 or so.
+    stream_sample_t *adcBuf = malloc(DMA_BUF_SAMPLES * CONFIG_MIC_OVERSAMPLE
+                                     * sizeof(stream_sample_t));
     struct CODEC2 *codec2;
     struct dcBlock dcBlock;
+    struct oversamplingBlock oversamplingBlock;
 
-    iStream = audioStream_start(iPath, audioBuf, 320, 8000,
+    if (adcBuf == NULL) {
+        pthread_detach(pthread_self());
+        running = false;
+        return NULL;
+    }
+
+    iStream = audioStream_start(iPath, adcBuf,
+                                DMA_BUF_SAMPLES * CONFIG_MIC_OVERSAMPLE,
+                                8000 * CONFIG_MIC_OVERSAMPLE,
                                 STREAM_INPUT | BUF_CIRC_DOUBLE);
     if (iStream < 0) {
+        free(adcBuf);
         pthread_detach(pthread_self());
         running = false;
         return NULL;
     }
 
     dsp_resetState(dcBlock);
+    dsp_resetState(oversamplingBlock);
+    dsp_oversamplingSetOversampling(&oversamplingBlock, CONFIG_MIC_OVERSAMPLE);
     codec2 = codec2_create(CODEC2_MODE_3200);
 
     while (reqStop == false) {
-        // Invalid path, quit
+        // Invalid audio path, quit
         if (audioPath_getStatus(iPath) != PATH_OPEN)
             break;
 
         dataBlock_t audio = inputStream_getData(iStream);
-        if (audio.data == NULL)
+        if (audio.data == NULL || audio.len == 0)
             break;
 
-#ifndef PLATFORM_LINUX
+        // Each inputStream_getData call returns exactly
+        // CODEC2_FRAME_SAMPLES * CONFIG_MIC_OVERSAMPLE raw samples
+        // (one half of the double-buffered DMA transfer).  Decimate
+        // by averaging each group of CONFIG_MIC_OVERSAMPLE samples.
+        stream_sample_t audioBuf[CODEC2_FRAME_SAMPLES];
+        size_t outIdx = 0;
         for (size_t i = 0; i < audio.len; i++) {
-            int16_t sample;
-
-            sample = dsp_dcBlockFilter(&dcBlock, audio.data[i]);
-            audio.data[i] = sample * CONFIG_MIC_GAIN;
+            stream_sample_t sample = audio.data[i];
+            if (dsp_oversamplingDecimate(&oversamplingBlock, &sample)) {
+                sample = dsp_dcBlockFilter(&dcBlock, sample);
+                audioBuf[outIdx++] = sample * CONFIG_MIC_GAIN;
+            }
         }
-#endif
 
-        // CODEC2 encodes 160ms of speech into 8 bytes: here we write the
-        // new encoded data into a buffer of 16 bytes writing the first
-        // half and then the second one, sequentially.
+        // CODEC2 encodes 20ms of audio, 160 samples, into 8 bytes:
+        // here we write the new encoded data into a buffer of 16 bytes
+        // writing the first half and then the second one, sequentially.
         // Data ready flag is rised once all the 16 bytes contain new data.
         uint64_t frame = 0;
-        codec2_encode(codec2, ((uint8_t *)&frame), audio.data);
+        codec2_encode(codec2, ((uint8_t *)&frame), audioBuf);
 
         pthread_mutex_lock(&data_mutex);
 
@@ -222,6 +248,7 @@ static void *encodeFunc(void *arg)
 
     audioStream_terminate(iStream);
     codec2_destroy(codec2);
+    free(adcBuf);
 
     // In case thread terminates due to invalid path or stream error, detach it
     // to ensure that its memory gets freed by the OS.
@@ -236,12 +263,12 @@ static void *decodeFunc(void *arg)
 {
     streamId oStream;
     pathId oPath = *((pathId *)arg);
-    stream_sample_t audioBuf[320];
+    stream_sample_t audioBuf[DMA_BUF_SAMPLES];
     struct CODEC2 *codec2;
 
     // Open output stream
-    memset(audioBuf, 0x00, 320 * sizeof(stream_sample_t));
-    oStream = audioStream_start(oPath, audioBuf, 320, 8000,
+    memset(audioBuf, 0x00, DMA_BUF_SAMPLES * sizeof(stream_sample_t));
+    oStream = audioStream_start(oPath, audioBuf, DMA_BUF_SAMPLES, 8000,
                                 STREAM_OUTPUT | BUF_CIRC_DOUBLE);
     if (oStream < 0) {
         pthread_detach(pthread_self());
@@ -289,12 +316,13 @@ static void *decodeFunc(void *arg)
 
 #ifdef PLATFORM_MD3x0
             // Bump up volume a little bit, as on MD3x0 is quite low
-            for (size_t i = 0; i < 160; i++)
+            for (size_t i = 0; i < CODEC2_FRAME_SAMPLES; i++)
                 audioBuf[i] *= 2;
 #endif
 
         } else {
-            memset(audioBuf, 0x00, 160 * sizeof(stream_sample_t));
+            memset(audioBuf, 0x00,
+                   CODEC2_FRAME_SAMPLES * sizeof(stream_sample_t));
         }
 
         outputStream_sync(oStream, true);

--- a/openrtx/src/core/audio_codec.c
+++ b/openrtx/src/core/audio_codec.c
@@ -22,22 +22,22 @@
 
 #define BUF_SIZE 4
 
-static pathId           audioPath;
+static pathId audioPath;
 
-static uint8_t          initCnt = 0;
-static bool             running;
+static uint8_t initCnt = 0;
+static bool running;
 
-static bool             reqStop;
-static pthread_t        codecThread;
-static pthread_attr_t   codecAttr;
-static pthread_mutex_t  data_mutex  = PTHREAD_MUTEX_INITIALIZER;
-static pthread_mutex_t  init_mutex  = PTHREAD_MUTEX_INITIALIZER;
-static pthread_cond_t   wakeup_cond = PTHREAD_COND_INITIALIZER;
+static bool reqStop;
+static pthread_t codecThread;
+static pthread_attr_t codecAttr;
+static pthread_mutex_t data_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t init_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t wakeup_cond = PTHREAD_COND_INITIALIZER;
 
-static uint8_t          readPos;
-static uint8_t          writePos;
-static uint8_t          numElements;
-static uint64_t         dataBuffer[BUF_SIZE];
+static uint8_t readPos;
+static uint8_t writePos;
+static uint8_t numElements;
+static uint64_t dataBuffer[BUF_SIZE];
 
 #ifdef PLATFORM_MOD17
 static const uint8_t micGain = 12;
@@ -49,9 +49,8 @@ static const uint8_t micGain = 32;
 
 static void *encodeFunc(void *arg);
 static void *decodeFunc(void *arg);
-static bool startThread(const pathId path, void *(*func) (void *));
+static bool startThread(const pathId path, void *(*func)(void *));
 static void stopThread();
-
 
 void codec_init()
 {
@@ -59,12 +58,12 @@ void codec_init()
     initCnt += 1;
     pthread_mutex_unlock(&init_mutex);
 
-    if(initCnt > 0)
+    if (initCnt > 0)
         return;
 
-    running     = false;
-    readPos     = 0;
-    writePos    = 0;
+    running = false;
+    readPos = 0;
+    writePos = 0;
     numElements = 0;
 }
 
@@ -74,10 +73,10 @@ void codec_terminate()
     initCnt -= 1;
     pthread_mutex_unlock(&init_mutex);
 
-    if(initCnt > 0)
+    if (initCnt > 0)
         return;
 
-    if(running)
+    if (running)
         stopThread();
 }
 
@@ -93,10 +92,10 @@ bool codec_startDecode(const pathId path)
 
 void codec_stop(const pathId path)
 {
-    if(running == false)
+    if (running == false)
         return;
 
-    if(audioPath != path)
+    if (audioPath != path)
         return;
 
     stopThread();
@@ -109,24 +108,23 @@ bool codec_running()
 
 int codec_popFrame(uint8_t *frame, const bool blocking)
 {
-    if(running == false)
+    if (running == false)
         return -EPERM;
 
     uint64_t element;
 
     // No data available and non-blocking call: just return false.
-    if((numElements == 0) && (blocking == false))
+    if ((numElements == 0) && (blocking == false))
         return -EAGAIN;
 
     // Blocking call: wait until some data is pushed
     pthread_mutex_lock(&data_mutex);
-    while(numElements == 0)
-    {
+    while (numElements == 0) {
         pthread_cond_wait(&wakeup_cond, &data_mutex);
     }
 
-    element      = dataBuffer[readPos];
-    readPos      = (readPos + 1) % BUF_SIZE;
+    element = dataBuffer[readPos];
+    readPos = (readPos + 1) % BUF_SIZE;
     numElements -= 1;
     pthread_mutex_unlock(&data_mutex);
 
@@ -139,7 +137,7 @@ int codec_popFrame(uint8_t *frame, const bool blocking)
 
 int codec_pushFrame(const uint8_t *frame, const bool blocking)
 {
-    if(running == false)
+    if (running == false)
         return -EPERM;
 
     // Copy data to a temporary variable before mutex lock to reduce execution
@@ -147,15 +145,13 @@ int codec_pushFrame(const uint8_t *frame, const bool blocking)
     uint64_t element;
     memcpy(&element, frame, 8);
 
-
     // No space available and non-blocking call: return
-    if((numElements >= BUF_SIZE) && (blocking == false))
+    if ((numElements >= BUF_SIZE) && (blocking == false))
         return -EAGAIN;
 
     // Blocking call: wait until there is some free space
     pthread_mutex_lock(&data_mutex);
-    while(numElements >= BUF_SIZE)
-    {
+    while (numElements >= BUF_SIZE) {
         pthread_cond_wait(&wakeup_cond, &data_mutex);
     }
 
@@ -168,22 +164,17 @@ int codec_pushFrame(const uint8_t *frame, const bool blocking)
     return 0;
 }
 
-
-
-
 static void *encodeFunc(void *arg)
 {
-
-    streamId        iStream;
-    pathId          iPath = *((pathId*) arg);
+    streamId iStream;
+    pathId iPath = *((pathId *)arg);
     stream_sample_t audioBuf[320];
-    struct CODEC2   *codec2;
-    struct dcBlock  dcBlock;
+    struct CODEC2 *codec2;
+    struct dcBlock dcBlock;
 
     iStream = audioStream_start(iPath, audioBuf, 320, 8000,
                                 STREAM_INPUT | BUF_CIRC_DOUBLE);
-    if(iStream < 0)
-    {
+    if (iStream < 0) {
         pthread_detach(pthread_self());
         running = false;
         return NULL;
@@ -192,47 +183,45 @@ static void *encodeFunc(void *arg)
     dsp_resetState(dcBlock);
     codec2 = codec2_create(CODEC2_MODE_3200);
 
-    while(reqStop == false)
-    {
+    while (reqStop == false) {
         // Invalid path, quit
-        if(audioPath_getStatus(iPath) != PATH_OPEN)
+        if (audioPath_getStatus(iPath) != PATH_OPEN)
             break;
 
         dataBlock_t audio = inputStream_getData(iStream);
-        if(audio.data == NULL)
+        if (audio.data == NULL)
             break;
 
-        #ifndef PLATFORM_LINUX
-        for(size_t i = 0; i < audio.len; i++) {
+#ifndef PLATFORM_LINUX
+        for (size_t i = 0; i < audio.len; i++) {
             int16_t sample;
 
             sample = dsp_dcBlockFilter(&dcBlock, audio.data[i]);
             audio.data[i] = sample * micGain;
         }
-        #endif
+#endif
 
         // CODEC2 encodes 160ms of speech into 8 bytes: here we write the
         // new encoded data into a buffer of 16 bytes writing the first
         // half and then the second one, sequentially.
         // Data ready flag is rised once all the 16 bytes contain new data.
         uint64_t frame = 0;
-        codec2_encode(codec2, ((uint8_t*) &frame), audio.data);
+        codec2_encode(codec2, ((uint8_t *)&frame), audio.data);
 
         pthread_mutex_lock(&data_mutex);
 
         // If buffer is full erase the oldest frame
-        if(numElements >= BUF_SIZE)
-        {
+        if (numElements >= BUF_SIZE) {
             readPos = (readPos + 1) % BUF_SIZE;
         }
 
         dataBuffer[writePos] = frame;
         writePos = (writePos + 1) % BUF_SIZE;
 
-        if(numElements == 0)
+        if (numElements == 0)
             pthread_cond_signal(&wakeup_cond);
 
-        if(numElements < BUF_SIZE)
+        if (numElements < BUF_SIZE)
             numElements += 1;
 
         pthread_mutex_unlock(&data_mutex);
@@ -243,7 +232,7 @@ static void *encodeFunc(void *arg)
 
     // In case thread terminates due to invalid path or stream error, detach it
     // to ensure that its memory gets freed by the OS.
-    if(reqStop == false)
+    if (reqStop == false)
         pthread_detach(pthread_self());
 
     running = false;
@@ -252,17 +241,16 @@ static void *encodeFunc(void *arg)
 
 static void *decodeFunc(void *arg)
 {
-    streamId        oStream;
-    pathId          oPath = *((pathId*) arg);
+    streamId oStream;
+    pathId oPath = *((pathId *)arg);
     stream_sample_t audioBuf[320];
-    struct CODEC2   *codec2;
+    struct CODEC2 *codec2;
 
     // Open output stream
     memset(audioBuf, 0x00, 320 * sizeof(stream_sample_t));
     oStream = audioStream_start(oPath, audioBuf, 320, 8000,
                                 STREAM_OUTPUT | BUF_CIRC_DOUBLE);
-    if(oStream < 0)
-    {
+    if (oStream < 0) {
         pthread_detach(pthread_self());
         running = false;
         return NULL;
@@ -276,47 +264,43 @@ static void *decodeFunc(void *arg)
     // noises at speaker output. Behaviour observed on both Module17 and MD-UV380
     outputStream_sync(oStream, false);
 
-    while(reqStop == false)
-    {
+    while (reqStop == false) {
         // Invalid path, quit
-        if(audioPath_getStatus(oPath) != PATH_OPEN)
+        if (audioPath_getStatus(oPath) != PATH_OPEN)
             break;
 
         // Try popping data from the queue
-        uint64_t frame   = 0;
-        bool     newData = false;
+        uint64_t frame = 0;
+        bool newData = false;
 
         pthread_mutex_lock(&data_mutex);
 
-        if(numElements != 0)
-        {
-            frame        = dataBuffer[readPos];
-            readPos      = (readPos + 1) % BUF_SIZE;
-            if(numElements >= BUF_SIZE)
+        if (numElements != 0) {
+            frame = dataBuffer[readPos];
+            readPos = (readPos + 1) % BUF_SIZE;
+            if (numElements >= BUF_SIZE)
                 pthread_cond_signal(&wakeup_cond);
 
             numElements -= 1;
-            newData      = true;
+            newData = true;
         }
 
         pthread_mutex_unlock(&data_mutex);
 
         stream_sample_t *audioBuf = outputStream_getIdleBuffer(oStream);
-        if(audioBuf == NULL)
+        if (audioBuf == NULL)
             break;
 
-        if(newData)
-        {
-            codec2_decode(codec2, audioBuf, ((uint8_t *) &frame));
+        if (newData) {
+            codec2_decode(codec2, audioBuf, ((uint8_t *)&frame));
 
-            #ifdef PLATFORM_MD3x0
+#ifdef PLATFORM_MD3x0
             // Bump up volume a little bit, as on MD3x0 is quite low
-            for(size_t i = 0; i < 160; i++) audioBuf[i] *= 2;
-            #endif
+            for (size_t i = 0; i < 160; i++)
+                audioBuf[i] *= 2;
+#endif
 
-        }
-        else
-        {
+        } else {
             memset(audioBuf, 0x00, 160 * sizeof(stream_sample_t));
         }
 
@@ -329,27 +313,25 @@ static void *decodeFunc(void *arg)
 
     // In case thread terminates due to invalid path or stream error, detach it
     // to ensure that its memory gets freed by the OS.
-    if(reqStop == false)
+    if (reqStop == false)
         pthread_detach(pthread_self());
 
     running = false;
     return NULL;
 }
 
-static bool startThread(const pathId path, void *(*func) (void *))
+static bool startThread(const pathId path, void *(*func)(void *))
 {
     // Bad incoming path
-    if(audioPath_getStatus(path) != PATH_OPEN)
+    if (audioPath_getStatus(path) != PATH_OPEN)
         return false;
 
     // Handle access contention when starting the codec thread to ensure that
     // only one call at a time can effectively start the thread.
     pthread_mutex_lock(&init_mutex);
-    if(running)
-    {
+    if (running) {
         // Same path as before, path open, codec already running: all good.
-        if(path == audioPath)
-        {
+        if (path == audioPath) {
             pthread_mutex_unlock(&init_mutex);
             return true;
         }
@@ -358,29 +340,26 @@ static bool startThread(const pathId path, void *(*func) (void *))
         // or the current one is closed/suspended.
         pathInfo_t newPath = audioPath_getInfo(path);
         pathInfo_t curPath = audioPath_getInfo(audioPath);
-        if((curPath.status == PATH_OPEN) && (curPath.prio >= newPath.prio))
-        {
+        if ((curPath.status == PATH_OPEN) && (curPath.prio >= newPath.prio)) {
             pthread_mutex_unlock(&init_mutex);
             return false;
-        }
-        else
-        {
+        } else {
             stopThread();
         }
     }
 
-    running   = true;
+    running = true;
     audioPath = path;
     pthread_mutex_unlock(&init_mutex);
 
-    readPos     = 0;
-    writePos    = 0;
+    readPos = 0;
+    writePos = 0;
     numElements = 0;
-    reqStop     = false;
+    reqStop = false;
 
     pthread_attr_init(&codecAttr);
 
-    #if defined(_MIOSIX)
+#if defined(_MIOSIX)
     // Set stack size of CODEC2 thread to 16kB.
     pthread_attr_setstacksize(&codecAttr, CODEC2_THREAD_STKSIZE);
 
@@ -388,15 +367,16 @@ static bool startThread(const pathId path, void *(*func) (void *))
     struct sched_param param;
     param.sched_priority = THREAD_PRIO_HIGH;
     pthread_attr_setschedparam(&codecAttr, &param);
-    #elif defined(__ZEPHYR__)
+#elif defined(__ZEPHYR__)
     // Allocate and set the stack for CODEC2 thread
     void *codec_thread_stack = malloc(CODEC2_THREAD_STKSIZE * sizeof(uint8_t));
-    pthread_attr_setstack(&codecAttr, codec_thread_stack, CODEC2_THREAD_STKSIZE);
-    #endif
+    pthread_attr_setstack(&codecAttr, codec_thread_stack,
+                          CODEC2_THREAD_STKSIZE);
+#endif
 
     // Start thread
     int ret = pthread_create(&codecThread, &codecAttr, func, &audioPath);
-    if(ret < 0)
+    if (ret < 0)
         running = false;
 
     return running;
@@ -408,11 +388,11 @@ static void stopThread()
     pthread_join(codecThread, NULL);
     running = false;
 
-    #ifdef __ZEPHYR__
-    void  *addr;
+#ifdef __ZEPHYR__
+    void *addr;
     size_t size;
 
     pthread_attr_getstack(&codecAttr, &addr, &size);
     free(addr);
-    #endif
+#endif
 }

--- a/openrtx/src/core/audio_codec.c
+++ b/openrtx/src/core/audio_codec.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <errno.h>
 #include "core/dsp.h"
+#include "hwconfig.h"
 
 #define BUF_SIZE 4
 
@@ -38,14 +39,6 @@ static uint8_t readPos;
 static uint8_t writePos;
 static uint8_t numElements;
 static uint64_t dataBuffer[BUF_SIZE];
-
-#ifdef PLATFORM_MOD17
-static const uint8_t micGain = 12;
-#else
-#ifndef PLATFORM_LINUX
-static const uint8_t micGain = 32;
-#endif
-#endif
 
 static void *encodeFunc(void *arg);
 static void *decodeFunc(void *arg);
@@ -197,7 +190,7 @@ static void *encodeFunc(void *arg)
             int16_t sample;
 
             sample = dsp_dcBlockFilter(&dcBlock, audio.data[i]);
-            audio.data[i] = sample * micGain;
+            audio.data[i] = sample * CONFIG_MIC_GAIN;
         }
 #endif
 

--- a/openrtx/src/core/dsp.cpp
+++ b/openrtx/src/core/dsp.cpp
@@ -23,3 +23,27 @@ int16_t dsp_dcBlockFilter(struct dcBlock *dcb, int16_t sample)
 
     return static_cast<int16_t>(dcb->prevOut);
 }
+
+void dsp_oversamplingSetOversampling(
+    struct oversamplingBlock *oversamplingBlock, uint8_t oversampling)
+{
+    oversamplingBlock->oversampling = oversampling;
+}
+
+bool dsp_oversamplingDecimate(struct oversamplingBlock *oversamplingBlock,
+                              stream_sample_t *sample)
+{
+    oversamplingBlock->accumulator += (uint16_t)*sample;
+    oversamplingBlock->count++;
+    if (oversamplingBlock->count >= oversamplingBlock->oversampling) {
+        // Integer division truncates toward zero; this is intentional as
+        // rounding is unnecessary for audio signal averaging.
+        *sample = oversamplingBlock->accumulator
+                / oversamplingBlock->oversampling;
+        oversamplingBlock->accumulator = 0;
+        oversamplingBlock->count = 0;
+        return true;
+    }
+
+    return false;
+}

--- a/platform/targets/CS7000-PLUS/hwconfig.h
+++ b/platform/targets/CS7000-PLUS/hwconfig.h
@@ -71,6 +71,7 @@ extern const struct gpsDevice gps;
 
 /* Microphone audio input */
 #define CONFIG_MIC_GAIN 32
+#define CONFIG_MIC_OVERSAMPLE 6
 
 #ifdef __cplusplus
 }

--- a/platform/targets/CS7000-PLUS/hwconfig.h
+++ b/platform/targets/CS7000-PLUS/hwconfig.h
@@ -20,15 +20,14 @@ extern HR_C6000 C6000;
 extern "C" {
 #endif
 
-enum AdcChannels
-{
-    ADC_VOL_CH   = 8,   /* PC5  */
-    ADC_VBAT_CH  = 3,   /* PA6  */
-    ADC_RTX_CH   = 15,  /* PA3  */
-    ADC_RSSI_CH  = 9,   /* PB0  */
-    ADC_MIC_CH   = 7,   /* PA7  */
-    ADC_CTCSS_CH = 2,   /* PA2  */
-    ADC_VOX_CH   = 4,   /* PC4  */
+enum AdcChannels {
+    ADC_VOL_CH = 8,   /* PC5  */
+    ADC_VBAT_CH = 3,  /* PA6  */
+    ADC_RTX_CH = 15,  /* PA3  */
+    ADC_RSSI_CH = 9,  /* PB0  */
+    ADC_MIC_CH = 7,   /* PA7  */
+    ADC_CTCSS_CH = 2, /* PA2  */
+    ADC_VOX_CH = 4,   /* PC4  */
 };
 
 extern const struct Adc adc1;

--- a/platform/targets/CS7000-PLUS/hwconfig.h
+++ b/platform/targets/CS7000-PLUS/hwconfig.h
@@ -69,6 +69,9 @@ extern const struct gpsDevice gps;
 /* Device has a vibration motor */
 #define CONFIG_VIBRATION
 
+/* Microphone audio input */
+#define CONFIG_MIC_GAIN 32
+
 #ifdef __cplusplus
 }
 #endif

--- a/platform/targets/CS7000/hwconfig.h
+++ b/platform/targets/CS7000/hwconfig.h
@@ -20,14 +20,13 @@ extern HR_C6000 C6000;
 extern "C" {
 #endif
 
-enum AdcChannels
-{
-    ADC_VOL_CH  = 15,  /* PC5  */
-    ADC_VBAT_CH = 6,   /* PA6  */
-    ADC_MIC_CH  = 3,   /* PA3  */
-    ADC_RSSI_CH = 8,   /* PB0  */
-    ADC_RTX_CH  = 7,   /* PA7  */
-    ADC_CTCSS_CH = 2,  /* PA2  */
+enum AdcChannels {
+    ADC_VOL_CH = 15,  /* PC5  */
+    ADC_VBAT_CH = 6,  /* PA6  */
+    ADC_MIC_CH = 3,   /* PA3  */
+    ADC_RSSI_CH = 8,  /* PB0  */
+    ADC_RTX_CH = 7,   /* PA7  */
+    ADC_CTCSS_CH = 2, /* PA2  */
 };
 
 extern const struct Adc adc1;

--- a/platform/targets/CS7000/hwconfig.h
+++ b/platform/targets/CS7000/hwconfig.h
@@ -64,6 +64,7 @@ extern const struct gpsDevice gps;
 
 /* Microphone audio input */
 #define CONFIG_MIC_GAIN 32
+#define CONFIG_MIC_OVERSAMPLE 8
 
 #ifdef __cplusplus
 }

--- a/platform/targets/CS7000/hwconfig.h
+++ b/platform/targets/CS7000/hwconfig.h
@@ -62,6 +62,9 @@ extern const struct gpsDevice gps;
 #define CONFIG_GPS_STM32_USART6
 #define CONFIG_NMEA_RBUF_SIZE 128
 
+/* Microphone audio input */
+#define CONFIG_MIC_GAIN 32
+
 #ifdef __cplusplus
 }
 #endif

--- a/platform/targets/DM-1701/hwconfig.h
+++ b/platform/targets/DM-1701/hwconfig.h
@@ -47,6 +47,9 @@ extern const struct Adc adc1;
 /* Device supports M17 mode */
 #define CONFIG_M17
 
+/* Microphone audio input */
+#define CONFIG_MIC_GAIN 32
+
 /*
  * To enable pwm for display backlight dimming uncomment this directive.
  *

--- a/platform/targets/DM-1701/hwconfig.h
+++ b/platform/targets/DM-1701/hwconfig.h
@@ -49,6 +49,7 @@ extern const struct Adc adc1;
 
 /* Microphone audio input */
 #define CONFIG_MIC_GAIN 32
+#define CONFIG_MIC_OVERSAMPLE 8
 
 /*
  * To enable pwm for display backlight dimming uncomment this directive.

--- a/platform/targets/DM-1701/hwconfig.h
+++ b/platform/targets/DM-1701/hwconfig.h
@@ -20,11 +20,10 @@ extern HR_C6000 C6000;
 extern "C" {
 #endif
 
-enum AdcChannel
-{
-    ADC_VOL_CH   = 0,
-    ADC_VBAT_CH  = 1,
-    ADC_MIC_CH   = 3,
+enum AdcChannel {
+    ADC_VOL_CH = 0,
+    ADC_VBAT_CH = 1,
+    ADC_MIC_CH = 3,
 };
 
 extern const struct spiCustomDevice c6000_spi;

--- a/platform/targets/GDx/hwconfig.h
+++ b/platform/targets/GDx/hwconfig.h
@@ -40,6 +40,9 @@ extern const struct spiDevice c6000_spi;
 #define CONFIG_BAT_LIION
 #define CONFIG_BAT_NCELLS 2
 
+/* Microphone audio input */
+#define CONFIG_MIC_GAIN 32
+
 #ifdef __cplusplus
 }
 #endif

--- a/platform/targets/MD-3x0/hwconfig.h
+++ b/platform/targets/MD-3x0/hwconfig.h
@@ -14,12 +14,11 @@
 extern "C" {
 #endif
 
-enum adcChannel
-{
-    ADC_VOL_CH   = 0,
-    ADC_VBAT_CH  = 1,
-    ADC_VOX_CH   = 3,
-    ADC_RSSI_CH  = 8
+enum adcChannel {
+    ADC_VOL_CH = 0,
+    ADC_VBAT_CH = 1,
+    ADC_VOX_CH = 3,
+    ADC_RSSI_CH = 8
 };
 
 extern const struct gpsDevice gps;

--- a/platform/targets/MD-3x0/hwconfig.h
+++ b/platform/targets/MD-3x0/hwconfig.h
@@ -58,6 +58,7 @@ extern const struct Adc adc1;
 
 /* Microphone audio input */
 #define CONFIG_MIC_GAIN 32
+#define CONFIG_MIC_OVERSAMPLE 8
 
 #ifdef __cplusplus
 }

--- a/platform/targets/MD-3x0/hwconfig.h
+++ b/platform/targets/MD-3x0/hwconfig.h
@@ -56,6 +56,9 @@ extern const struct Adc adc1;
 /* Device supports M17 mode */
 #define CONFIG_M17
 
+/* Microphone audio input */
+#define CONFIG_MIC_GAIN 32
+
 #ifdef __cplusplus
 }
 #endif

--- a/platform/targets/MD-9600/hwconfig.h
+++ b/platform/targets/MD-9600/hwconfig.h
@@ -14,14 +14,13 @@
 extern "C" {
 #endif
 
-enum adcChannel
-{
-    ADC_VOL_CH   = 0,
-    ADC_VBAT_CH  = 1,
-    ADC_VOX_CH   = 3,
-    ADC_RSSI_CH  = 8,
-    ADC_SW1_CH   = 7,
-    ADC_SW2_CH   = 6,
+enum adcChannel {
+    ADC_VOL_CH = 0,
+    ADC_VBAT_CH = 1,
+    ADC_VOX_CH = 3,
+    ADC_RSSI_CH = 8,
+    ADC_SW1_CH = 7,
+    ADC_SW2_CH = 6,
     ADC_RSSI2_CH = 9,
     ADC_HTEMP_CH = 15
 };

--- a/platform/targets/MD-9600/hwconfig.h
+++ b/platform/targets/MD-9600/hwconfig.h
@@ -56,6 +56,7 @@ extern const struct Adc adc1;
 
 /* Microphone audio input */
 #define CONFIG_MIC_GAIN 32
+#define CONFIG_MIC_OVERSAMPLE 8
 
 #ifdef __cplusplus
 }

--- a/platform/targets/MD-9600/hwconfig.h
+++ b/platform/targets/MD-9600/hwconfig.h
@@ -54,6 +54,9 @@ extern const struct Adc adc1;
 /* Battery type */
 #define CONFIG_BAT_NONE
 
+/* Microphone audio input */
+#define CONFIG_MIC_GAIN 32
+
 #ifdef __cplusplus
 }
 #endif

--- a/platform/targets/MD-UV3x0/hwconfig.h
+++ b/platform/targets/MD-UV3x0/hwconfig.h
@@ -53,6 +53,9 @@ extern const struct Adc adc1;
 /* Device supports M17 mode */
 #define CONFIG_M17
 
+/* Microphone audio input */
+#define CONFIG_MIC_GAIN 32
+
 /*
  * To enable pwm for display backlight dimming uncomment this directive.
  *

--- a/platform/targets/MD-UV3x0/hwconfig.h
+++ b/platform/targets/MD-UV3x0/hwconfig.h
@@ -20,11 +20,10 @@ extern HR_C6000 C6000;
 extern "C" {
 #endif
 
-enum AdcChannel
-{
-    ADC_VOL_CH   = 0,
-    ADC_VBAT_CH  = 1,
-    ADC_MIC_CH   = 3,
+enum AdcChannel {
+    ADC_VOL_CH = 0,
+    ADC_VBAT_CH = 1,
+    ADC_MIC_CH = 3,
 };
 
 extern const struct gpsDevice gps;

--- a/platform/targets/MD-UV3x0/hwconfig.h
+++ b/platform/targets/MD-UV3x0/hwconfig.h
@@ -55,6 +55,7 @@ extern const struct Adc adc1;
 
 /* Microphone audio input */
 #define CONFIG_MIC_GAIN 32
+#define CONFIG_MIC_OVERSAMPLE 8
 
 /*
  * To enable pwm for display backlight dimming uncomment this directive.

--- a/platform/targets/Module17/hwconfig.h
+++ b/platform/targets/Module17/hwconfig.h
@@ -55,4 +55,7 @@ enum Mod17Flags { MOD17_FLAGS_HMI_PRESENT = 1, MOD17_FLAGS_SOFTPOT = 2 };
 /* Device supports M17 mode */
 #define CONFIG_M17
 
+/* Microphone audio input */
+#define CONFIG_MIC_GAIN 12
+
 #endif

--- a/platform/targets/Module17/hwconfig.h
+++ b/platform/targets/Module17/hwconfig.h
@@ -13,42 +13,34 @@
 #include <stdbool.h>
 #include "pinmap.h"
 
-enum AdcChannel
-{
-    ADC_HWVER_CH     = 3,
-    ADC_HMI_HWVER_CH = 13,
-    ADC_VBAT_CH      = 18
-};
+enum AdcChannel { ADC_HWVER_CH = 3, ADC_HMI_HWVER_CH = 13, ADC_VBAT_CH = 18 };
 
 extern const struct i2cDevice i2c1;
 extern const struct i2cDevice i2c2;
 
-enum Mod17HwVersion
-{
-    MOD17_HW_V01_D = 0,    /* Hardware version 0.1d */
-    MOD17_HW_V01_E = 1,    /* Hardware version 0.1e */
-    MOD17_HW_V10   = 2     /* Hardware version 1.0  */
+enum Mod17HwVersion {
+    MOD17_HW_V01_D = 0, /* Hardware version 0.1d */
+    MOD17_HW_V01_E = 1, /* Hardware version 0.1e */
+    MOD17_HW_V10 = 2    /* Hardware version 1.0  */
 };
 
-enum Mod17HmiVersion
-{
-    MOD17_HMI_V10 = 1     /* HMI hardware ver. 1.0  */
+enum Mod17HmiVersion {
+    MOD17_HMI_V10 = 1 /* HMI hardware ver. 1.0  */
 };
 
-enum Mod17Flags
-{
-    MOD17_FLAGS_HMI_PRESENT = 1,
-    MOD17_FLAGS_SOFTPOT     = 2
-};
+enum Mod17Flags { MOD17_FLAGS_HMI_PRESENT = 1, MOD17_FLAGS_SOFTPOT = 2 };
 
-#define MOD17_HWDET_THRESH   300000    /* Threshold for hardware detection, in uV    */
+#define MOD17_HWDET_THRESH \
+    300000                    /* Threshold for hardware detection, in uV    */
 
-#define MOD17_HW01D_VOLTAGE  0         /* Hardware version 0.1d: gpio pulled to 0V   */
-#define MOD17_HW01E_VOLTAGE  3300000   /* Hardware version 0.1e: gpio pulled to 3.3V */
-#define MOD17_HW10_VOLTAGE   1650000   /* Hardware version 1.0: gpio pulled to 1.65V */
+#define MOD17_HW01D_VOLTAGE 0 /* Hardware version 0.1d: gpio pulled to 0V   */
+#define MOD17_HW01E_VOLTAGE \
+    3300000                   /* Hardware version 0.1e: gpio pulled to 3.3V */
+#define MOD17_HW10_VOLTAGE \
+    1650000                   /* Hardware version 1.0: gpio pulled to 1.65V */
 
-#define MOD17_HMI10_VOLTAGE  1688000   /* HMI version 1.0: gpio pulled to 1.68V      */
-
+#define MOD17_HMI10_VOLTAGE \
+    1688000 /* HMI version 1.0: gpio pulled to 1.68V      */
 
 /* Screen dimensions */
 #define CONFIG_SCREEN_WIDTH 128

--- a/platform/targets/linux/hwconfig.h
+++ b/platform/targets/linux/hwconfig.h
@@ -24,6 +24,9 @@ enum Mod17Flags { MOD17_FLAGS_HMI_PRESENT = 1, MOD17_FLAGS_SOFTPOT = 2 };
 /* Device supports M17 mode */
 #define CONFIG_M17
 
+/* Microphone audio input */
+#define CONFIG_MIC_GAIN 1
+
 #ifdef __cplusplus
 }
 #endif

--- a/platform/targets/linux/hwconfig.h
+++ b/platform/targets/linux/hwconfig.h
@@ -12,11 +12,7 @@ extern "C" {
 #endif
 
 /* Module17 hardware info flags, required by Module17 UI emulator target */
-enum Mod17Flags
-{
-    MOD17_FLAGS_HMI_PRESENT = 1,
-    MOD17_FLAGS_SOFTPOT     = 2
-};
+enum Mod17Flags { MOD17_FLAGS_HMI_PRESENT = 1, MOD17_FLAGS_SOFTPOT = 2 };
 
 /* Screen has adjustable brightness */
 #define CONFIG_SCREEN_BRIGHTNESS

--- a/platform/targets/ttwrplus/hwconfig.h
+++ b/platform/targets/ttwrplus/hwconfig.h
@@ -25,4 +25,7 @@
 
 #define CONFIG_M17
 
+/* Microphone audio input */
+#define CONFIG_MIC_GAIN 1
+
 #endif /* HWCONFIG_H */

--- a/platform/targets/ttwrplus/hwconfig.h
+++ b/platform/targets/ttwrplus/hwconfig.h
@@ -12,8 +12,8 @@
 /*
  * Display properties are encoded in the devicetree
  */
-#define DISPLAY       DT_CHOSEN(zephyr_display)
-#define CONFIG_SCREEN_WIDTH  DT_PROP(DISPLAY, width)
+#define DISPLAY DT_CHOSEN(zephyr_display)
+#define CONFIG_SCREEN_WIDTH DT_PROP(DISPLAY, width)
 #define CONFIG_SCREEN_HEIGHT DT_PROP(DISPLAY, height)
 #define CONFIG_PIX_FMT_BW
 

--- a/scripts/clang_format.sh
+++ b/scripts/clang_format.sh
@@ -114,6 +114,7 @@ tests/unit/M17_viterbi.cpp
 tests/unit/ui_check_standby.cpp
 tests/unit/M17_metatext.cpp
 tests/unit/M17_packet.cpp
+tests/unit/dsp_oversampling.cpp
 EOF
 )
 

--- a/scripts/clang_format.sh
+++ b/scripts/clang_format.sh
@@ -67,6 +67,7 @@ openrtx/include/protocols/M17/MetaText.hpp
 openrtx/include/ui/utils.h
 openrtx/src/core/crc.c
 openrtx/src/core/dsp.cpp
+openrtx/src/core/audio_codec.c
 openrtx/src/core/nvmem_access.c
 openrtx/src/core/memory_profiling.cpp
 openrtx/src/protocols/M17/Callsign.cpp
@@ -88,7 +89,16 @@ platform/drivers/GPIO/gpio-native.h
 platform/drivers/GPS/gps_stm32.h
 platform/drivers/GPS/gps_zephyr.h
 platform/drivers/USB/usb.h
+platform/targets/CS7000/hwconfig.h
+platform/targets/CS7000-PLUS/hwconfig.h
+platform/targets/DM-1701/hwconfig.h
 platform/targets/GDx/hwconfig.h
+platform/targets/linux/hwconfig.h
+platform/targets/MD-3x0/hwconfig.h
+platform/targets/MD-9600/hwconfig.h
+platform/targets/MD-UV3x0/hwconfig.h
+platform/targets/Module17/hwconfig.h
+platform/targets/ttwrplus/hwconfig.h
 platform/targets/linux/emulator/sdl_engine.h
 platform/targets/ttwrplus/pmu.h
 tests/platform/mic_test.c

--- a/tests/platform/oversample_test.c
+++ b/tests/platform/oversample_test.c
@@ -1,0 +1,105 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "core/audio_stream.h"
+#include "core/audio_path.h"
+#include "interfaces/platform.h"
+#include "interfaces/delays.h"
+#include "core/memory_profiling.h"
+#include "interfaces/audio.h"
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include "core/dsp.h"
+
+static const size_t audioBufSize = 320;
+static const size_t outBufSize = 45 * 1024;
+// Value in range [1, 16] any larger will overflow the uint16_t and bit shifting will become necessary
+static const size_t oversample = 4;
+// Is essentially sqrt(oversample)/2
+static const size_t oversample_bits = 0;
+
+void error()
+{
+    while (1) {
+        platform_ledOn(RED);
+        sleepFor(0u, 500u);
+        platform_ledOff(RED);
+        sleepFor(0u, 500u);
+    }
+}
+
+void blink_green(size_t count)
+{
+    for (size_t i = 0; count == 0 || i < count; i++)
+    {
+        platform_ledOn(GREEN);
+        sleepFor(0u, 500u);
+        platform_ledOff(GREEN);
+        sleepFor(0u, 500u);
+    }
+}
+
+int main()
+{
+    platform_init();
+
+    int16_t *audioBuf = ((int16_t *)malloc(audioBufSize * sizeof(int16_t)));
+    if (audioBuf == NULL)
+        error();
+    uint16_t *outBuf = ((uint16_t *)malloc(outBufSize * sizeof(uint16_t)));
+    if (outBuf == NULL)
+        error();
+
+    // Requesting the audio path enables the preamp and some other stuff, this needs a few seconds to settle before ready
+    pathId path = audioPath_request(SOURCE_MIC, SINK_MCU, PRIO_TX);
+
+    blink_green(3);
+    platform_ledOn(RED);
+
+    streamId id = audioStream_start(path, audioBuf, audioBufSize, 8000 * oversample,
+                                    BUF_CIRC_DOUBLE | STREAM_INPUT);
+
+    size_t outPos = 0;
+    size_t subPos = 0;
+    uint32_t sum = 0;
+
+    while (true) {
+        dataBlock_t data = inputStream_getData(id);
+
+        if (data.data == NULL)
+            error();
+
+        for (size_t i = 0; i < data.len; i++)
+        {
+            sum += (uint16_t)data.data[i];
+            subPos++;
+            if (subPos >= oversample)
+            {
+                subPos = 0;
+                outBuf[outPos++] = sum >> oversample_bits;
+                sum = 0;
+                if (outPos >= outBufSize)
+                    goto done;
+            }
+        }
+    }
+done:
+
+    audioStream_stop(id);
+
+    platform_ledOff(RED);
+    blink_green(10);
+    platform_ledOn(RED);
+
+    for (size_t i = 0; i < outBufSize; i++)
+        iprintf("%04x\n", outBuf[i]);
+
+    platform_ledOff(RED);
+
+    blink_green(0);
+}

--- a/tests/platform/oversample_test.py
+++ b/tests/platform/oversample_test.py
@@ -1,0 +1,181 @@
+#
+# SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import serial
+import time
+import argparse
+import csv
+import numpy as np
+from scipy.io.wavfile import write
+import sys
+
+def connect_serial(port, baudrate, retries=60, delay=1):
+    """
+    Connects to the serial port with retries and shows a waiting indicator.
+    """
+    spinner_chars = ['-', '\\', '|', '/']
+    print(f"Attempting to connect to serial port {port}...", flush=True)
+
+    for i in range(retries):
+        try:
+            ser = serial.Serial(port, baudrate, timeout=1)
+            print("\rSuccessfully connected to serial port.   ") # Clear spinner
+            return ser
+        except serial.SerialException:
+            sys.stdout.write(f"\rAttempt {i + 1}/{retries} {spinner_chars[i % len(spinner_chars)]}")
+            sys.stdout.flush()
+            time.sleep(delay)
+    print("\rFailed to connect to serial port after multiple retries.   ") # Clear spinner
+    return None
+
+def read_and_decode_data(ser, buffer_size):
+    """
+    Reads data from the serial port, decodes hex values, and returns a list of integers,
+    showing a progress bar.
+    """
+    data = []
+    print(f"Receiving {buffer_size} values from serial...")
+    progress_bar_length = 50
+    start_time = time.time()
+
+    while len(data) < buffer_size:
+        line = ser.readline().strip()
+        if line:
+            try:
+                hex_value = line.decode('ascii')
+                data_value = int(hex_value, 16)
+                data.append(data_value)
+
+                # Update progress bar
+                current_progress = len(data)
+                percentage = (current_progress / buffer_size) * 100
+                filled_length = int(progress_bar_length * current_progress / buffer_size)
+                bar = '█' * filled_length + '-' * (progress_bar_length - filled_length)
+                
+                # Estimate remaining time
+                elapsed_time = time.time() - start_time
+                if current_progress > 0:
+                    time_per_item = elapsed_time / current_progress
+                    remaining_items = buffer_size - current_progress
+                    estimated_remaining_time = remaining_items * time_per_item
+                    time_str = f" {estimated_remaining_time:.1f}s remaining"
+                else:
+                    time_str = ""
+
+                sys.stdout.write(f'\rProgress: |{bar}| {percentage:.1f}% ({current_progress}/{buffer_size}){time_str}')
+                sys.stdout.flush()
+            except (UnicodeDecodeError, ValueError) as e:
+                # Clear current line before printing warning
+                sys.stdout.write('\r' + ' ' * (progress_bar_length + 60) + '\r')
+                sys.stdout.flush()
+                print(f"Warning: Could not decode or parse line: {line}. Error: {e}")
+                # Re-draw progress bar
+                current_progress = len(data) # Recalculate based on actual data
+                percentage = (current_progress / buffer_size) * 100
+                filled_length = int(progress_bar_length * current_progress / buffer_size)
+                bar = '█' * filled_length + '-' * (progress_bar_length - filled_length)
+                sys.stdout.write(f'\rProgress: |{bar}| {percentage:.1f}% ({current_progress}/{buffer_size})')
+                sys.stdout.flush()
+
+    sys.stdout.write('\n') # New line after progress bar is complete
+    print(f"Received {len(data)} values.")
+    return data
+
+def normalize_audio(audio_data):
+    """
+    Normalizes audio data: converts to float, removes DC offset, and scales for no clipping.
+    The output is a float array scaled between -1.0 and 1.0.
+    """
+    #audio_float = (np.array(audio_data, dtype=np.float64) - 32767.5) / 32768.0
+    audio_float = np.array(audio_data, dtype=np.float32)
+
+    dc_offset = np.mean(audio_float)
+    audio_dc_removed = audio_float - dc_offset
+
+    max_abs_val = np.max(np.abs(audio_dc_removed))
+
+    if max_abs_val > 0:
+        scaling_factor = 1.0 / max_abs_val
+        audio_normalized = audio_dc_removed * scaling_factor
+    else:
+        audio_normalized = audio_dc_removed
+
+    audio_normalized = np.clip(audio_normalized, -1.0, 1.0)
+
+    #return audio_normalized.astype(np.float32)
+    return audio_normalized
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Read audio data from microcontroller, save to CSV and WAV."
+    )
+    parser.add_argument(
+        "filename_base",
+        type=str,
+        help="Base filename for CSV and WAV files (e.g., 'audio_capture')"
+    )
+    parser.add_argument(
+        "--port",
+        type=str,
+        default="/dev/ttyACM",
+        help="Serial port (e.g., /dev/ttyACM0 or COM3)"
+    )
+    parser.add_argument(
+        "--baudrate",
+        type=int,
+        default=115200,
+        help="Serial baud rate"
+    )
+    parser.add_argument(
+        "--buffer_size",
+        type=int,
+        default=45 * 1024,
+        help="Number of 16-bit unsigned integers in the microcontroller's buffer"
+    )
+    parser.add_argument(
+        "--samplerate",
+        type=int,
+        default=8000,
+        help="Sample rate of the microphone in Hz"
+    )
+
+    args = parser.parse_args()
+
+    csv_filename = f"{args.filename_base}.csv"
+    wav_filename = f"{args.filename_base}.wav"
+
+    ser = connect_serial(args.port, args.baudrate)
+    if not ser:
+        return
+
+    try:
+        raw_data = read_and_decode_data(ser, args.buffer_size)
+
+        print(f"Saving raw data to {csv_filename}...")
+        with open(csv_filename, 'w', newline='') as csvfile:
+            writer = csv.writer(csvfile)
+            #writer.writerow(['Raw_Value'])
+            for value in raw_data:
+                writer.writerow([value])
+        print("Raw data saved to CSV.")
+
+        if raw_data:
+            print("Normalizing audio data to float format...")
+            normalized_audio_float = normalize_audio(raw_data)
+
+            print(f"Saving normalized audio to {wav_filename} (float format)...")
+            write(wav_filename, args.samplerate, normalized_audio_float)
+            print("Normalized audio saved to WAV.")
+        else:
+            print("No audio data to normalize or save to WAV.")
+
+    finally:
+        ser.close()
+        print("Serial connection closed.")
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/platform/oversample_test_analyse.py
+++ b/tests/platform/oversample_test_analyse.py
@@ -1,0 +1,85 @@
+#
+# SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import argparse
+import os
+import math
+from scipy.io.wavfile import write
+import numpy as np
+
+def normalize_audio(audio_data):
+    """
+    Normalizes audio data: converts to float, removes DC offset, and scales for no clipping.
+    The output is a float array scaled between -1.0 and 1.0.
+    """
+    #audio_float = (np.array(audio_data, dtype=np.float64) - 32767.5) / 32768.0
+    audio_float = np.array(audio_data, dtype=np.float32)
+ 
+    dc_offset = np.mean(audio_float)
+    audio_dc_removed = audio_float - dc_offset
+ 
+    max_abs_val = np.max(np.abs(audio_dc_removed))
+ 
+    if max_abs_val > 0:
+        scaling_factor = 1.0 / max_abs_val
+        audio_normalized = audio_dc_removed * scaling_factor
+    else:
+        audio_normalized = audio_dc_removed
+ 
+    audio_normalized = np.clip(audio_normalized, -1.0, 1.0)
+    #print(dc_offset, max_abs_val, np.max(np.abs(audio_normalized)))
+ 
+    #return audio_normalized.astype(np.float32)
+    return audio_normalized
+
+def calculate_stats(directory_path):
+    print("File\t\tDC offset\tRMS")
+    files_to_process = []
+    for filename in os.listdir(directory_path):
+        if filename.endswith(".csv"):
+            files_to_process.append(filename)
+    
+    files_to_process.sort()
+
+    for filename in files_to_process:
+        filepath = os.path.join(directory_path, filename)
+        numbers = []
+        
+        with open(filepath, 'r') as f:
+            for line in f:
+                try:
+                    numbers.append(float(line.strip()))
+                except ValueError:
+                    continue
+
+        normalized_audio_float = normalize_audio(numbers[1:])
+        wav_filename = filepath.replace('.csv', '.wav')
+        write(wav_filename, 8000, normalized_audio_float)
+
+        if numbers:
+            # Calculate DC offset (average)
+            dc_offset = sum(numbers) / len(numbers)
+            
+            # Subtract DC offset and calculate sum of squares for RMS
+            sum_sq_after_dc = 0.0
+            for num in numbers:
+                sum_sq_after_dc += (num - dc_offset) ** 2
+            
+            rms_after_dc = math.sqrt(sum_sq_after_dc / len(numbers))
+            
+            print(f"{filename}\t{dc_offset:8.1f}\t{rms_after_dc:8.2f}")
+        else:
+            print(f"{filename}\tN/A")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Calculate RMS after subtracting DC offset from single-column CSV files.")
+    parser.add_argument("path", help="Path to the directory containing CSV files.")
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.path):
+        print(f"Error: Directory not found at '{args.path}'")
+    else:
+        calculate_stats(args.path)

--- a/tests/unit/dsp_oversampling.cpp
+++ b/tests/unit/dsp_oversampling.cpp
@@ -1,0 +1,100 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include "core/dsp.h"
+
+TEST_CASE("Oversampling decimation with factor 1 passes through",
+          "[dsp][oversampling]")
+{
+    struct oversamplingBlock blk;
+    dsp_resetState(blk);
+    dsp_oversamplingSetOversampling(&blk, 1);
+
+    stream_sample_t sample = 1000;
+    REQUIRE(dsp_oversamplingDecimate(&blk, &sample) == true);
+    REQUIRE(sample == 1000);
+}
+
+TEST_CASE("Oversampling decimation with factor 4 accumulates and averages",
+          "[dsp][oversampling]")
+{
+    struct oversamplingBlock blk;
+    dsp_resetState(blk);
+    dsp_oversamplingSetOversampling(&blk, 4);
+
+    stream_sample_t sample;
+
+    sample = 100;
+    REQUIRE(dsp_oversamplingDecimate(&blk, &sample) == false);
+
+    sample = 200;
+    REQUIRE(dsp_oversamplingDecimate(&blk, &sample) == false);
+
+    sample = 300;
+    REQUIRE(dsp_oversamplingDecimate(&blk, &sample) == false);
+
+    sample = 400;
+    REQUIRE(dsp_oversamplingDecimate(&blk, &sample) == true);
+    // Average of 100, 200, 300, 400 = 250
+    REQUIRE(sample == 250);
+}
+
+TEST_CASE("Oversampling decimation with factor 8 does not overflow",
+          "[dsp][oversampling]")
+{
+    struct oversamplingBlock blk;
+    dsp_resetState(blk);
+    dsp_oversamplingSetOversampling(&blk, 8);
+
+    // Feed 8 samples at ADC full-scale (12-bit: 4095); sum = 8 * 4095 = 32760
+    // The uint32_t accumulator must handle this without overflow.
+    stream_sample_t sample;
+    for (int i = 0; i < 7; i++) {
+        sample = 4095;
+        REQUIRE(dsp_oversamplingDecimate(&blk, &sample) == false);
+    }
+
+    sample = 4095;
+    REQUIRE(dsp_oversamplingDecimate(&blk, &sample) == true);
+    REQUIRE(sample == 4095);
+}
+
+TEST_CASE("Oversampling decimation resets between frames",
+          "[dsp][oversampling]")
+{
+    struct oversamplingBlock blk;
+    dsp_resetState(blk);
+    dsp_oversamplingSetOversampling(&blk, 2);
+
+    stream_sample_t sample;
+
+    // First pair
+    sample = 100;
+    REQUIRE(dsp_oversamplingDecimate(&blk, &sample) == false);
+    sample = 200;
+    REQUIRE(dsp_oversamplingDecimate(&blk, &sample) == true);
+    REQUIRE(sample == 150);
+
+    // Second pair should start fresh
+    sample = 500;
+    REQUIRE(dsp_oversamplingDecimate(&blk, &sample) == false);
+    sample = 700;
+    REQUIRE(dsp_oversamplingDecimate(&blk, &sample) == true);
+    REQUIRE(sample == 600);
+}
+
+TEST_CASE("Oversampling decimation with factor 1 and zero returns immediately",
+          "[dsp][oversampling]")
+{
+    struct oversamplingBlock blk;
+    dsp_resetState(blk);
+    dsp_oversamplingSetOversampling(&blk, 1);
+
+    stream_sample_t sample = 0;
+    REQUIRE(dsp_oversamplingDecimate(&blk, &sample) == true);
+    REQUIRE(sample == 0);
+}


### PR DESCRIPTION
This PR takes @JetseVerschuren's work on oversampling and makes a few tweaks based on real world testing (cs7000p and uv390) plus anticipated code review feedback. I'm helping with getting the changes landed here as well as trying to quantify the impact of the work.

## Summary of problem and changes

OpenRTX samples the microphone ADC at 8 kHz: the same rate codec2 consumes samples. Quantization noise from the 12-bit ADC is encoded alongside speech, degrading transmitted audio.
This change oversamples the ADC at N×8 kHz, then averages every N samples back to 8 kHz before feeding codec2. Averaging acts as a low-pass decimation filter that discards out-of-band quantization noise, yielding a theoretical noise reduction of 10·log10(N) dB.

The oversampling factor is configured per-platform via CONFIG_MIC_OVERSAMPLE in each target's hwconfig.h. Most platforms use factor 8 (64 kHz). The CS7000-PLUS uses factor 6 (48 kHz) because its LPTIM3 timer cannot reliably trigger ADC conversions at 64 kHz. Platforms without oversampling support use factor 1, which compiles out the decimation path.

## Results

### Speech SNR Improved >4dB

A simple power-ratio SNR of real-world voice recordings was measured (only considering the times when there was no speaking, following ITU-T P.56 and using WebRTC VAD). **This resulted in a measurable, consistent noise floor drop (consistent across all pairs) of over 4 dB with oversampling enabled.**

This aligns with the theoretical expectation from oversampling. Decimating by a factor of N reduces uncorrelated noise by 10log10(N). For the CS7000-PLUS with oversampling=6: 10log10(6) = 7.8 dB theoretical max. The measured 4.9 dB is in the right ballpark — the gap is expected since not all noise in the system is uncorrelated quantization noise (some is analog, some is RF)

### Raw spoken recordings

Reading some of the [harvard speech quality measurement sentences](https://www.cs.columbia.edu/~hgs/audio/harvard.html) from https://doi.org/10.1109/IEEESTD.1969.7405210. Using radios held about 3 inches away from the mouth. In a household environment with some background noises. Recordings produced using m17-fme and the codec2 to ogg mechanism, placed in webm containers to make github happy.

[catherine-cs7000p-without-oversampling.webm](https://github.com/user-attachments/assets/89070694-0e9f-40a1-b762-ef2a009eeac4)
[catherine-cs7000p-with-oversampling.webm](https://github.com/user-attachments/assets/85a6ede7-002c-4d11-bb98-47826271d290)
[ryan-cs7000p-without-oversampling.webm](https://github.com/user-attachments/assets/abc820ef-8089-4e88-8aad-c659e2d47a26)
[ryan-cs7000p-with-oversampling.webm](https://github.com/user-attachments/assets/472ae178-917a-41f9-bd0b-53e2efb19812)
[catherine-uv390-without-oversampling.webm](https://github.com/user-attachments/assets/e6dfaf2f-ea6b-43f1-b15f-e045d327347a)
[catherine-uv390-with-oversampling.webm](https://github.com/user-attachments/assets/e88531c3-253b-4a46-b92b-629f2522f0c8)
[ryan-uv390-without-oversampling.webm](https://github.com/user-attachments/assets/9175b772-cee4-429e-a5e8-4c86b1e387bc)
[ryan-uv390-with-oversampling.webm](https://github.com/user-attachments/assets/e792f62a-bd26-4de4-ae17-e4e2dba962bf)

Note: ryan's recordings without oversampling appear to be mislabeled, and one is missing (tbd which one)