### PR TITLE
(1/2) core: Add 'extern' blocks to core/ files used by the UI

### DIFF
--- a/openrtx/include/core/battery.h
+++ b/openrtx/include/core/battery.h
@@ -1,8 +1,12 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
- * 
+ *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #ifndef BATTERY_H
 #define BATTERY_H
@@ -15,5 +19,9 @@
  * @return state of charge percentage, from 0% to 100%.
  */
 uint8_t battery_getCharge(uint16_t vbat);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif /* BATTERY_H */

--- a/openrtx/include/core/beeps.h
+++ b/openrtx/include/core/beeps.h
@@ -1,11 +1,16 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
- * 
+ *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
 #ifndef BEEPS_H_INCLUDED
 #define BEEPS_H_INCLUDED
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // Duration in tenths of a second.
 #define SHORT_BEEP 3
 #define LONG_BEEP 7
@@ -17,5 +22,9 @@
 #define BEEP_FUNCTION_LATCH_OFF 400
 #define BEEP_KEY_GENERIC 750
 extern const uint16_t BOOT_MELODY[];
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif // BEEPS_H_INCLUDED

--- a/openrtx/include/core/input.h
+++ b/openrtx/include/core/input.h
@@ -11,6 +11,10 @@
 #include <inttypes.h>
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Time interval in milliseconds after which a keypress is considered a long-press
  */
@@ -81,5 +85,9 @@ uint8_t input_getPressedNumber(kbd_msg_t msg);
  * @return the smallest number associated to a char.
  */
 uint8_t input_getPressedChar(kbd_msg_t msg);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif /* INPUT_H */

--- a/openrtx/include/core/input.h
+++ b/openrtx/include/core/input.h
@@ -26,19 +26,15 @@ static const uint16_t input_longPressTimeout = 700;
  * For a keyboard event we use 1 bit to signal a short or long press
  * And the remaining 29 bits to communicate currently pressed keys.
  */
-typedef union
-{
-    struct
-    {
-        uint32_t long_press : 1,
-                 keys       : 29,
-                 _padding   : 2;
+typedef union {
+    struct {
+        uint32_t long_press : 1;
+        uint32_t keys       : 29;
+        uint32_t _padding   : 2;
     };
 
     uint32_t value;
-}
-kbd_msg_t;
-
+} kbd_msg_t;
 
 /**
  * Scan all the keyboard buttons to detect possible keypresses filling a

--- a/openrtx/include/core/state.h
+++ b/openrtx/include/core/state.h
@@ -14,6 +14,10 @@
 #include "core/cps.h"
 #include "core/gps.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Part of this structure has been commented because the corresponding
  * functionality is not yet implemented.
@@ -102,5 +106,9 @@ void state_task();
  * Reset the fields of radio state containing user settings and VFO channel.
  */
 void state_resetSettingsAndVfo();
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif /* STATE_H */

--- a/openrtx/include/core/state.h
+++ b/openrtx/include/core/state.h
@@ -23,63 +23,58 @@ extern "C" {
  * functionality is not yet implemented.
  * Uncomment once the related feature is ready
  */
-typedef struct
-{
-    uint8_t    devStatus;
+typedef struct {
+    uint8_t devStatus;
     datetime_t time;
-    uint16_t   v_bat;
-    uint8_t    charge;
-    rssi_t     rssi;
-    uint8_t    volume;
+    uint16_t v_bat;
+    uint8_t charge;
+    rssi_t rssi;
+    uint8_t volume;
 
-    uint8_t    ui_screen;
-    uint8_t    tuner_mode;
+    uint8_t ui_screen;
+    uint8_t tuner_mode;
 
-    uint16_t   channel_index;
-    channel_t  channel;
-    channel_t  vfo_channel;
-    bool       bank_enabled;
-    uint16_t   bank;
-    uint8_t    rtxStatus;
-    bool       tone_enabled;
+    uint16_t channel_index;
+    channel_t channel;
+    channel_t vfo_channel;
+    bool bank_enabled;
+    uint16_t bank;
+    uint8_t rtxStatus;
+    bool tone_enabled;
 
-    bool       emergency;
+    bool emergency;
     settings_t settings;
-    gps_t      gps_data;
-    bool       gps_set_time;
-    bool       gpsDetected;
-    bool       backup_eflash;
-    bool       restore_eflash;
-    bool       txDisable;
-    uint8_t    step_index;
-}
-state_t;
+    gps_t gps_data;
+    bool gps_set_time;
+    bool gpsDetected;
+    bool backup_eflash;
+    bool restore_eflash;
+    bool txDisable;
+    uint8_t step_index;
+} state_t;
 
 extern const uint32_t freq_steps[];
 extern const size_t n_freq_steps;
 
-enum TunerMode
-{
+enum TunerMode {
     VFO = 0,
     CH,
     SCAN,
-    CHSCAN
+    CHSCAN,
 };
 
-enum RtxStatus
-{
+enum RtxStatus {
     RTX_OFF = 0,
     RTX_RX,
-    RTX_TX
+    RTX_TX,
 };
 
-enum DeviceStatus
-{
+enum DeviceStatus {
     PWROFF = 0,
     STARTUP,
     RUNNING,
     DATATRANSFER,
-    SHUTDOWN
+    SHUTDOWN,
 };
 
 extern state_t state;

--- a/openrtx/include/core/ui.h
+++ b/openrtx/include/core/ui.h
@@ -10,6 +10,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * This function initialises the User Interface, starting the
  * Finite State Machine describing the user interaction.
@@ -57,5 +61,9 @@ bool ui_pushEvent(const uint8_t type, const uint32_t data);
  * This function terminates the User Interface.
  */
 void ui_terminate();
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* UI_H */

--- a/openrtx/include/core/voicePromptUtils.h
+++ b/openrtx/include/core/voicePromptUtils.h
@@ -11,6 +11,10 @@
 #include "ui/ui_strings.h"
 #include "core/voicePrompts.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
 Please Note!
 
@@ -224,5 +228,9 @@ void vp_announceSplashScreen();
  * @param flags: control flags.
  */
 void vp_announceTimeZone(const int8_t timeZone, const vpQueueFlags_t flags);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif  // VOICE_PROMPT_UTILS_H

--- a/openrtx/include/core/voicePromptUtils.h
+++ b/openrtx/include/core/voicePromptUtils.h
@@ -28,11 +28,10 @@ should be used to ensure that the message interupts the current prompt and
 plays immediately.
 */
 
-
 /**
  * Note: channelNumber is 1-based, index is 0-based.
  */
-void vp_announceChannelName(const channel_t* channel,
+void vp_announceChannelName(const channel_t *channel,
                             const uint16_t channelNumber,
                             const vpQueueFlags_t flags);
 
@@ -60,8 +59,9 @@ void vp_announceBandwidth(const uint8_t bandwidth, const vpQueueFlags_t flags);
 /**
  * channelNumber is 1-based, channelIndex is 0-based.
  */
-void vp_announceChannelSummary(const channel_t* channel,
-                               const uint16_t channelNumber, const uint16_t bank,
+void vp_announceChannelSummary(const channel_t *channel,
+                               const uint16_t channelNumber,
+                               const uint16_t bank,
                                const vpSummaryInfoFlags_t infoFlags);
 
 /**
@@ -72,7 +72,8 @@ void vp_announceInputChar(const char ch);
 /**
  *
  */
-void vp_announceInputReceiveOrTransmit(const bool tx, const vpQueueFlags_t flags);
+void vp_announceInputReceiveOrTransmit(const bool tx,
+                                       const vpQueueFlags_t flags);
 
 /**
  *
@@ -93,7 +94,7 @@ character by character.
 /**
  *
  */
-void vp_announceText(const char* text, const vpQueueFlags_t flags);
+void vp_announceText(const char *text, const vpQueueFlags_t flags);
 
 /**
  *
@@ -110,17 +111,18 @@ void vp_announcePower(const uint32_t power, const vpQueueFlags_t flags);
 /**
  *
  */
-void vp_announceSquelch(const uint8_t squelch,const vpQueueFlags_t flags);
+void vp_announceSquelch(const uint8_t squelch, const vpQueueFlags_t flags);
 
 /**
  *
  */
-void vp_announceContact(const contact_t* contact, const vpQueueFlags_t flags);
+void vp_announceContact(const contact_t *contact, const vpQueueFlags_t flags);
 
 /**
  *
  */
-bool vp_announceContactWithIndex(const uint16_t index, const vpQueueFlags_t flags);
+bool vp_announceContactWithIndex(const uint16_t index,
+                                 const vpQueueFlags_t flags);
 
 /**
  *
@@ -141,7 +143,7 @@ void vp_announceBank(const uint16_t bank, const vpQueueFlags_t flags);
 /**
  *
  */
-void vp_announceM17Info(const channel_t* channel, bool isEditing,
+void vp_announceM17Info(const channel_t *channel, bool isEditing,
                         const vpQueueFlags_t flags);
 
 /**
@@ -181,13 +183,13 @@ void vp_announceSettingsVoiceLevel(const vpQueueFlags_t flags);
 /**
  * This is called to speak generic settings on/off toggles.
  */
-void vp_announceSettingsOnOffToggle(const char* const* stringTableStringPtr,
+void vp_announceSettingsOnOffToggle(const char *const *stringTableStringPtr,
                                     const vpQueueFlags_t flags, bool val);
 
 /**
  * This is called to speak generic settings int values.
  */
-void vp_announceSettingsInt(const char* const* stringTableStringPtr,
+void vp_announceSettingsInt(const char *const *stringTableStringPtr,
                             const vpQueueFlags_t flags, int val);
 
 /**
@@ -198,8 +200,8 @@ void vp_announceScreen(uint8_t ui_screen);
 /**
  * This function is called from  ui_updateFSM to speak string buffers.
  */
-void vp_announceBuffer(const char* const* stringTableStringPtr, bool editMode,
-                       bool callsign, const char* buffer);
+void vp_announceBuffer(const char *const *stringTableStringPtr, bool editMode,
+                       bool callsign, const char *buffer);
 
 /**
  * This function is called from  ui_updateFSM to speak display timer changes.
@@ -233,4 +235,4 @@ void vp_announceTimeZone(const int8_t timeZone, const vpQueueFlags_t flags);
 } // extern "C"
 #endif
 
-#endif  // VOICE_PROMPT_UTILS_H
+#endif // VOICE_PROMPT_UTILS_H

--- a/openrtx/include/core/voicePrompts.h
+++ b/openrtx/include/core/voicePrompts.h
@@ -10,6 +10,10 @@
 #include "core/datatypes.h"
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * List of voice prompts for spoken words or phrases which are not in the UI
  * string table. The voice prompt data file stores these first, then after the
@@ -327,5 +331,9 @@ void vp_beep(uint16_t freq, uint16_t duration);
  * Array is freq, duration, ... 0, 0 to terminate series.
  */
 void vp_beepSeries(const uint16_t* beepSeries);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
 
 #endif

--- a/openrtx/include/core/voicePrompts.h
+++ b/openrtx/include/core/voicePrompts.h
@@ -22,232 +22,220 @@ extern "C" {
  * WARNING: this enum must match the order of prompts defined in the
  * wordlist.csv file in the voicePrompts generator project.
  */
-typedef enum
-{
-    PROMPT_SILENCE,     //
-    PROMPT_0,           // 0
-    PROMPT_1,           // 1
-    PROMPT_2,           // 2
-    PROMPT_3,           // 3
-    PROMPT_4,           // 4
-    PROMPT_5,           // 5
-    PROMPT_6,           // 6
-    PROMPT_7,           // 7
-    PROMPT_8,           // 8
-    PROMPT_9,           // 9
-    PROMPT_A,           // A
-    PROMPT_B,           // B
-    PROMPT_C,           // C
-    PROMPT_D,           // D
-    PROMPT_E,           // E
-    PROMPT_F,           // F
-    PROMPT_G,           // G
-    PROMPT_H,           // H
-    PROMPT_I,           // I
-    PROMPT_J,           // J
-    PROMPT_K,           // K
-    PROMPT_L,           // L
-    PROMPT_M,           // M
-    PROMPT_N,           // N
-    PROMPT_O,           // O
-    PROMPT_P,           // P
-    PROMPT_Q,           // Q
-    PROMPT_R,           // R
-    PROMPT_S,           // S
-    PROMPT_T,           // T
-    PROMPT_U,           // U
-    PROMPT_V,           // V
-    PROMPT_W,           // W
-    PROMPT_X,           // X
-    PROMPT_Y,           // Y
-    PROMPT_Z,           // Zed
-    PROMPT_A_PHONETIC,  // alpha
-    PROMPT_B_PHONETIC,  // bravo
-    PROMPT_C_PHONETIC,  // charlie
-    PROMPT_D_PHONETIC,  // delta
-    PROMPT_E_PHONETIC,  // echo
-    PROMPT_F_PHONETIC,  // foxtrot
-    PROMPT_G_PHONETIC,  // golf
-    PROMPT_H_PHONETIC,  // hotel
-    PROMPT_I_PHONETIC,  // india
-    PROMPT_J_PHONETIC,  // juliet
-    PROMPT_K_PHONETIC,  // kilo
-    PROMPT_L_PHONETIC,  // lema
-    PROMPT_M_PHONETIC,  // mike
-    PROMPT_N_PHONETIC,  // november
-    PROMPT_O_PHONETIC,  // oscar
-    PROMPT_P_PHONETIC,  // papa
-    PROMPT_Q_PHONETIC,  // quebec
-    PROMPT_R_PHONETIC,  // romeo
-    PROMPT_S_PHONETIC,  // siera
-    PROMPT_T_PHONETIC,  // tango
-    PROMPT_U_PHONETIC,  // uniform
-    PROMPT_V_PHONETIC,  // victor
-    PROMPT_W_PHONETIC,  // whisky
-    PROMPT_X_PHONETIC,  // exray
-    PROMPT_Y_PHONETIC,  // yankie
-    PROMPT_Z_PHONETIC,  // zulu
-    PROMPT_CAP,         // cap
-    PROMPT_HERTZ,       // hertz
-    PROMPT_KILOHERTZ,   // Kilohertz
-    PROMPT_MEGAHERTZ,   // Megahertz
+typedef enum {
+    PROMPT_SILENCE,        //
+    PROMPT_0,              // 0
+    PROMPT_1,              // 1
+    PROMPT_2,              // 2
+    PROMPT_3,              // 3
+    PROMPT_4,              // 4
+    PROMPT_5,              // 5
+    PROMPT_6,              // 6
+    PROMPT_7,              // 7
+    PROMPT_8,              // 8
+    PROMPT_9,              // 9
+    PROMPT_A,              // A
+    PROMPT_B,              // B
+    PROMPT_C,              // C
+    PROMPT_D,              // D
+    PROMPT_E,              // E
+    PROMPT_F,              // F
+    PROMPT_G,              // G
+    PROMPT_H,              // H
+    PROMPT_I,              // I
+    PROMPT_J,              // J
+    PROMPT_K,              // K
+    PROMPT_L,              // L
+    PROMPT_M,              // M
+    PROMPT_N,              // N
+    PROMPT_O,              // O
+    PROMPT_P,              // P
+    PROMPT_Q,              // Q
+    PROMPT_R,              // R
+    PROMPT_S,              // S
+    PROMPT_T,              // T
+    PROMPT_U,              // U
+    PROMPT_V,              // V
+    PROMPT_W,              // W
+    PROMPT_X,              // X
+    PROMPT_Y,              // Y
+    PROMPT_Z,              // Zed
+    PROMPT_A_PHONETIC,     // alpha
+    PROMPT_B_PHONETIC,     // bravo
+    PROMPT_C_PHONETIC,     // charlie
+    PROMPT_D_PHONETIC,     // delta
+    PROMPT_E_PHONETIC,     // echo
+    PROMPT_F_PHONETIC,     // foxtrot
+    PROMPT_G_PHONETIC,     // golf
+    PROMPT_H_PHONETIC,     // hotel
+    PROMPT_I_PHONETIC,     // india
+    PROMPT_J_PHONETIC,     // juliet
+    PROMPT_K_PHONETIC,     // kilo
+    PROMPT_L_PHONETIC,     // lema
+    PROMPT_M_PHONETIC,     // mike
+    PROMPT_N_PHONETIC,     // november
+    PROMPT_O_PHONETIC,     // oscar
+    PROMPT_P_PHONETIC,     // papa
+    PROMPT_Q_PHONETIC,     // quebec
+    PROMPT_R_PHONETIC,     // romeo
+    PROMPT_S_PHONETIC,     // siera
+    PROMPT_T_PHONETIC,     // tango
+    PROMPT_U_PHONETIC,     // uniform
+    PROMPT_V_PHONETIC,     // victor
+    PROMPT_W_PHONETIC,     // whisky
+    PROMPT_X_PHONETIC,     // exray
+    PROMPT_Y_PHONETIC,     // yankie
+    PROMPT_Z_PHONETIC,     // zulu
+    PROMPT_CAP,            // cap
+    PROMPT_HERTZ,          // hertz
+    PROMPT_KILOHERTZ,      // Kilohertz
+    PROMPT_MEGAHERTZ,      // Megahertz
     PROMPT_CHANNEL,
-    PROMPT_VFO,             // V F O
-    PROMPT_MILLISECONDS,    // Milliseconds
-    PROMPT_SECONDS,         // Seconds
-    PROMPT_MINUTES,         // Minutes
-    PROMPT_VOLTS,           // Volts
-    PROMPT_MILLIWATTS,      // Milliwatts
-    PROMPT_WATT,            // Wattt
-    PROMPT_WATTS,           // Watts
-    PROMPT_RECEIVE,         // Receive
-    PROMPT_TRANSMIT,        // Transmit
-    PROMPT_MODE,            // Mode
-    PROMPT_BANDWIDTH,       // bandwidth
-    PROMPT_POWER,           // power
-    PROMPT_SQUELCH,         // squelch
-    PROMPT_SOURCE_ID,       // Source ID
-    PROMPT_DEST_ID,         // Destination ID
-    PROMPT_DMR_ID,          // DMR ID
-    PROMPT_TALKGROUP,       // Talk group
-    PROMPT_TIMESLOT,        // timeslot
-    PROMPT_COLORCODE,       // color code
-    PROMPT_TONE,            // tone
-    PROMPT_CONTACT,         // contact
-    PROMPT_NORTH,           // north
-    PROMPT_SOUTH,           // south
-    PROMPT_EAST,            // east
-    PROMPT_WEST,            // west
-    PROMPT_LATITUDE,        // latitude
-    PROMPT_LONGITUDE,       // longitude
-    PROMPT_SPEED,           // speed
-    PROMPT_ALTITUDE,        // altitude
-    PROMPT_SATELLITES,      // satellites
-    PROMPT_COMPASS,         // compass
-    PROMPT_DEGREES,         // degrees
-    PROMPT_VP_UNAVAILABLE,  // Voice prompts will be unavailable during this
-                            // operation.
-    PROMPT_CHARACTER,       // character
-    PROMPT_SPACE,           // space
-    PROMPT_PERCENT,         // Percent
-    PROMPT_POINT,           // POINT
-    PROMPT_PLUS,            // Plus
-    PROMPT_MINUS,           // Minus
-    PROMPT_STAR,            // Star
-    PROMPT_HASH,            // Hash
-    PROMPT_EXCLAIM,         // exclaim
-    PROMPT_COMMA,           // comma
-    PROMPT_AT,              // at
-    PROMPT_COLON,           // colon
-    PROMPT_QUESTION,        // question
-    PROMPT_LEFT_PAREN,      // left paren
-    PROMPT_RIGHT_PAREN,     // right paren
-    PROMPT_TILDE,           // tilde
-    PROMPT_SLASH,           // slash
-    PROMPT_LEFT_BRACKET,    // left bracket
-    PROMPT_RIGHT_BRACKET,   // right bracket
-    PROMPT_LESS,            // less
-    PROMPT_GREATER,         // greater
-    PROMPT_EQUALS,          // equals
-    PROMPT_DOLLAR,          // dollar
-    PROMPT_APOSTROPHE,      // apostrophe
-    PROMPT_GRAVE,           // grave
-    PROMPT_AMPERSAND,       // and
-    PROMPT_BAR,             // bar
-    PROMPT_UNDERLINE,       // underline
-    PROMPT_CARET,           // caret
-    PROMPT_LEFT_BRACE,      // left brace
-    PROMPT_RIGHT_BRACE,     // right brace
-    PROMPT_EDIT,            // edit
-    PROMPT_CUSTOM1,         // Hotspot
-    PROMPT_CUSTOM2,         // ClearNode
-    PROMPT_CUSTOM3,         // ShariNode
-    PROMPT_CUSTOM4,         // MicroHub
-    PROMPT_CUSTOM5,         // Openspot
-    PROMPT_CUSTOM6,         // repeater
-    PROMPT_CUSTOM7,         // BlindHams
-    PROMPT_CUSTOM8,         // Allstar
-    PROMPT_CUSTOM9,         // parrot
-    PROMPT_CUSTOM10,        // unused
+    PROMPT_VFO,            // V F O
+    PROMPT_MILLISECONDS,   // Milliseconds
+    PROMPT_SECONDS,        // Seconds
+    PROMPT_MINUTES,        // Minutes
+    PROMPT_VOLTS,          // Volts
+    PROMPT_MILLIWATTS,     // Milliwatts
+    PROMPT_WATT,           // Wattt
+    PROMPT_WATTS,          // Watts
+    PROMPT_RECEIVE,        // Receive
+    PROMPT_TRANSMIT,       // Transmit
+    PROMPT_MODE,           // Mode
+    PROMPT_BANDWIDTH,      // bandwidth
+    PROMPT_POWER,          // power
+    PROMPT_SQUELCH,        // squelch
+    PROMPT_SOURCE_ID,      // Source ID
+    PROMPT_DEST_ID,        // Destination ID
+    PROMPT_DMR_ID,         // DMR ID
+    PROMPT_TALKGROUP,      // Talk group
+    PROMPT_TIMESLOT,       // timeslot
+    PROMPT_COLORCODE,      // color code
+    PROMPT_TONE,           // tone
+    PROMPT_CONTACT,        // contact
+    PROMPT_NORTH,          // north
+    PROMPT_SOUTH,          // south
+    PROMPT_EAST,           // east
+    PROMPT_WEST,           // west
+    PROMPT_LATITUDE,       // latitude
+    PROMPT_LONGITUDE,      // longitude
+    PROMPT_SPEED,          // speed
+    PROMPT_ALTITUDE,       // altitude
+    PROMPT_SATELLITES,     // satellites
+    PROMPT_COMPASS,        // compass
+    PROMPT_DEGREES,        // degrees
+    PROMPT_VP_UNAVAILABLE, // Voice prompts will be unavailable during this
+                           // operation.
+    PROMPT_CHARACTER,      // character
+    PROMPT_SPACE,          // space
+    PROMPT_PERCENT,        // Percent
+    PROMPT_POINT,          // POINT
+    PROMPT_PLUS,           // Plus
+    PROMPT_MINUS,          // Minus
+    PROMPT_STAR,           // Star
+    PROMPT_HASH,           // Hash
+    PROMPT_EXCLAIM,        // exclaim
+    PROMPT_COMMA,          // comma
+    PROMPT_AT,             // at
+    PROMPT_COLON,          // colon
+    PROMPT_QUESTION,       // question
+    PROMPT_LEFT_PAREN,     // left paren
+    PROMPT_RIGHT_PAREN,    // right paren
+    PROMPT_TILDE,          // tilde
+    PROMPT_SLASH,          // slash
+    PROMPT_LEFT_BRACKET,   // left bracket
+    PROMPT_RIGHT_BRACKET,  // right bracket
+    PROMPT_LESS,           // less
+    PROMPT_GREATER,        // greater
+    PROMPT_EQUALS,         // equals
+    PROMPT_DOLLAR,         // dollar
+    PROMPT_APOSTROPHE,     // apostrophe
+    PROMPT_GRAVE,          // grave
+    PROMPT_AMPERSAND,      // and
+    PROMPT_BAR,            // bar
+    PROMPT_UNDERLINE,      // underline
+    PROMPT_CARET,          // caret
+    PROMPT_LEFT_BRACE,     // left brace
+    PROMPT_RIGHT_BRACE,    // right brace
+    PROMPT_EDIT,           // edit
+    PROMPT_CUSTOM1,        // Hotspot
+    PROMPT_CUSTOM2,        // ClearNode
+    PROMPT_CUSTOM3,        // ShariNode
+    PROMPT_CUSTOM4,        // MicroHub
+    PROMPT_CUSTOM5,        // Openspot
+    PROMPT_CUSTOM6,        // repeater
+    PROMPT_CUSTOM7,        // BlindHams
+    PROMPT_CUSTOM8,        // Allstar
+    PROMPT_CUSTOM9,        // parrot
+    PROMPT_CUSTOM10,       // unused
     NUM_VOICE_PROMPTS,
-}
-voicePrompt_t;
+} voicePrompt_t;
 
 // The name of the voice prompt file is always encoded as the last prompt.
-#define PROMPT_VOICE_NAME (NUM_VOICE_PROMPTS + (sizeof(stringsTable_t)/sizeof(char*)))
+#define PROMPT_VOICE_NAME \
+    (NUM_VOICE_PROMPTS + (sizeof(stringsTable_t) / sizeof(char *)))
 
 /**
  * Flags controlling how vp_queueString operates.
  */
-typedef enum
-{
-    vpDefault                           = 0x00,
-    vpAnnounceCaps                      = 0x01,
-    vpAnnounceCustomPrompts             = 0x02,
-    vpAnnounceSpace                     = 0x04,
-    vpAnnounceCommonSymbols             = 0x08,
-    vpAnnounceLessCommonSymbols         = 0x10,
+typedef enum {
+    vpDefault = 0x00,
+    vpAnnounceCaps = 0x01,
+    vpAnnounceCustomPrompts = 0x02,
+    vpAnnounceSpace = 0x04,
+    vpAnnounceCommonSymbols = 0x08,
+    vpAnnounceLessCommonSymbols = 0x10,
     vpAnnounceASCIIValueForUnknownChars = 0x20,
-    vpAnnouncePhoneticRendering         = 0x40,
-}
-vpFlags_t;
+    vpAnnouncePhoneticRendering = 0x40,
+} vpFlags_t;
 
 /**
  * Queuing flags determining if speech is interrupted, played immediately,
  * whether prompts are queued for values, etc.
  */
-typedef enum
-{
-    vpqDefault                         = 0,
-    vpqInit                            = 0x01,  // stop any voice prompts already in progress.
-    vpqPlayImmediately                 = 0x02,  // call play after queue at all levels.
+typedef enum {
+    vpqDefault = 0,
+    vpqInit = 0x01,            // stop any voice prompts already in progress.
+    vpqPlayImmediately = 0x02, // call play after queue at all levels.
     vpqPlayImmediatelyAtMediumOrHigher = 0x04,
-    vpqIncludeDescriptions             = 0x08,
-    vpqAddSeparatingSilence            = 0x10
-}
-vpQueueFlags_t;
+    vpqIncludeDescriptions = 0x08,
+    vpqAddSeparatingSilence = 0x10
+} vpQueueFlags_t;
 
 /**
  * Voice prompt verbosity levels.
  */
-typedef enum
-{
+typedef enum {
     vpNone = 0,
     vpBeep,
     vpLow,
     vpMedium,
-    vpHigh
-}
-vpVerbosity_t;
+    vpHigh,
+} vpVerbosity_t;
 
-typedef enum
-{
-    vpChannelNameOrVFO      = 0x01,
-    vpFrequencies           = 0x02,
-    vpRadioMode             = 0x04,
-    vpModeSpecificInfo      = 0x08,
-    vpPower                 = 0x10,
+typedef enum {
+    vpChannelNameOrVFO = 0x01,
+    vpFrequencies = 0x02,
+    vpRadioMode = 0x04,
+    vpModeSpecificInfo = 0x08,
+    vpPower = 0x10,
     vpBankNameOrAllChannels = 0x20,
-    vpAllInfo               = 0xff
-}
-vpSummaryInfoFlags_t;
+    vpAllInfo = 0xff
+} vpSummaryInfoFlags_t;
 
-typedef enum
-{
-    vpGPSNone       = 0,
-    vpGPSIntro      = 0x01,
+typedef enum {
+    vpGPSNone = 0,
+    vpGPSIntro = 0x01,
     vpGPSFixQuality = 0x02,
-    vpGPSFixType    = 0x04,
-    vpGPSLatitude   = 0x08,
-    vpGPSLongitude  = 0x10,
-    vpGPSSpeed      = 0x20,
-    vpGPSAltitude   = 0x40,
-    vpGPSDirection  = 0x80,
-    vpGPSSatCount   = 0x100,
-    vpGPSAll        = 0x1ff,
-}
-vpGPSInfoFlags_t;
-
+    vpGPSFixType = 0x04,
+    vpGPSLatitude = 0x08,
+    vpGPSLongitude = 0x10,
+    vpGPSSpeed = 0x20,
+    vpGPSAltitude = 0x40,
+    vpGPSDirection = 0x80,
+    vpGPSSatCount = 0x100,
+    vpGPSAll = 0x1ff,
+} vpGPSInfoFlags_t;
 
 /**
  * Initialise the voice prompt system and load vp table of contents.
@@ -283,7 +271,7 @@ void vp_queuePrompt(const uint16_t prompt);
  * @param string: string to be spelled.
  * @param flags: control flags.
  */
-void vp_queueString(const char* string, vpFlags_t flags);
+void vp_queueString(const char *string, vpFlags_t flags);
 
 /**
  * Append a signed integer to the queue.
@@ -295,7 +283,7 @@ void vp_queueInteger(const int value);
 /**
  * Append a text string from the current language to the queue.
  */
-void vp_queueStringTableEntry(const char* const* stringTableStringPtr);
+void vp_queueStringTableEntry(const char *const *stringTableStringPtr);
 
 /**
  * Start prompt playback.
@@ -330,7 +318,7 @@ void vp_beep(uint16_t freq, uint16_t duration);
  * Play a series of beeps at a given frequency for a given duration.
  * Array is freq, duration, ... 0, 0 to terminate series.
  */
-void vp_beepSeries(const uint16_t* beepSeries);
+void vp_beepSeries(const uint16_t *beepSeries);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/scripts/clang_format.sh
+++ b/scripts/clang_format.sh
@@ -44,12 +44,16 @@ openrtx/include/core/crc.h
 openrtx/include/core/dsp.h
 openrtx/include/core/data_conversion.h
 openrtx/include/core/datatypes.h
+openrtx/include/core/input.h
 openrtx/include/core/memory_profiling.h
 openrtx/include/core/nvmem_access.h
 openrtx/include/core/nvmem_device.h
 openrtx/include/core/openrtx.h
+openrtx/include/core/state.h
 openrtx/include/core/ui.h
 openrtx/include/core/utils.h
+openrtx/include/core/voicePrompts.h
+openrtx/include/core/voicePromptUtils.h
 openrtx/include/core/xmodem.h
 openrtx/include/fonts/symbols/symbols.h
 openrtx/include/interfaces/cps_io.h


### PR DESCRIPTION
This PR adds the following blocks at the top and bottom of C headers in `core/` used by the UI respectively:

```diff
+#ifdef __cplusplus
+extern "C" {
+#endif
```

```diff
+#ifdef __cplusplus
+} // extern "C"
+#endif
```

Additionally, modified files are added to the `clang-format` script and formatting is applied. 

This PR is the 1st of multiple proposed in a larger refactor, and is a requisite for refactoring the UI in C++.