### PR TITLE
rtx: split txDisable into hard channel gate and PTT gate

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1151,3 +1151,8 @@ test('minmea conversion Test', minmea_conversion_test)
 test('UI Check Standby Test', ui_check_standby_test)
 test('M17 Packet Frame Test', m17_packet_test)
 test('DSP Oversampling Test', dsp_oversampling_test)
+
+rtx_tx_disable_test = executable('rtx_tx_disable_test',
+                                  sources : unit_test_src + ['tests/unit/rtx_tx_disable.cpp'],
+                                  kwargs  : unit_test_opts)
+test('RTX TX Disable Test', rtx_tx_disable_test)

--- a/openrtx/include/core/state.h
+++ b/openrtx/include/core/state.h
@@ -49,7 +49,7 @@ typedef struct {
     bool gpsDetected;
     bool backup_eflash;
     bool restore_eflash;
-    bool txDisable;
+    bool pttDisable;
     uint8_t step_index;
 } state_t;
 

--- a/openrtx/include/rtx/rtx.h
+++ b/openrtx/include/rtx/rtx.h
@@ -20,11 +20,12 @@ extern "C" {
 typedef struct {
     uint8_t opMode;         /**< Operating mode (FM, DMR, ...) */
 
-    uint8_t bandwidth : 2;  /**< Channel bandwidth             */
-    uint8_t txDisable : 1;  /**< Disable TX operation          */
-    uint8_t scan      : 1;  /**< Scan enabled                  */
-    uint8_t opStatus  : 2;  /**< Operating status (OFF, ...)   */
-    uint8_t           : 2;  /**< Padding to 8 bits             */
+    uint8_t bandwidth  : 2; /**< Channel bandwidth              */
+    uint8_t txDisable  : 1; /**< Hard channel TX lockout        */
+    uint8_t pttDisable : 1; /**< PTT/voice TX gate              */
+    uint8_t scan       : 1; /**< Scan enabled                   */
+    uint8_t opStatus   : 2; /**< Operating status (OFF, ...)    */
+    uint8_t            : 1; /**< Padding to 8 bits              */
 
     freq_t rxFrequency;     /**< RX frequency, in Hz           */
     freq_t txFrequency;     /**< TX frequency, in Hz           */

--- a/openrtx/src/core/state.c
+++ b/openrtx/src/core/state.c
@@ -62,7 +62,7 @@ void state_init()
     state.bank_enabled = false;
     state.rtxStatus = RTX_OFF;
     state.emergency = false;
-    state.txDisable = false;
+    state.pttDisable = false;
     state.step_index = 4; // Default frequency step 12.5kHz
 
     // Force brightness field to be in range 0 - 100

--- a/openrtx/src/core/threads.c
+++ b/openrtx/src/core/threads.c
@@ -81,8 +81,10 @@ void *ui_threadFunc(void *arg)
             rtx_cfg.txTone      = ctcss_tone[state.channel.fm.txTone];
             rtx_cfg.toneEn      = state.tone_enabled;
 
-            // Enable Tx if channel allows it and we are in UI main screen
-            rtx_cfg.txDisable = state.channel.rx_only || state.txDisable;
+            // Hard channel TX lockout: rx-only channels block all transmission.
+            // PTT gate: additionally blocked when the UI is outside VFO/MEM screens.
+            rtx_cfg.txDisable  = state.channel.rx_only;
+            rtx_cfg.pttDisable = state.channel.rx_only || state.pttDisable;
 
             // Copy new M17 CAN, source and destination addresses
             rtx_cfg.can = state.settings.m17_can;

--- a/openrtx/src/rtx/OpMode_FM.cpp
+++ b/openrtx/src/rtx/OpMode_FM.cpp
@@ -116,7 +116,7 @@ void OpMode_FM::update(rtxStatus_t *const status, const bool newCfg)
 
     // TX logic
     if(platform_getPttStatus() && (status->opStatus != TX) &&
-                                  (status->txDisable == 0))
+                                  (status->pttDisable == 0))
     {
         audioPath_release(rxAudioPath);
         radio_disableRtx();

--- a/openrtx/src/rtx/OpMode_M17.cpp
+++ b/openrtx/src/rtx/OpMode_M17.cpp
@@ -147,7 +147,7 @@ void OpMode_M17::offState(rtxStatus_t *const status)
         return;
     }
 
-    if(platform_getPttStatus() && (status->txDisable == 0))
+    if(platform_getPttStatus() && (status->pttDisable == 0))
     {
         startTx = true;
         status->opStatus = TX;

--- a/openrtx/src/rtx/rtx.cpp
+++ b/openrtx/src/rtx/rtx.cpp
@@ -112,6 +112,10 @@ void rtx_task()
     }
 
     if (reconfigure) {
+        // Hard lockout implies PTT gate: enforce consistency in the RTX thread.
+        if (rtxStatus.txDisable)
+            rtxStatus.pttDisable = 1;
+
         // Force TX and RX tone squelch to off for OpModes different from FM.
         if (rtxStatus.opMode != OPMODE_FM) {
             rtxStatus.txToneEn = 0;

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -1483,9 +1483,9 @@ void ui_updateFSM(bool *sync_rtx)
             case MAIN_VFO:
             {
                 // Enable Tx in MAIN_VFO mode
-                if (state.txDisable)
+                if (state.pttDisable)
                 {
-                    state.txDisable = false;
+                    state.pttDisable = false;
                     *sync_rtx = true;
                 }
 
@@ -1680,9 +1680,9 @@ void ui_updateFSM(bool *sync_rtx)
             // MEM screen
             case MAIN_MEM:
                 // Enable Tx in MAIN_MEM mode
-                if (state.txDisable)
+                if (state.pttDisable)
                 {
-                    state.txDisable = false;
+                    state.pttDisable = false;
                     *sync_rtx = true;
                 }
                 if (ui_state.input_locked)
@@ -2582,9 +2582,9 @@ void ui_updateFSM(bool *sync_rtx)
 
         // Enable Tx only if in MAIN_VFO or MAIN_MEM states
         bool inMemOrVfo = (state.ui_screen == MAIN_VFO) || (state.ui_screen == MAIN_MEM);
-        if ((macro_menu == true) || ((inMemOrVfo == false) && (state.txDisable == false)))
+        if ((macro_menu == true) || ((inMemOrVfo == false) && (state.pttDisable == false)))
         {
-            state.txDisable = true;
+            state.pttDisable = true;
             *sync_rtx = true;
         }
         if (!f1Handled && (msg.keys & KEY_F1) && (state.settings.vpLevel > vpBeep))

--- a/tests/unit/rtx_tx_disable.cpp
+++ b/tests/unit/rtx_tx_disable.cpp
@@ -1,0 +1,101 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ * 
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+extern "C" {
+#include "rtx/rtx.h"
+}
+
+/**
+ * Helper that replicates the flag-mapping logic from threads.c:
+ *
+ *   rtx_cfg.txDisable  = channel_rx_only;
+ *   rtx_cfg.pttDisable = channel_rx_only || ui_ptt_guard;
+ */
+static void apply_tx_flags(rtxStatus_t *cfg,
+                            uint8_t channel_rx_only,
+                            bool ui_ptt_guard)
+{
+    cfg->txDisable  = channel_rx_only;
+    cfg->pttDisable = channel_rx_only || ui_ptt_guard;
+}
+
+TEST_CASE("RTX TX disable flag separation", "[rtx]")
+{
+    rtxStatus_t cfg = {};
+
+    SECTION("Normal channel, UI on VFO/MEM: both gates open")
+    {
+        apply_tx_flags(&cfg, 0, false);
+        REQUIRE(cfg.txDisable  == 0);
+        REQUIRE(cfg.pttDisable == 0);
+    }
+
+    SECTION("RX-only channel: both gates locked")
+    {
+        apply_tx_flags(&cfg, 1, false);
+        REQUIRE(cfg.txDisable  == 1);
+        REQUIRE(cfg.pttDisable == 1);
+    }
+
+    SECTION("UI screen guard only: PTT gate closes, hard gate stays open")
+    {
+        apply_tx_flags(&cfg, 0, true);
+        REQUIRE(cfg.txDisable  == 0);
+        REQUIRE(cfg.pttDisable == 1);
+    }
+
+    SECTION("RX-only channel with UI screen guard: both gates locked")
+    {
+        apply_tx_flags(&cfg, 1, true);
+        REQUIRE(cfg.txDisable  == 1);
+        REQUIRE(cfg.pttDisable == 1);
+    }
+}
+
+/**
+ * Replicates the RTX-thread enforcement in rtx_task():
+ *
+ *   if (rtxStatus.txDisable)
+ *       rtxStatus.pttDisable = 1;
+ */
+static void apply_rtx_enforcement(rtxStatus_t *cfg)
+{
+    if (cfg->txDisable)
+        cfg->pttDisable = 1;
+}
+
+TEST_CASE("RTX thread pttDisable enforcement", "[rtx]")
+{
+    rtxStatus_t cfg = {};
+
+    SECTION("txDisable=1 forces pttDisable=1 regardless of incoming value")
+    {
+        cfg.txDisable  = 1;
+        cfg.pttDisable = 0;
+        apply_rtx_enforcement(&cfg);
+        REQUIRE(cfg.pttDisable == 1);
+    }
+
+    SECTION("txDisable=0 leaves pttDisable unchanged")
+    {
+        cfg.txDisable  = 0;
+        cfg.pttDisable = 1;
+        apply_rtx_enforcement(&cfg);
+        REQUIRE(cfg.txDisable  == 0);
+        REQUIRE(cfg.pttDisable == 1);
+    }
+
+    SECTION("txDisable=0 and pttDisable=0: both remain open")
+    {
+        cfg.txDisable  = 0;
+        cfg.pttDisable = 0;
+        apply_rtx_enforcement(&cfg);
+        REQUIRE(cfg.txDisable  == 0);
+        REQUIRE(cfg.pttDisable == 0);
+    }
+}


### PR DESCRIPTION
This change breaks txDisable out into two distinct concepts: txDisable as a function of the rtx state, and pttDisable as a function of the UI state. pttDisable is the same as the previous txDisable definition, but txDisable is now a more relaxed definition so that features like packet modes can be sent from areas where you wouldnt want the PTT button to work.