### PR TITLE
Fix #444: Wraparound in offset 

### DIFF
--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -1238,14 +1238,18 @@ static void _ui_numberInputKeypad(uint32_t *num, kbd_msg_t msg)
     // Update reference values
     ui_state.input_number = *num % 10;
 #else
-    // Maximum frequency len is uint32_t max value number of decimal digits
-    if(ui_state.input_position >= 10)
-        return;
-
     // Get currently pressed number key
     uint8_t num_key = input_getPressedNumber(msg);
-    *num *= 10;
-    *num += num_key;
+
+    uint32_t tmp = 0;
+
+    // Add a another digit onto the offset only if
+    // it won't cause an overflow
+    if (__builtin_mul_overflow(*num, 10, &tmp) ||
+        __builtin_add_overflow(tmp, num_key, &tmp))
+        return;
+
+    *num = tmp;
 
     // Announce the character
     vp_announceInputChar('0' + num_key);

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -1230,7 +1230,11 @@ static void _ui_numberInputKeypad(uint32_t *num, kbd_msg_t msg)
 
     // If enter is pressed, advance to the next digit
     if (msg.keys & KEY_ENTER)
-        *num *= 10;
+    {
+        uint32_t tmp = 0;
+        if (!__builtin_mul_overflow(*num, 10, &tmp))
+            *num = tmp;
+    }
 
     // Announce the character
     vp_announceInputChar('0' + *num % 10);


### PR DESCRIPTION
This PR fixes issue #444. The offset bug can occur in two separate cases, with the default UI as well as the UI variant when `CONFIG_UI_NO_KEYBOARD` is set.

To prevent a wraparound, the `__builtlin_mul_overflow` and `__builtin_add_overflow` macros from the compiler are used. These are supported in GCC and Clang so should not pose any portability issues for any of our targets.

To-Do: Validate if the fix in the `CONFIG_UI_NO_KEYBOARD` case works