### PR TITLE
RTX packet interface API

### DIFF
--- a/openrtx/include/core/ringbuf.hpp
+++ b/openrtx/include/core/ringbuf.hpp
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
- * 
+ *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
@@ -13,22 +13,178 @@
 
 #include <pthread.h>
 #include <cstdint>
+#include <errno.h>
+
+/**
+ * Class implementing a statically allocated circular buffer with non-blocking
+ * push and pop functions.
+ */
+template <typename T, size_t N>
+class NbRingBuffer
+{
+public:
+    /**
+     * Constructor.
+     */
+    NbRingBuffer() : readPos(0), writePos(0), numElements(0)
+    {
+        pthread_mutex_init(&mutex, NULL);
+    }
+
+    /**
+     * Destructor.
+     */
+    ~NbRingBuffer()
+    {
+        pthread_mutex_destroy(&mutex);
+    }
+
+    /**
+     * Push an element to the buffer.
+     *
+     * @param elem: element to be pushed.
+     * @return zero on success, -EAGAIN if the queue is full and -EBUSY if the
+     * queue is kept by another thread.
+     */
+    int tryPush(const T &elem)
+    {
+        int ret = pthread_mutex_trylock(&mutex);
+        if (ret)
+            return ret;
+
+        if (full()) {
+            pthread_mutex_unlock(&mutex);
+            return -EAGAIN;
+        }
+
+        doPush(elem);
+        pthread_mutex_unlock(&mutex);
+
+        return 0;
+    }
+
+    /**
+     * Pop an element from the buffer.
+     *
+     * @param elem: place where to store the popped element.
+     * @return zero on success, -EAGAIN if the queue is empty and -EBUSY if the
+     * queue is kept by another thread.
+     */
+    int tryPop(T &elem)
+    {
+        int ret = pthread_mutex_trylock(&mutex);
+        if (ret)
+            return ret;
+
+        if (empty()) {
+            pthread_mutex_unlock(&mutex);
+            return -EAGAIN;
+        }
+
+        doPop(elem);
+        pthread_mutex_unlock(&mutex);
+
+        return 0;
+    }
+
+    /**
+     * Check if the buffer is empty.
+     * This function is not thread safe.
+     *
+     * @return true if the buffer is empty.
+     */
+    bool empty() const
+    {
+        return numElements == 0;
+    }
+
+    /**
+     * Check if the buffer is full.
+     * This function is not thread safe.
+     *
+     * @return true if the buffer is full.
+     */
+    bool full() const
+    {
+        return numElements >= N;
+    }
+
+    /**
+     * Get the number of elements currently stored in the buffer.
+     * This function is not thread safe.
+     *
+     * @return the number of elements currently present in the buffer.
+     */
+    size_t size() const
+    {
+        return numElements;
+    }
+
+    /**
+     * Reset the buffer to its empty state discarding all the elements stored,
+     * blocking function.
+
+     * Reset is "lazy", as it just sets read pointer, write pointer and
+     * number of elements to zero. No actual erasure of the stored elements is
+     * done until they are effectively overwritten by new push()es.
+     */
+    void reset()
+    {
+        pthread_mutex_lock(&mutex);
+        readPos = 0;
+        writePos = 0;
+        numElements = 0;
+        pthread_mutex_unlock(&mutex);
+    }
+
+protected:
+    /**
+     * Enqueueing helper function.
+     *
+     * @param elem: element to enqueue.
+     */
+    inline void doPush(const T &elem)
+    {
+        data[writePos++] = elem;
+        if (writePos == N)
+            writePos = 0;
+        numElements += 1;
+    }
+
+    /**
+     * Dequeueing helper function.
+     *
+     * @param elem: element to dequeue.
+     */
+    inline void doPop(T &elem)
+    {
+        elem = data[readPos++];
+        if (readPos == N)
+            readPos = 0;
+        numElements -= 1;
+    }
+
+    size_t readPos;        ///< Read pointer.
+    size_t writePos;       ///< Write pointer.
+    size_t numElements;    ///< Number of elements currently present.
+    T data[N];             ///< Data storage.
+
+    pthread_mutex_t mutex; ///< Mutex for concurrent access.
+};
 
 /**
  * Class implementing a statically allocated circular buffer with blocking and
  * non-blocking push and pop functions.
  */
-template < typename T, size_t N >
-class RingBuffer
+template <typename T, size_t N>
+class RingBuffer : public NbRingBuffer<T, N>
 {
 public:
-
     /**
      * Constructor.
      */
-    RingBuffer() : readPos(0), writePos(0), numElements(0)
+    RingBuffer()
     {
-        pthread_mutex_init(&mutex, NULL);
         pthread_cond_init(&not_empty, NULL);
         pthread_cond_init(&not_full, NULL);
     }
@@ -38,106 +194,50 @@ public:
      */
     ~RingBuffer()
     {
-        pthread_mutex_destroy(&mutex);
         pthread_cond_destroy(&not_empty);
         pthread_cond_destroy(&not_full);
     }
 
     /**
      * Push an element to the buffer.
+     * If the buffer is full the execution flow is blocked until at least one
+     * slot is available.
      *
      * @param elem: element to be pushed.
-     * @param blocking: if set to true, when the buffer is full this function
-     * blocks the execution flow until at least one empty slot is available.
-     * @return true if the element has been successfully pushed to the queue,
-     * false if the queue is empty.
      */
-    bool push(const T& elem, bool blocking)
+    void push(const T &elem)
     {
-        pthread_mutex_lock(&mutex);
+        pthread_mutex_lock(&this->mutex);
 
-        if((numElements >= N) && (blocking == false))
-        {
-            // No space available and non-blocking call: unlock mutex and return
-            pthread_mutex_unlock(&mutex);
-            return false;
-        }
+        while (this->numElements >= N)
+            pthread_cond_wait(&not_full, &this->mutex);
 
-        // The call is blocking: wait until there is some free space
-        while(numElements >= N)
-        {
-            pthread_cond_wait(&not_full, &mutex);
-        }
+        this->doPush(elem);
+        if (this->numElements == 1)
+            pthread_cond_signal(&not_empty);
 
-        // There is free space, push data into the queue
-        data[writePos] = elem;
-        writePos = (writePos + 1) % N;
-
-        // Signal that the queue is not empty
-        if(numElements == 0) pthread_cond_signal(&not_empty);
-        numElements += 1;
-
-        pthread_mutex_unlock(&mutex);
-        return true;
+        pthread_mutex_unlock(&this->mutex);
     }
 
     /**
      * Pop an element from the buffer.
+     * If the buffer is empty the execution flow is blocked until at least one
+     * element is available.
      *
      * @param elem: place where to store the popped element.
-     * @param blocking: if set to true, when the buffer is empty this function
-     * blocks the execution flow until at least one element is available.
-     * @return true if the element has been successfully popped from the queue,
-     * false if the queue is empty.
      */
-    bool pop(T& elem, bool blocking)
+    void pop(T &elem)
     {
-        pthread_mutex_lock(&mutex);
+        pthread_mutex_lock(&this->mutex);
 
-        if((numElements == 0) && (blocking == false))
-        {
-            // No elements present and non-blocking call: unlock mutex and return
-            pthread_mutex_unlock(&mutex);
-            return false;
-        }
+        while (this->numElements == 0)
+            pthread_cond_wait(&not_empty, &this->mutex);
 
-        // The call is blocking: wait until there is something into the queue
-        while(numElements == 0)
-        {
-            pthread_cond_wait(&not_empty, &mutex);
-        }
+        this->doPop(elem);
+        if (this->numElements == (N - 1))
+            pthread_cond_signal(&not_full);
 
-        // At least one element present pop one.
-        elem    = data[readPos];
-        readPos = (readPos + 1) % N;
-
-        // Signal that the queue is no more full
-        if(numElements >= N) pthread_cond_signal(&not_full);
-        numElements -= 1;
-
-        pthread_mutex_unlock(&mutex);
-
-        return true;
-    }
-
-    /**
-     * Check if the buffer is empty.
-     *
-     * @return true if the buffer is empty.
-     */
-    bool empty()
-    {
-        return numElements == 0;
-    }
-
-    /**
-     * Check if the buffer is full.
-     *
-     * @return true if the buffer is full.
-     */
-    bool full()
-    {
-        return numElements >= N;
+        pthread_mutex_unlock(&this->mutex);
     }
 
     /**
@@ -147,44 +247,25 @@ public:
      */
     void eraseElement()
     {
-        // Nothing to erase
-        if(numElements == 0) return;
+        pthread_mutex_lock(&this->mutex);
 
-        pthread_mutex_lock(&mutex);
+        if (this->numElements == 0) {
+            pthread_mutex_unlock(&this->mutex);
+            return;
+        }
 
-        // Chomp away one element just by advancing the read pointer.
-        readPos = (readPos + 1) % N;
+        this->readPos = (this->readPos + 1) % N;
+        this->numElements -= 1;
 
-        if(numElements >= N) pthread_cond_signal(&not_full);
-        numElements -= 1;
+        if (this->numElements == (N - 1))
+            pthread_cond_signal(&not_full);
 
-        pthread_mutex_unlock(&mutex);
-    }
-
-    /**
-     * Reset the buffer to its empty state discarding all the elements stored.
-     *
-     * Note: reset is "lazy", as it just sets read pointer, write pointer and
-     * number of elements to zero. No actual erasure of the stored elements is
-     * done until they are effectively overwritten by new push()es.
-     */
-    void reset()
-    {
-        readPos     = 0;
-        writePos    = 0;
-        numElements = 0;
+        pthread_mutex_unlock(&this->mutex);
     }
 
 private:
-
-    size_t readPos;      ///< Read pointer.
-    size_t writePos;     ///< Write pointer.
-    size_t numElements;  ///< Number of elements currently present.
-    T      data[N];      ///< Data storage.
-
-    pthread_mutex_t mutex;      ///< Mutex for concurrent access.
-    pthread_cond_t  not_empty;  ///< Queue not empty condition.
-    pthread_cond_t  not_full;   ///< Queue not full condition.
+    pthread_cond_t not_empty; ///< Queue not empty condition.
+    pthread_cond_t not_full;  ///< Queue not full condition.
 };
 
-#endif  // RINGBUF_H
+#endif // RINGBUF_H

--- a/openrtx/include/rtx/OpMode.hpp
+++ b/openrtx/include/rtx/OpMode.hpp
@@ -1,12 +1,13 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
- * 
+ *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 #ifndef OPMODE_H
 #define OPMODE_H
 
+#include <errno.h>
 #include "interfaces/delays.h"
 #include "rtx/rtx.h"
 
@@ -90,6 +91,30 @@ public:
     virtual bool rxSquelchOpen()
     {
         return false;
+    }
+
+    /**
+     * Submit a packet reception request.
+     *
+     * @param packet: pointer to packet descriptor.
+     * @return zero on success a negative error code otherwise.
+     */
+    virtual int addPacketRx(struct pktDesc *packet)
+    {
+        (void)packet;
+        return -ENOTSUP;
+    }
+
+    /**
+     * Submit a packet transmission request.
+     *
+     * @param packet: pointer to packet descriptor.
+     * @return zero on success a negative error code otherwise.
+     */
+    virtual int addPacketTx(struct pktDesc *packet)
+    {
+        (void)packet;
+        return -ENOTSUP;
     }
 };
 

--- a/openrtx/include/rtx/rtx.h
+++ b/openrtx/include/rtx/rtx.h
@@ -11,6 +11,7 @@
 #include <stdint.h>
 #include "core/cps.h"
 #include <pthread.h>
+#include <sys/types.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -82,6 +83,26 @@ enum opstatus {
 };
 
 /**
+ * \enum pktStatus Enumeration type describing the status of a data packet.
+ */
+enum pktStatus {
+    PKT_STATUS_IDLE,      /**< No operation in progress */
+    PKT_STATUS_SUBMITTED, /**< Submitted to RX/TX queue */
+    PKT_STATUS_DONE,      /**< RX/TX done */
+    PKT_STATUS_ERROR,     /**< RX/TX error */
+};
+
+/**
+ * Data packet descriptor
+ */
+struct pktDesc {
+    enum pktStatus status;
+    void *buffer;
+    size_t size;
+    ssize_t res;
+};
+
+/**
  * Initialise rtx stage.
  * @param m: pointer to the mutex protecting the shared configuration data
  * structure.
@@ -126,6 +147,22 @@ rssi_t rtx_getRssi();
  * @return true if RX squelch is open.
  */
 bool rtx_rxSquelchOpen();
+
+/**
+ * Submit a packet reception request.
+ *
+ * @param packet: pointer to packet descriptor.
+ * @return zero on success a negative error code otherwise.
+ */
+int rtx_addPacketRx(struct pktDesc *packet);
+
+/**
+ * Submit a packet transmission request.
+ *
+ * @param packet: pointer to packet descriptor.
+ * @return zero on success a negative error code otherwise.
+ */
+int rtx_addPacketTx(struct pktDesc *packet);
 
 #ifdef __cplusplus
 }

--- a/openrtx/src/protocols/M17/Demodulator.cpp
+++ b/openrtx/src/protocols/M17/Demodulator.cpp
@@ -70,7 +70,7 @@ static void *logFunc(void *arg)
             // the dump.
             log_entry_t entry;
             memset(&entry, 0x00, sizeof(log_entry_t));
-            if(logBuf.pop(entry, false) == false) emptyCtr++;
+            if(logBuf.tryPop(entry) == false) emptyCtr++;
 
             if(emptyCtr >= 100)
             {
@@ -126,7 +126,7 @@ static inline void pushLog(const log_entry_t& e)
         trigCnt   = 0;
     }
     if(logBuf.full()) logBuf.eraseElement();
-    logBuf.push(e, false);
+    logBuf.tryPush(e);
 }
 
 #endif

--- a/openrtx/src/rtx/rtx.cpp
+++ b/openrtx/src/rtx/rtx.cpp
@@ -207,3 +207,41 @@ bool rtx_rxSquelchOpen()
 {
     return currMode->rxSquelchOpen();
 }
+
+int rtx_addPacketRx(struct pktDesc *packet)
+{
+    int ret;
+
+    if (packet->status != PKT_STATUS_IDLE)
+        return -EPERM;
+
+    if ((packet->buffer == NULL) || (packet->size == 0))
+        return -EINVAL;
+
+    packet->status = PKT_STATUS_SUBMITTED;
+    packet->res = 0;
+    ret = currMode->addPacketRx(packet);
+    if (ret)
+        packet->status = PKT_STATUS_IDLE;
+
+    return ret;
+}
+
+int rtx_addPacketTx(struct pktDesc *packet)
+{
+    int ret;
+
+    if (packet->status != PKT_STATUS_IDLE)
+        return -EPERM;
+
+    if ((packet->buffer == NULL) || (packet->size == 0))
+        return -EINVAL;
+
+    packet->status = PKT_STATUS_SUBMITTED;
+    packet->res = 0;
+    ret = currMode->addPacketTx(packet);
+    if (ret)
+        packet->status = PKT_STATUS_IDLE;
+
+    return ret;
+}


### PR DESCRIPTION
Common interface between application and operating modes for sending and receiving packet data. The API is asynchronous and meant to allow zero-copy transmission and reception of packets.

## Application side:

Application code sends packet transmission and reception requests by means of packet descriptors. A packet descriptor contains a status variable, a pointer to the packet data and a size field. To submit a request, the application code populates the descriptor, sets its status to `PKT_STATUS_IDLE` and calls `rtx_addPacketRx` or `rtx_addPacketTx`: the rtx layer accepts the request and sets the status to `PKT_STATUS_SUBMITTED`. Once the status is set to `PKT_STATUS_SUBMITTED`, the application code should not change the struct fields. Once submitted, the application code polls the `status` field until it becomes `PKT_STATUS_DONE` or `PKT_STATUS_ERROR`.

The `size` field assumes the following meanings:
| Operation | PKT_STATUS_IDLE | PKT_STATUS_DONE | PKT_STATUS_ERROR |
| --------------- | ------------------------- | ---------------------------- | ----------------------------- |
| TX               |  # bytes to send | (no change) | ERRNO code |
| RX               |  max buffer size | # bytes received | ERRNO code |

TX example:
```
uint8_t msg[42];
struct pktDesc desc {
    .status = PKT_STATUS_IDLE,
    .buffer = msg,
    .size = sizeof(msg);
};

if (rtx_addPacketTx(&desc))
    puts("msg submit error");

[...]
    
if (desc->status == PKT_STATUS_DONE)
    puts("msg send ok");

if (desc->status == PKT_STATUS_ERROR)
    puts("msg send error");
```
The descriptor must live also after the call to `rtx_addPacketRx`/`rtx_addPacketTx`.

## OpMode side

OpMode classes supporting packet data have to implement the `addPacketRx` and `addPacketTx` functions. In doing so, is necessary to take into account that these functions can be called by multiple threads at the same time. A useful primitive is the `NbRingBuffer` class, providing a non-blocking multi-threaded ring buffer implementation.

Code example:
```
NbRingBuffer < struct pktDesc *, 4 > rxPktQueue;
struct pktDesc *currPkt = NULL;

int addPacketRx(struct pktDesc *packet) override
{
    return rxPktQueue.tryPush(packet);
}

[...]

rxPktQueue.tryPop(currPkt);
if (currPkt) {
    // do actual RX
    [...]
    
    // Once done
    currPkt->status = PKT_STATUS_DONE;
    currPkt = NULL;
}
```

OpModes can also keep a queue of a single descriptor:
```
pthread_mutex_t mutex;
struct pktDesc *currPkt = NULL;

int addPacketRx(struct pktDesc *packet) override
{
    int ret = 0;
    
    pthread_mutex_lock(&mutex);
    if (currPkt)
        ret = -EBUSY;
    else
         currPkt = packet;
    pthread_mutex_unlock(&mutex);

    return ret;
}

[...]

if (currPkt) {
    // do actual RX
    [...]
    
    // Once done
    currPkt->status = PKT_STATUS_DONE;
    currPkt = NULL;
}
```