### PR TITLE
NVM: Updated EEEP + emulated flash memory

### DIFF
--- a/platform/drivers/NVM/eeep.c
+++ b/platform/drivers/NVM/eeep.c
@@ -5,51 +5,48 @@
  */
 
 #include "core/nvmem_access.h"
-#include "core/nvmem_device.h"
+#include "interfaces/nvmem.h"
 #include <stdint.h>
 #include <limits.h>
 #include <errno.h>
 #include "eeep.h"
 
 // NOTE: cannot use an enum for these because enum type is "int"
-#define EEEP_PAGE_ERASED      (0xFFFFFFFF)
-#define EEEP_PAGE_VERIFIED    (0x00FFFFFF)
-#define EEEP_PAGE_COPYING     (0x0000FFFF)
-#define EEEP_PAGE_ACTIVE      (0x000000FF)
-#define EEEP_PAGE_INACTIVE    (0x00000000)
-#define EEEP_PAGE_HDR_SIZE    sizeof(uint32_t)
+#define EEEP_PAGE_ERASED (0xFFFFFFFF)
+#define EEEP_PAGE_VERIFIED (0x00FFFFFF)
+#define EEEP_PAGE_COPYING (0x0000FFFF)
+#define EEEP_PAGE_ACTIVE (0x000000FF)
+#define EEEP_PAGE_INACTIVE (0x00000000)
+#define EEEP_PAGE_HDR_SIZE sizeof(uint32_t)
 
-enum RecordStatus
-{
-    EEEP_RECORD_EMPTY   = 0xFF,
+enum RecordStatus {
+    EEEP_RECORD_EMPTY = 0xFF,
     EEEP_RECORD_INVALID = 0x55,
-    EEEP_RECORD_VALID   = 0x05,
-    EEEP_RECORD_ERASED  = 0x00
+    EEEP_RECORD_VALID = 0x05,
+    EEEP_RECORD_ERASED = 0x00
 };
 
-struct eeepRecord
-{
-    uint8_t  status;
-    uint8_t  size;
+struct eeepRecord {
+    uint8_t status;
+    uint8_t size;
     uint16_t virtAddr;
 };
 
-struct eeepEntry
-{
+struct eeepEntry {
     uint32_t physAddr;
     uint16_t virtAddr;
 };
 
-static uint32_t nextRecordAddress(const uint32_t addr, const struct eeepRecord *rec)
+static uint32_t nextRecordAddress(const uint32_t addr,
+                                  const struct eeepRecord *rec)
 {
     uint32_t nextAddr = addr;
-    switch(rec->status)
-    {
+    switch (rec->status) {
         case EEEP_RECORD_EMPTY:
             break;
 
         case EEEP_RECORD_INVALID:
-            if(rec->size != 0xFF)
+            if (rec->size != 0xFF)
                 nextAddr += rec->size;
             break;
 
@@ -63,58 +60,58 @@ static uint32_t nextRecordAddress(const uint32_t addr, const struct eeepRecord *
     return nextAddr + sizeof(struct eeepRecord);
 }
 
-static int findRecord(struct eeepData *priv, uint32_t *memAddr, const uint16_t virtAddr)
+static int findRecord(struct eeepData *priv, uint32_t *memAddr,
+                      const uint16_t virtAddr)
 {
     struct eeepRecord rec;
     uint32_t addr = priv->readAddr;
     *memAddr = 0xFFFFFFFF;
 
-    while(addr < priv->writeAddr)
-    {
-        int ret = nvm_devRead(priv->nvm, addr, &rec, sizeof(struct eeepRecord));
-        if(ret < 0)
+    while (addr < priv->writeAddr) {
+        int ret = nvm_read(priv->nvm, priv->part, addr, &rec,
+                           sizeof(struct eeepRecord));
+        if (ret < 0)
             return ret;
 
-        if((rec.status == EEEP_RECORD_VALID) && (rec.virtAddr == virtAddr))
+        if ((rec.status == EEEP_RECORD_VALID) && (rec.virtAddr == virtAddr))
             *memAddr = addr;
 
         addr = nextRecordAddress(addr, &rec);
     }
 
-    if(*memAddr != 0xFFFFFFFF)
+    if (*memAddr != 0xFFFFFFFF)
         return 0;
 
     return -1;
 }
 
-static int writeRecord(struct eeepData *priv, uint16_t virtAddr, const void *data,
-                       size_t len)
+static int writeRecord(struct eeepData *priv, uint16_t virtAddr,
+                       const void *data, size_t len)
 {
     uint32_t dataAddr = priv->writeAddr + sizeof(struct eeepRecord);
     uint32_t headAddr = priv->writeAddr;
-    struct eeepRecord rec =
-    {
-        .status   = EEEP_RECORD_INVALID,
-        .size     = len,
-        .virtAddr = virtAddr
-    };
+    struct eeepRecord rec = { .status = EEEP_RECORD_INVALID,
+                              .size = len,
+                              .virtAddr = virtAddr };
 
     // Write record header
-    int ret = nvm_devWrite(priv->nvm, headAddr, &rec, sizeof(struct eeepRecord));
-    if(ret < 0)
+    int ret = nvm_write(priv->nvm, priv->part, headAddr, &rec,
+                        sizeof(struct eeepRecord));
+    if (ret < 0)
         return ret;
 
     // Write data. If the operation fails, it is assumed anyways that the entire
     // data block has been written. This to be sure that following writes do not
     // end up in a partially-written space.
     priv->writeAddr += sizeof(struct eeepRecord) + len;
-    ret = nvm_devWrite(priv->nvm, dataAddr, data, len);
-    if(ret < 0)
+    ret = nvm_write(priv->nvm, priv->part, dataAddr, data, len);
+    if (ret < 0)
         return ret;
 
     // Finally, update the record header changing the state to "valid".
     rec.status = EEEP_RECORD_VALID;
-    ret = nvm_devWrite(priv->nvm, headAddr, &rec, sizeof(struct eeepRecord));
+    ret = nvm_write(priv->nvm, priv->part, headAddr, &rec,
+                    sizeof(struct eeepRecord));
 
     return ret;
 }
@@ -125,45 +122,43 @@ static int swapBlock(struct eeepData *priv)
     // Note: when computing the next block address we have to take into account
     // that readAddr points at the first record after the page header.
     uint32_t currBlock = priv->readAddr - EEEP_PAGE_HDR_SIZE;
-    uint32_t nextBlock = currBlock + priv->nvm->info->erase_size;
-    if(nextBlock >= (priv->part->offset + priv->part->size))
-        nextBlock = priv->part->offset;
+    uint32_t nextBlock = currBlock + priv->pageSize;
+    struct nvmPartition pInfo;
+    nvm_getPart(priv->nvm, priv->part, &pInfo);
+    if (nextBlock >= pInfo.size)
+        nextBlock = 0;
 
     // Erase new page
-    int ret = nvm_devErase(priv->nvm, nextBlock, priv->nvm->info->erase_size);
-    if(ret < 0)
+    int ret = nvm_erase(priv->nvm, priv->part, nextBlock, priv->pageSize);
+    if (ret < 0)
         return ret;
 
     // Search for all the active entries
     // TODO: use dynamic memory allocation
-    struct eeepEntry entryList[8] = {0};
+    struct eeepEntry entryList[8] = { 0 };
     uint32_t address = priv->readAddr;
     uint8_t numEntries = 0;
 
-    while(address < priv->writeAddr)
-    {
+    while (address < priv->writeAddr) {
         struct eeepRecord rec;
 
-        ret = nvm_devRead(priv->nvm, address, &rec, sizeof(struct eeepRecord));
-        if(ret < 0)
+        ret = nvm_read(priv->nvm, priv->part, address, &rec,
+                       sizeof(struct eeepRecord));
+        if (ret < 0)
             return ret;
 
-        if(rec.status == EEEP_RECORD_VALID)
-        {
+        if (rec.status == EEEP_RECORD_VALID) {
             uint8_t pos;
-            for(pos = 0; pos < numEntries; pos++)
-            {
+            for (pos = 0; pos < numEntries; pos++) {
                 // Found record in list, update its physical address
-                if(entryList[pos].virtAddr == rec.virtAddr)
-                {
+                if (entryList[pos].virtAddr == rec.virtAddr) {
                     entryList[pos].physAddr = address;
                     break;
                 }
             }
 
             // Record not found, append it to the list
-            if(pos == numEntries)
-            {
+            if (pos == numEntries) {
                 entryList[pos].virtAddr = rec.virtAddr;
                 entryList[pos].physAddr = address;
                 numEntries += 1;
@@ -175,42 +170,42 @@ static int swapBlock(struct eeepData *priv)
 
     // Set new write address, mark the page as a page with an ogoing copy
     priv->writeAddr = nextBlock + sizeof(uint32_t);
-    uint32_t tmp    = EEEP_PAGE_COPYING;
-    ret = nvm_devWrite(priv->nvm, nextBlock, &tmp, sizeof(uint32_t));
-    if(ret < 0)
+    uint32_t tmp = EEEP_PAGE_COPYING;
+    ret = nvm_write(priv->nvm, priv->part, nextBlock, &tmp, sizeof(uint32_t));
+    if (ret < 0)
         return ret;
 
     // Copy over the records to the new page,
-    for(uint8_t i = 0; i < numEntries; i++)
-    {
+    for (uint8_t i = 0; i < numEntries; i++) {
         struct eeepRecord rec;
         uint8_t data[256];
         uint32_t address = entryList[i].physAddr;
 
-        ret = nvm_devRead(priv->nvm, address, &rec, sizeof(struct eeepRecord));
-        if(ret < 0)
+        ret = nvm_read(priv->nvm, priv->part, address, &rec,
+                       sizeof(struct eeepRecord));
+        if (ret < 0)
             return ret;
 
         address += sizeof(struct eeepRecord);
-        ret = nvm_devRead(priv->nvm, address, data, rec.size);
-        if(ret < 0)
+        ret = nvm_read(priv->nvm, priv->part, address, data, rec.size);
+        if (ret < 0)
             return ret;
 
         ret = writeRecord(priv, rec.virtAddr, data, rec.size);
-        if(ret < 0)
+        if (ret < 0)
             return ret;
     }
 
     // Finally, set the page as the new active page, invalidate the previous one
     // and update the reading address
     tmp = EEEP_PAGE_ACTIVE;
-    ret = nvm_devWrite(priv->nvm, nextBlock, &tmp, sizeof(uint32_t));
-    if(ret < 0)
+    ret = nvm_write(priv->nvm, priv->part, nextBlock, &tmp, sizeof(uint32_t));
+    if (ret < 0)
         return ret;
 
     tmp = EEEP_PAGE_INACTIVE;
-    ret = nvm_devWrite(priv->nvm, currBlock, &tmp, sizeof(uint32_t));
-    if(ret < 0)
+    ret = nvm_write(priv->nvm, priv->part, currBlock, &tmp, sizeof(uint32_t));
+    if (ret < 0)
         return ret;
 
     priv->readAddr = nextBlock + EEEP_PAGE_HDR_SIZE;
@@ -221,28 +216,29 @@ static int swapBlock(struct eeepData *priv)
 static int eeep_read(const struct nvmDevice *dev, uint32_t offset, void *data,
                      size_t len)
 {
-    struct eeepData *priv = (struct eeepData *) dev->priv;
+    struct eeepData *priv = (struct eeepData *)dev->priv;
     struct eeepRecord rec;
     uint32_t memAddr;
 
-    if((offset >= 0xFFFF) || (len >= 255))
+    if ((offset >= 0xFFFF) || (len >= 255))
         return -EINVAL;
 
     int ret = findRecord(priv, &memAddr, offset);
-    if(ret < 0)
+    if (ret < 0)
         return ret;
 
     // Found, read infoblock
-    ret = nvm_devRead(priv->nvm, memAddr, &rec, sizeof(struct eeepRecord));
-    if(ret < 0)
+    ret = nvm_read(priv->nvm, priv->part, memAddr, &rec,
+                   sizeof(struct eeepRecord));
+    if (ret < 0)
         return ret;
 
     // Adjust size and read data
-    if(rec.size < len)
+    if (rec.size < len)
         len = rec.size;
 
     memAddr += sizeof(struct eeepRecord);
-    ret = nvm_devRead(priv->nvm, memAddr, data, rec.size);
+    ret = nvm_read(priv->nvm, priv->part, memAddr, data, rec.size);
 
     return ret;
 }
@@ -250,20 +246,20 @@ static int eeep_read(const struct nvmDevice *dev, uint32_t offset, void *data,
 static int eeep_write(const struct nvmDevice *dev, uint32_t offset,
                       const void *data, size_t len)
 {
-    struct eeepData *priv = (struct eeepData *) dev->priv;
+    struct eeepData *priv = (struct eeepData *)dev->priv;
     int ret;
 
-    if((offset >= 0xFFFF) || (len >= 255))
+    if ((offset >= 0xFFFF) || (len >= 255))
         return -EINVAL;
 
-    uint32_t usedSpace = (priv->writeAddr - priv->readAddr) + EEEP_PAGE_HDR_SIZE;
-    uint32_t freeSpace = priv->nvm->info->erase_size - usedSpace;
+    uint32_t usedSpace = (priv->writeAddr - priv->readAddr)
+                       + EEEP_PAGE_HDR_SIZE;
+    uint32_t freeSpace = priv->pageSize - usedSpace;
     uint32_t entrySize = sizeof(struct eeepRecord) + len;
 
-    if(entrySize > freeSpace)
-    {
+    if (entrySize > freeSpace) {
         ret = swapBlock(priv);
-        if(ret < 0)
+        if (ret < 0)
             return ret;
     }
 
@@ -274,61 +270,54 @@ int eeep_init(const struct nvmDevice *dev, const uint32_t nvm,
               const uint32_t part)
 {
     const struct nvmDescriptor *desc = nvm_getDesc(nvm);
-    if(desc == NULL)
+    if (desc == NULL)
         return -EINVAL;
 
-    if(part >= desc->nbPart)
-        return -EINVAL;
+    struct nvmPartition pInfo;
+    nvm_getPart(nvm, part, &pInfo);
 
-    uint32_t partAddr = desc->partitions[part].offset;
-    uint32_t partSize = desc->partitions[part].size;
-    uint32_t pageSize = desc->dev->info->erase_size;
+    uint32_t partSize = pInfo.size;
 
-    struct eeepData *priv = (struct eeepData *) dev->priv;
-    priv->nvm = desc->dev;
-    priv->part = &desc->partitions[part];
+    struct eeepData *priv = (struct eeepData *)dev->priv;
+    priv->nvm = nvm;
+    priv->part = part;
     priv->readAddr = 0xFFFFFFFF;
+    priv->pageSize = desc->dev->info->erase_size;
 
     // Search for an active page, set the read address to the first record
     // immediately after the page header
-    for(uint32_t i = 0; i < partSize; i += pageSize)
-    {
-        uint32_t pageAddr = partAddr + i;
+    for (uint32_t i = 0; i < partSize; i += priv->pageSize) {
         uint32_t tmp;
 
-        nvm_devRead(priv->nvm, pageAddr, &tmp, sizeof(uint32_t));
-        if(tmp == EEEP_PAGE_ACTIVE)
-        {
-            priv->readAddr = pageAddr + EEEP_PAGE_HDR_SIZE;
+        nvm_read(priv->nvm, priv->part, i, &tmp, sizeof(uint32_t));
+        //nvm_devRead(priv->nvm, pageAddr, &tmp, sizeof(uint32_t));
+        if (tmp == EEEP_PAGE_ACTIVE) {
+            priv->readAddr = i + EEEP_PAGE_HDR_SIZE;
             break;
         }
     }
 
     // If no active page found, erase all the memory and set the first page as
     // active page.
-    if(priv->readAddr == 0xFFFFFFFF)
-    {
+    if (priv->readAddr == 0xFFFFFFFF) {
         uint32_t tmp = EEEP_PAGE_ACTIVE;
-
-        nvm_devErase(priv->nvm, partAddr, partSize);
-        nvm_devWrite(priv->nvm, partAddr, &tmp, sizeof(uint32_t));
-        priv->readAddr = partAddr + EEEP_PAGE_HDR_SIZE;
+        nvm_erase(priv->nvm, priv->part, 0, partSize);
+        nvm_write(priv->nvm, priv->part, 0, &tmp, sizeof(uint32_t));
+        priv->readAddr = EEEP_PAGE_HDR_SIZE;
         priv->writeAddr = priv->readAddr;
-    }
-    else
-    {
+    } else {
         uint32_t addr = priv->readAddr;
-        uint32_t end = priv->readAddr + pageSize - EEEP_PAGE_HDR_SIZE;
+        uint32_t end = priv->readAddr + priv->pageSize - EEEP_PAGE_HDR_SIZE;
         priv->writeAddr = end;
 
-        while(addr < end)
-        {
+        // Walk across page until empty memory is found
+        while (addr < end) {
             struct eeepRecord rec;
-            uint32_t *tmp = (uint32_t *) &rec;
+            uint32_t *tmp = (uint32_t *)&rec;
 
-            nvm_devRead(desc->dev, addr, &rec, sizeof(struct eeepRecord));
-            if(*tmp == 0xFFFFFFFF)
-            {
+            nvm_read(priv->nvm, priv->part, addr, &rec,
+                     sizeof(struct eeepRecord));
+            if (*tmp == 0xFFFFFFFF) {
                 priv->writeAddr = addr;
                 break;
             }
@@ -340,25 +329,19 @@ int eeep_init(const struct nvmDevice *dev, const uint32_t nvm,
     return 0;
 }
 
-int eeep_terminate(const struct nvmDevice* dev)
+int eeep_terminate(const struct nvmDevice *dev)
 {
-    (void) dev;
+    (void)dev;
 
     return 0;
 }
 
-const struct nvmOps eeep_ops =
-{
-    .read   = eeep_read,
-    .write  = eeep_write,
-    .erase  = NULL,
-    .sync   = NULL
-};
+const struct nvmOps eeep_ops = { .read = eeep_read,
+                                 .write = eeep_write,
+                                 .erase = NULL,
+                                 .sync = NULL };
 
-const struct nvmInfo eeep_info =
-{
-    .write_size   = 1,
-    .erase_size   = 1,
-    .erase_cycles = INT_MAX,
-    .device_info  = NVM_EEEPROM | NVM_WRITE
-};
+const struct nvmInfo eeep_info = { .write_size = 1,
+                                   .erase_size = 1,
+                                   .erase_cycles = INT_MAX,
+                                   .device_info = NVM_EEEPROM | NVM_WRITE };

--- a/platform/drivers/NVM/eeep.c
+++ b/platform/drivers/NVM/eeep.c
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <limits.h>
 #include <errno.h>
+#include <stdlib.h>
 #include "eeep.h"
 
 // NOTE: cannot use an enum for these because enum type is "int"
@@ -134,8 +135,9 @@ static int swapBlock(struct eeepData *priv)
         return ret;
 
     // Search for all the active entries
-    // TODO: use dynamic memory allocation
-    struct eeepEntry entryList[8] = { 0 };
+    size_t entryListSize = 8;
+    struct eeepEntry *entryList =
+        (struct eeepEntry *)malloc(entryListSize * sizeof(struct eeepEntry));
     uint32_t address = priv->readAddr;
     uint8_t numEntries = 0;
 
@@ -159,6 +161,16 @@ static int swapBlock(struct eeepData *priv)
 
             // Record not found, append it to the list
             if (pos == numEntries) {
+                if (pos == entryListSize) {
+                    entryListSize *= 2;
+                    void *tmp = reallocarray(entryList, entryListSize,
+                                             sizeof(struct eeepEntry));
+                    if (tmp == NULL) {
+                        free(entryList);
+                        return -ENOMEM;
+                    }
+                    entryList = (struct eeepEntry *)tmp;
+                }
                 entryList[pos].virtAddr = rec.virtAddr;
                 entryList[pos].physAddr = address;
                 numEntries += 1;
@@ -172,8 +184,10 @@ static int swapBlock(struct eeepData *priv)
     priv->writeAddr = nextBlock + sizeof(uint32_t);
     uint32_t tmp = EEEP_PAGE_COPYING;
     ret = nvm_write(priv->nvm, priv->part, nextBlock, &tmp, sizeof(uint32_t));
-    if (ret < 0)
+    if (ret < 0) {
+        free(entryList);
         return ret;
+    }
 
     // Copy over the records to the new page,
     for (uint8_t i = 0; i < numEntries; i++) {
@@ -183,18 +197,25 @@ static int swapBlock(struct eeepData *priv)
 
         ret = nvm_read(priv->nvm, priv->part, address, &rec,
                        sizeof(struct eeepRecord));
-        if (ret < 0)
+        if (ret < 0) {
+            free(entryList);
             return ret;
+        }
 
         address += sizeof(struct eeepRecord);
         ret = nvm_read(priv->nvm, priv->part, address, data, rec.size);
-        if (ret < 0)
+        if (ret < 0) {
+            free(entryList);
             return ret;
+        }
 
         ret = writeRecord(priv, rec.virtAddr, data, rec.size);
-        if (ret < 0)
+        if (ret < 0) {
+            free(entryList);
             return ret;
+        }
     }
+    free(entryList);
 
     // Finally, set the page as the new active page, invalidate the previous one
     // and update the reading address

--- a/platform/drivers/NVM/eeep.h
+++ b/platform/drivers/NVM/eeep.h
@@ -1,6 +1,6 @@
 /*
  * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
- * 
+ *
  * SPDX-License-Identifier: GPL-3.0-or-later
  */
 
@@ -17,18 +17,18 @@
 /**
  * Device driver and information block for EEEPROM memory.
  */
-extern const struct nvmOps  eeep_ops;
+extern const struct nvmOps eeep_ops;
 extern const struct nvmInfo eeep_info;
 
 /**
  * Driver private data.
  */
-struct eeepData
-{
-    const struct nvmDevice    *nvm;         ///< Underlying NVM device
-    const struct nvmPartition *part;        ///< Memory partition used for EEPROM emulation
-    uint32_t                  readAddr;     ///< Physical start address for EEEPROM reads
-    uint32_t                  writeAddr;    ///< Physical start address for EEEPROM writes
+struct eeepData {
+    size_t pageSize;    ///< Underlying NVM page size
+    uint32_t nvm;       ///< Underlying NVM device
+    uint32_t part;      ///< Memory partition used for EEPROM emulation
+    uint32_t readAddr;  ///< Physical start address for EEEPROM reads
+    uint32_t writeAddr; ///< Physical start address for EEEPROM writes
 };
 
 /**
@@ -38,14 +38,13 @@ struct eeepData
  * @param path: full path of the file used for data storage.
  * @param size: size of the storage file, in bytes.
  */
-#define EEEP_DEVICE_DEFINE(name)        \
-static struct eeepData eeepData_##name; \
-struct nvmDevice name =                 \
-{                                       \
-    .priv = &eeepData_##name,           \
-    .ops  = &eeep_ops,                  \
-    .info = &eeep_info,                 \
-};
+#define EEEP_DEVICE_DEFINE(name)            \
+    static struct eeepData eeepData_##name; \
+    struct nvmDevice name = {               \
+        .priv = &eeepData_##name,           \
+        .ops = &eeep_ops,                   \
+        .info = &eeep_info,                 \
+    };
 
 /**
  * Initialize an EEEP driver instance.

--- a/platform/drivers/NVM/emulated_flash.c
+++ b/platform/drivers/NVM/emulated_flash.c
@@ -1,0 +1,133 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "interfaces/nvmem.h"
+#include <limits.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <stdio.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <stdlib.h>
+#include "emulated_flash.h"
+
+int emulatedFlash_init(struct nvmEmulatedFlashDevice *dev, const char *fileName,
+                       const size_t size)
+{
+    // struct nvmFileDevice *pDev = (struct nvmFileDevice *)(dev);
+
+    // Test if file exists, if it doesn't create it.
+    int flags = O_RDWR;
+    int ret = access(fileName, F_OK);
+    if (ret != 0)
+        flags |= O_CREAT | O_EXCL;
+
+    // Open file
+    int fd = open(fileName, flags, S_IRUSR | S_IWUSR);
+    if (fd < 0)
+        return fd;
+
+    // Truncate to size, pad with zeroes if extending.
+    ftruncate(fd, size);
+
+    dev->fd = fd;
+
+    return 0;
+}
+
+int emulatedFlash_terminate(struct nvmEmulatedFlashDevice *dev)
+{
+    if (dev->fd < 0)
+        return -EBADF;
+
+    fsync(dev->fd);
+    close(dev->fd);
+
+    dev->fd = -1;
+
+    return 0;
+}
+
+static int nvm_api_read(const struct nvmDevice *dev, uint32_t offset,
+                        void *data, size_t len)
+{
+    struct nvmEmulatedFlashDevice *pDev =
+        (struct nvmEmulatedFlashDevice *)(dev);
+
+    if (pDev->fd < 0)
+        return -EBADF;
+
+    lseek(pDev->fd, offset, SEEK_SET);
+    return read(pDev->fd, data, len);
+}
+
+static int nvm_api_write(const struct nvmDevice *dev, uint32_t offset,
+                         const void *data, size_t len)
+{
+    struct nvmEmulatedFlashDevice *pDev =
+        (struct nvmEmulatedFlashDevice *)(dev);
+
+    if (pDev->fd < 0)
+        return -EBADF;
+
+    lseek(pDev->fd, offset, SEEK_SET);
+    const uint8_t *input = (const uint8_t *)data;
+    uint8_t *tmp = (uint8_t *)malloc(len);
+    if (tmp == NULL)
+        return -ENOMEM;
+
+    int ret = read(pDev->fd, tmp, len);
+    if (ret != len) {
+        free(tmp);
+        return -EIO;
+    }
+
+    for (size_t i = 0; i < len; i++)
+        tmp[i] &= input[i];
+
+    lseek(pDev->fd, offset, SEEK_SET);
+    ret = write(pDev->fd, tmp, len);
+    free(tmp);
+    return ret;
+}
+
+static int nvm_api_erase(const struct nvmDevice *dev, uint32_t address,
+                         size_t len)
+{
+    struct nvmEmulatedFlashDevice *pDev =
+        (struct nvmEmulatedFlashDevice *)(dev);
+
+    if (pDev->fd < 0)
+        return -EBADF;
+
+    lseek(pDev->fd, address, SEEK_SET);
+
+    int ret = 0;
+    const uint64_t ff = 0xFFFFFFFFFFFFFFFF;
+    size_t to_write = len;
+    while (to_write > 0) {
+        size_t n = (to_write > 8) ? 8 : to_write;
+        ret = write(pDev->fd, &ff, n);
+        to_write -= ret;
+        if (ret < 0)
+            return ret;
+    }
+    return len;
+}
+
+const struct nvmOps emulated_flash_ops = {
+    .read = nvm_api_read,
+    .write = nvm_api_write,
+    .erase = nvm_api_erase,
+    .sync = NULL,
+};
+
+const struct nvmInfo emulated_flash_info = { .write_size = 1,
+                                             .erase_size = 4096,
+                                             .erase_cycles = INT_MAX,
+                                             .device_info = NVM_FILE | NVM_WRITE
+                                                          | NVM_ERASE };

--- a/platform/drivers/NVM/emulated_flash.h
+++ b/platform/drivers/NVM/emulated_flash.h
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef _EMULATED_FLASH_H_
+#define _EMULATED_FLASH_H_
+
+#include "interfaces/nvmem.h"
+
+/**
+ * Device driver for file-based emulated flash storage. The driver
+ * implementation is based on the POSIX syscalls for file management.
+ */
+
+/**
+ * Driver configuration data structure.
+ */
+struct nvmEmulatedFlashDevice {
+    const void *priv;           ///< Device driver private data
+    const struct nvmOps *ops;   ///< Device operations
+    const struct nvmInfo *info; ///< Device info
+    int fd;                     ///< File descriptor
+};
+
+/**
+ * Driver API functions and info.
+ */
+extern const struct nvmOps emulated_flash_ops;
+extern const struct nvmInfo emulated_flash_info;
+
+/**
+ * Instantiate a POSIX file storage NVM device.
+ *
+ * @param name: device name.
+ * @param path: full path of the file used for data storage.
+ * @param dim: size of the storage file, in bytes.
+ */
+#define EMULATED_FLASH_DEVICE_DEFINE(name)                                 \
+    static struct nvmEmulatedFlashDevice name = {                          \
+        .ops = &emulated_flash_ops, .info = &emulated_flash_info, .fd = -1 \
+    };
+
+/**
+ * Initialize an emulated flash driver instance.
+ * This function allows also to override the path of the file used for data
+ * storage, where necessary.
+ *
+ * @param dev: pointer to device descriptor.
+ * @param fileName: full path of the file used for data storage.
+ * @param size: file size.
+ * @return zero on success, a negative error code otherwise.
+ */
+int emulatedFlash_init(struct nvmEmulatedFlashDevice *dev, const char *fileName,
+                       const size_t size);
+
+/**
+ * Shut down an emulated flash driver instance.
+ *
+ * @param dev: pointer to device descriptor.
+ * @param maxSize: maximum size for the storage file, in bytes.
+ * @return zero on success, a negative error code otherwise.
+ */
+int emulatedFlash_terminate(struct nvmEmulatedFlashDevice *dev);
+
+#endif /* _EMULATED_FLASH_H_ */


### PR DESCRIPTION
This PR updates the EEEP implementation to the new NVM API. This makes it so that it now supports partition ID 0 to access the underlying NVM device directly without partition.

During this work I also needed a way to emulate flash memory on linux so I created an emulated flash implementation. I put it in this PR so that it does not get lost. No platform uses that implementation.

Except for any unforeseen mistake, this PR is ready to merge.