### PR TITLE
drivers: Fix bug in STM32 GPIO OPEN_DRAIN_PU case

### DIFF
--- a/platform/drivers/GPIO/gpio_stm32.c
+++ b/platform/drivers/GPIO/gpio_stm32.c
@@ -79,7 +79,7 @@ void gpio_setMode(const void *port, const uint8_t pin, const uint16_t mode)
             // (MODE=01 TYPE=1 PUP=01)
             p->MODER  |= 0x01 << (pin*2);
             p->OTYPER |= 0x01 << pin;
-            p->PUPDR  |= 0x00 << (pin*2);
+            p->PUPDR  |= 0x01 << (pin*2);
             break;
 
         case ALTERNATE:


### PR DESCRIPTION
It looks like this might be have been a typo. OPEN_DRAIN and OPEN_DRAIN_PU are identical case statements, but the name and comment both imply that the pull-up should be set but it isn't.

This code path doesn't seem to be used based on a grep for `OPEN_DRAIN_PU`, but presumably it would break something in the future if it was used.