### PR TITLE
Stop having branches/PRs trying to push the devcontainer

### DIFF
--- a/.github/workflows/build-devcontainer.yml
+++ b/.github/workflows/build-devcontainer.yml
@@ -2,6 +2,8 @@ name: "Build devcontainer"
 on:
   workflow_dispatch:
   push:
+    branches:
+      - master
     paths:
       - 'requirements.txt'
       - '.github/workflows/build-devcontainer.yml'
@@ -30,6 +32,7 @@ jobs:
         with:
           submodules: recursive
       - name: Login to GitHub Container Registry
+        if: github.repository == 'OpenRTX/OpenRTX' && github.event_name != 'pull_request'
         uses: docker/login-action@v2 
         with:
           registry: ghcr.io
@@ -40,4 +43,4 @@ jobs:
         with:
             imageName: ${{ env.DEVCONTAINER_NAME }}
             cacheFrom: ${{ env.DEVCONTAINER_NAME }}
-            push: always
+            push: ${{ github.repository == 'OpenRTX/OpenRTX' && github.event_name != 'pull_request' && 'always' || 'never' }}


### PR DESCRIPTION
I ran into a problem yesterday where my PR was triggering trying to push new devcontainer tags. We dont want that -- it's fine if PRs build, but they shouldn't try to push (it'll fail due to permissions). So, add logic to ensure that the push only happens if its on the mainline repo's default branch.