### PR TITLE
Enable reading of hardware info and calibration data for MD9600

### DIFF
--- a/platform/drivers/NVM/nvmem_MDx.c
+++ b/platform/drivers/NVM/nvmem_MDx.c
@@ -140,12 +140,18 @@ void nvm_readHwInfo(hwInfo_t *info)
     uint16_t freqMin = 0;
     uint16_t freqMax = 0;
     uint8_t  lcdInfo = 0;
+    #ifdef PLATFORM_MD9600
+    uint8_t  hwVersionMajor = 0;
+    #endif
 
     // Security register 3: base address 0x3000
     nvm_devRead(&secReg, 0x3000, info->name, 8);
     nvm_devRead(&secReg, 0x3014, &freqMin, 2);
     nvm_devRead(&secReg, 0x3016, &freqMax, 2);
     nvm_devRead(&secReg, 0x301D, &lcdInfo, 1);
+    #ifdef PLATFORM_MD9600
+    nvm_devRead(&secReg, 0x3035, &hwVersionMajor, 1);
+    #endif
 
     // Ensure correct null-termination of device name by removing the 0xff.
     for(uint8_t i = 0; i < sizeof(info->name); i++)
@@ -157,7 +163,11 @@ void nvm_readHwInfo(hwInfo_t *info)
     freqMin = ((uint16_t) bcdToBin(freqMin))/10;
     freqMax = ((uint16_t) bcdToBin(freqMax))/10;
 
+    #ifdef PLATFORM_MD9600
+    info->hw_version = hwVersionMajor;
+    #else
     info->hw_version = lcdInfo & 0x03;
+    #endif
 
     #ifdef PLATFORM_MD3x0
     // Single band device, either VHF or UHF

--- a/platform/drivers/NVM/nvmem_MDx.c
+++ b/platform/drivers/NVM/nvmem_MDx.c
@@ -139,18 +139,15 @@ void nvm_readHwInfo(hwInfo_t *info)
 {
     uint16_t freqMin = 0;
     uint16_t freqMax = 0;
-    uint8_t  lcdInfo = 0;
-    #ifdef PLATFORM_MD9600
-    uint8_t  hwVersionMajor = 0;
-    #endif
 
     // Security register 3: base address 0x3000
     nvm_devRead(&secReg, 0x3000, info->name, 8);
     nvm_devRead(&secReg, 0x3014, &freqMin, 2);
     nvm_devRead(&secReg, 0x3016, &freqMax, 2);
-    nvm_devRead(&secReg, 0x301D, &lcdInfo, 1);
     #ifdef PLATFORM_MD9600
-    nvm_devRead(&secReg, 0x3035, &hwVersionMajor, 1);
+    nvm_devRead(&secReg, 0x3035, &info->hw_version, 1);
+    #else
+    nvm_devRead(&secReg, 0x301D, &info->hw_version, 1);
     #endif
 
     // Ensure correct null-termination of device name by removing the 0xff.
@@ -162,12 +159,6 @@ void nvm_readHwInfo(hwInfo_t *info)
 
     freqMin = ((uint16_t) bcdToBin(freqMin))/10;
     freqMax = ((uint16_t) bcdToBin(freqMax))/10;
-
-    #ifdef PLATFORM_MD9600
-    info->hw_version = hwVersionMajor;
-    #else
-    info->hw_version = lcdInfo & 0x03;
-    #endif
 
     #ifdef PLATFORM_MD3x0
     // Single band device, either VHF or UHF

--- a/platform/drivers/display/HX8353_MD3x.cpp
+++ b/platform/drivers/display/HX8353_MD3x.cpp
@@ -203,7 +203,7 @@ void display_init()
      * Since we do not have the datasheet for the controller employed in this
      * screen, we can only do copy-and-paste...
      */
-    uint8_t lcd_type = platform_getHwInfo()->hw_version;
+    uint8_t lcd_type = platform_getHwInfo()->hw_version & 0x03;
 
     if((lcd_type == 2) || (lcd_type == 3))
     {

--- a/platform/targets/MD-9600/platform.c
+++ b/platform/targets/MD-9600/platform.c
@@ -21,18 +21,7 @@
 #include "drivers/chSelector/chSelector.h"
 #include "core/gps.h"
 
-/* TODO: Hardcoded hwInfo until we implement reading from flash */
-static const hwInfo_t hwInfo =
-{
-    .vhf_maxFreq = 174,
-    .vhf_minFreq = 136,
-    .vhf_band    = 1,
-    .uhf_maxFreq = 480,
-    .uhf_minFreq = 400,
-    .uhf_band    = 1,
-    .hw_version  = 0,
-    .name        = "MD-9600"
-};
+static hwInfo_t hwInfo;
 
 void platform_init()
 {
@@ -61,7 +50,10 @@ void platform_init()
     gpio_setMode(SPI2_SDI, ALTERNATE | ALTERNATE_FUNC(5));
     spiStm32_init(&spi2, 1300000, 0);
 
+    memset(&hwInfo, 0x00, sizeof(hwInfo));
+
     nvm_init();                      /* Initialise non volatile memory manager */
+    nvm_readHwInfo(&hwInfo);         /* Load hardware information data         */
     toneGen_init();                  /* Initialise tone generator              */
     rtc_init();                      /* Initialise RTC                         */
     backlight_init();                /* Initialize Backlight                   */


### PR DESCRIPTION
This merge request enables reading the hardware info and calibration data from flash for the MD9600.

The hardware version is handled different from other MDx targets.
Here we read the major hardware version from flash.
We can then later use this in order to correctly initialize and use the RF part.

As far as I can tell the calibration data is the same as for the MD-UV3x0