### PR TITLE
drivers: fix Linux platform unable to read baseband audio file sources

### DIFF
--- a/platform/drivers/audio/file_source.c
+++ b/platform/drivers/audio/file_source.c
@@ -41,6 +41,7 @@ static int fileSource_data(struct streamCtx *ctx, stream_sample_t **buf)
 
     FILE *fp = (FILE *)ctx->priv;
     stream_sample_t *dest = ctx->buffer;
+    *buf = dest;
     size_t size = ctx->bufSize;
     size_t i = 0;
 


### PR DESCRIPTION
fileSource_data() assigned dest from ctx->buffer but never wrote the pointer back to the caller's *buf, leaving the consumer with the original (uninitialized or stale) pointer it passed in. On the Linux platform this meant baseband audio streamed from file sources was silently dropped, breaking loopback and file-based baseband tests.

Set *buf = dest immediately after dest is initialized so the caller always receives the valid buffer pointer.