### PR TITLE
Improves in gfx printing for long, multiline strings

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1139,6 +1139,10 @@ dsp_oversampling_test = executable('dsp_oversampling_test',
                                     sources : unit_test_src + ['tests/unit/dsp_oversampling.cpp'],
                                     kwargs  : unit_test_opts)
 
+gfx_text_test = executable('gfx_text_test',
+                            sources : unit_test_src + ['tests/unit/gfx_text.cpp'],
+                            kwargs  : unit_test_opts)
+
 test('M17 Golay Unit Test',   m17_golay_test)
 test('M17 Viterbi Unit Test', m17_viterbi_test)
 test('M17 Demodulator Test',  m17_demodulator_test)
@@ -1156,3 +1160,4 @@ rtx_tx_disable_test = executable('rtx_tx_disable_test',
                                   sources : unit_test_src + ['tests/unit/rtx_tx_disable.cpp'],
                                   kwargs  : unit_test_opts)
 test('RTX TX Disable Test', rtx_tx_disable_test)
+test('GFX Text Test',        gfx_text_test)

--- a/openrtx/include/core/graphics.h
+++ b/openrtx/include/core/graphics.h
@@ -220,6 +220,11 @@ point_t gfx_printBuffer(point_t start, fontSize_t size, textAlign_t alignment,
  *
  * Simulates the same word-wrap line-break decisions (wrap at max_x).
  * Alignment is not simulated; only the vertical extent is computed.
+ * Wrap decisions always use start_x as the left margin of every line,
+ * which matches left-aligned layout.  For TEXT_ALIGN_CENTER or
+ * TEXT_ALIGN_RIGHT the actual rendered start.x may be larger than
+ * start_x, so the wrap point may differ and the returned height may
+ * not exactly match what gfx_printBufferClipped produces.
  * Passing char_count < strlen(buf) lets callers find the y-coordinate
  * of an arbitrary cursor position for scroll-offset calculations.
  *
@@ -236,6 +241,34 @@ point_t gfx_printBuffer(point_t start, fontSize_t size, textAlign_t alignment,
  */
 uint16_t gfx_measureText(fontSize_t size, const char *buf, uint16_t start_x,
                          uint16_t max_x, size_t char_count);
+
+/**
+ * Prints text from a char buffer into a clipped rectangular region.
+ *
+ * Like gfx_printBuffer but with an explicit right-edge limit and a
+ * vertical clip window.  Word-wrap fires when the next glyph would
+ * exceed max_x rather than CONFIG_SCREEN_WIDTH.  Pixels outside the
+ * range [clip_top_y, clip_bot_y] are suppressed without affecting
+ * layout, so a negative start.y can be used to implement scrolling.
+ *
+ * The returned text_size.y reflects only the lines processed before
+ * clip_bot_y is reached, not the full height of the text block.  Use
+ * gfx_measureText to obtain the total height for scroll calculations.
+ *
+ * @param start: top-left origin for the text block, in pixel coordinates.
+ * @param size: text font size.
+ * @param alignment: text alignment.
+ * @param color: text colour.
+ * @param buf: NUL-terminated string to render.
+ * @param max_x: right-edge pixel limit (exclusive) for word-wrap.
+ * @param clip_top_y: topmost pixel row to draw (inclusive).
+ * @param clip_bot_y: bottommost pixel row to draw (inclusive).
+ * @return text width and height of the processed portion as point_t.
+ */
+point_t gfx_printBufferClipped(point_t start, fontSize_t size,
+                               textAlign_t alignment, color_t color,
+                               const char *buf, uint16_t max_x,
+                               int16_t clip_top_y, int16_t clip_bot_y);
 
 /**
  * Prints text on the screen at the specified coordinates.

--- a/openrtx/include/core/graphics.h
+++ b/openrtx/include/core/graphics.h
@@ -215,6 +215,29 @@ point_t gfx_printBuffer(point_t start, fontSize_t size, textAlign_t alignment,
                         color_t color, const char *buf);
 
 /**
+ * Measure the pixel height of text as it would be laid out by
+ * gfx_printBufferClipped, without drawing anything.
+ *
+ * Simulates the same word-wrap line-break decisions (wrap at max_x).
+ * Alignment is not simulated; only the vertical extent is computed.
+ * Passing char_count < strlen(buf) lets callers find the y-coordinate
+ * of an arbitrary cursor position for scroll-offset calculations.
+ *
+ * start_x must match the x coordinate that will be passed to
+ * gfx_printBufferClipped so that wrap decisions use the same effective
+ * line width.
+ *
+ * @param size: text font size.
+ * @param buf: NUL-terminated string.
+ * @param start_x: left-edge x position (matches gfx_printBufferClipped start).
+ * @param max_x: right-edge pixel limit used for word-wrap.
+ * @param char_count: characters to measure; pass SIZE_MAX to measure all.
+ * @return y-extent in pixels of the text block; always >= one line height.
+ */
+uint16_t gfx_measureText(fontSize_t size, const char *buf, uint16_t start_x,
+                         uint16_t max_x, size_t char_count);
+
+/**
  * Prints text on the screen at the specified coordinates.
  * @param start: text line start point, in pixel coordinates.
  * @param size: text font size, defined as enum.

--- a/openrtx/src/core/graphics.c
+++ b/openrtx/src/core/graphics.c
@@ -403,7 +403,7 @@ static inline uint16_t get_line_size(GFXfont f, const char *text,
     uint16_t line_size = 0;
     for(unsigned i = 0; i < length && text[i] != '\n' && text[i] != '\r'; i++)
     {
-        if(text[i] < f.first || text[i] > f.last)
+        if (text[i] < f.first || text[i] > f.last)
             continue;
         GFXglyph glyph = f.glyph[text[i] - f.first];
         if (line_size + glyph.xAdvance <= max_width)
@@ -417,20 +417,22 @@ static inline uint16_t get_line_size(GFXfont f, const char *text,
 
 /**
  * Compute the start x coordinate of a new line of given pixel size
- * @param alinment: enum representing the text alignment
+ * @param alignment: enum representing the text alignment
  * @param line_size: the size of the current text line in pixels
+ * @param startx: left-edge x position of the text block
+ * @param max_width: right-edge pixel limit (width of the text region)
  */
 static inline uint16_t get_reset_x(textAlign_t alignment, uint16_t line_size,
-                                                          uint16_t startx)
+                                   uint16_t startx, uint16_t max_width)
 {
     switch(alignment)
     {
         case TEXT_ALIGN_LEFT:
             return startx;
         case TEXT_ALIGN_CENTER:
-            return (CONFIG_SCREEN_WIDTH - line_size)/2;
+            return (max_width - line_size)/2;
         case TEXT_ALIGN_RIGHT:
-            return CONFIG_SCREEN_WIDTH - line_size - startx;
+            return max_width - line_size - startx;
     }
 
     return 0;
@@ -446,102 +448,9 @@ uint8_t gfx_getFontHeight(fontSize_t size)
 point_t gfx_printBuffer(point_t start, fontSize_t size, textAlign_t alignment,
                         color_t color, const char *buf)
 {
-    GFXfont f = fonts[size];
-
-    size_t len = strlen(buf);
-
-    // Compute size of the first row in pixels
-    uint16_t line_size = get_line_size(f, buf, len, CONFIG_SCREEN_WIDTH);
-    uint16_t reset_x = get_reset_x(alignment, line_size, start.x);
-    start.x = reset_x;
-    // Save initial start.y value to calculate vertical size
-    int16_t saved_start_y = start.y;
-    uint16_t line_h = 0;
-
-    /* For each char in the string */
-    for(unsigned i = 0; i < len; i++)
-    {
-        char c = buf[i];
-
-        // Handle newline and carriage return before accessing glyph table
-        if (c == '\n')
-        {
-          if(alignment != TEXT_ALIGN_CENTER)
-          {
-            start.x = reset_x;
-          }
-          else
-          {
-            line_size = get_line_size(f, &buf[i+1], len-(i+1),
-                                      CONFIG_SCREEN_WIDTH);
-            start.x = reset_x = get_reset_x(alignment, line_size, start.x);
-          }
-          start.y += f.yAdvance;
-          continue;
-        }
-        else if (c == '\r')
-        {
-          start.x = reset_x;
-          continue;
-        }
-
-        GFXglyph glyph = f.glyph[c - f.first];
-        uint8_t *bitmap = f.bitmap;
-
-        uint16_t bo = glyph.bitmapOffset;
-        uint8_t w = glyph.width, h = glyph.height;
-        int8_t xo = glyph.xOffset,
-               yo = glyph.yOffset;
-        uint8_t xx, yy, bits = 0, bit = 0;
-        line_h = h;
-
-        // Handle wrap around
-        if (start.x + glyph.xAdvance > CONFIG_SCREEN_WIDTH)
-        {
-            // Compute size of the remaining text for this new line
-            line_size = get_line_size(f, &buf[i], len - i,
-                                      CONFIG_SCREEN_WIDTH);
-            // Pass reset_x (the original start x) not start.x (current pos)
-            start.x = reset_x = get_reset_x(alignment, line_size, reset_x);
-            start.y += f.yAdvance;
-        }
-
-        // Draw bitmap
-        for (yy = 0; yy < h; yy++)
-        {
-            for (xx = 0; xx < w; xx++)
-            {
-                if (!(bit++ & 7))
-                {
-                    bits = bitmap[bo++];
-                }
-
-                if (bits & 0x80)
-                {
-                    if (start.y + yo + yy < CONFIG_SCREEN_HEIGHT &&
-                        start.x + xo + xx < CONFIG_SCREEN_WIDTH &&
-                        start.y + yo + yy > 0 &&
-                        start.x + xo + xx > 0)
-                    {
-                        point_t pos;
-                        pos.x = start.x + xo + xx;
-                        pos.y = start.y + yo + yy;
-                        gfx_setPixel(pos, color);
-
-                    }
-                }
-
-                bits <<= 1;
-            }
-        }
-
-        start.x += glyph.xAdvance;
-    }
-    // Calculate text size
-    point_t text_size = {0, 0};
-    text_size.x = line_size;
-    text_size.y = (start.y - saved_start_y) + line_h;
-    return text_size;
+    return gfx_printBufferClipped(start, size, alignment, color, buf,
+                                  CONFIG_SCREEN_WIDTH, 0,
+                                  CONFIG_SCREEN_HEIGHT - 1);
 }
 
 uint16_t gfx_measureText(fontSize_t size, const char *buf, uint16_t start_x,
@@ -580,6 +489,103 @@ uint16_t gfx_measureText(fontSize_t size, const char *buf, uint16_t start_x,
     }
 
     return cur_y;
+}
+
+point_t gfx_printBufferClipped(point_t start, fontSize_t size,
+                               textAlign_t alignment, color_t color,
+                               const char *buf, uint16_t max_x,
+                               int16_t clip_top_y, int16_t clip_bot_y)
+{
+    GFXfont f = fonts[size];
+
+    size_t len = strlen(buf);
+
+    uint16_t line_size = get_line_size(f, buf, (uint16_t)len, max_x);
+    uint16_t max_line_size = line_size;
+    uint16_t origin_x = start.x;
+    uint16_t reset_x = get_reset_x(alignment, line_size, origin_x, max_x);
+    start.x = reset_x;
+    int16_t saved_start_y = start.y;
+    uint16_t line_h = 0;
+
+    for (unsigned i = 0; i < len; i++) {
+        /* Even the topmost pixel of the next glyph falls below clip_bot_y. */
+        if ((int16_t)(start.y - (int16_t)f.yAdvance) > clip_bot_y)
+            break;
+
+        char c = buf[i];
+
+        /* Handle control characters before accessing the glyph table. */
+        if (c == '\n') {
+            if (line_size > max_line_size)
+                max_line_size = line_size;
+            line_size = get_line_size(f, &buf[i + 1],
+                                      (uint16_t)(len - (i + 1)), max_x);
+            if (alignment == TEXT_ALIGN_CENTER
+                || alignment == TEXT_ALIGN_RIGHT) {
+                start.x = reset_x = get_reset_x(alignment, line_size, origin_x,
+                                                max_x);
+            } else {
+                start.x = reset_x;
+            }
+            start.y += f.yAdvance;
+            continue;
+        } else if (c == '\r') {
+            start.x = reset_x;
+            continue;
+        }
+
+        if (c < f.first || c > f.last)
+            continue;
+        GFXglyph glyph = f.glyph[c - f.first];
+        uint8_t *bitmap = f.bitmap;
+
+        uint16_t bo = glyph.bitmapOffset;
+        uint8_t w = glyph.width, h = glyph.height;
+        int8_t xo = glyph.xOffset, yo = glyph.yOffset;
+        uint8_t xx, yy, bits = 0, bit = 0;
+        line_h = h;
+
+        /* Wrap when the glyph would exceed the right-edge limit. */
+        if (start.x + glyph.xAdvance > max_x) {
+            if (line_size > max_line_size)
+                max_line_size = line_size;
+            line_size = get_line_size(f, &buf[i], (uint16_t)(len - i), max_x);
+            start.x = reset_x = get_reset_x(alignment, line_size, origin_x,
+                                            max_x);
+            start.y += f.yAdvance;
+        }
+
+        /* Draw pixels, suppressing those outside the clip window. */
+        for (yy = 0; yy < h; yy++) {
+            for (xx = 0; xx < w; xx++) {
+                if (!(bit++ & 7))
+                    bits = bitmap[bo++];
+
+                if (bits & 0x80) {
+                    int16_t px = (int16_t)(start.x + xo + xx);
+                    int16_t py = (int16_t)(start.y + yo + yy);
+
+                    if (py >= clip_top_y && py <= clip_bot_y && py >= 0
+                        && px >= 0 && px < (int16_t)max_x) {
+                        point_t pos = {(uint16_t)px, (uint16_t)py};
+                        gfx_setPixel(pos, color);
+                    }
+                }
+
+                bits <<= 1;
+            }
+        }
+
+        start.x += glyph.xAdvance;
+    }
+
+    if (line_size > max_line_size)
+        max_line_size = line_size;
+    point_t text_size = {0, 0};
+    text_size.x = max_line_size;
+    text_size.y = (start.y - saved_start_y) + line_h;
+    return text_size;
 }
 
 point_t gfx_print(point_t start, fontSize_t size, textAlign_t alignment,

--- a/openrtx/src/core/graphics.c
+++ b/openrtx/src/core/graphics.c
@@ -451,27 +451,18 @@ point_t gfx_printBuffer(point_t start, fontSize_t size, textAlign_t alignment,
     uint16_t reset_x = get_reset_x(alignment, line_size, start.x);
     start.x = reset_x;
     // Save initial start.y value to calculate vertical size
-    uint16_t saved_start_y = start.y;
+    int16_t saved_start_y = start.y;
     uint16_t line_h = 0;
 
     /* For each char in the string */
     for(unsigned i = 0; i < len; i++)
     {
         char c = buf[i];
-        GFXglyph glyph = f.glyph[c - f.first];
-        uint8_t *bitmap = f.bitmap;
 
-        uint16_t bo = glyph.bitmapOffset;
-        uint8_t w = glyph.width, h = glyph.height;
-        int8_t xo = glyph.xOffset,
-               yo = glyph.yOffset;
-        uint8_t xx, yy, bits = 0, bit = 0;
-        line_h = h;
-
-        // Handle newline and carriage return
+        // Handle newline and carriage return before accessing glyph table
         if (c == '\n')
         {
-          if(alignment!=TEXT_ALIGN_CENTER)
+          if(alignment != TEXT_ALIGN_CENTER)
           {
             start.x = reset_x;
           }
@@ -489,12 +480,23 @@ point_t gfx_printBuffer(point_t start, fontSize_t size, textAlign_t alignment,
           continue;
         }
 
+        GFXglyph glyph = f.glyph[c - f.first];
+        uint8_t *bitmap = f.bitmap;
+
+        uint16_t bo = glyph.bitmapOffset;
+        uint8_t w = glyph.width, h = glyph.height;
+        int8_t xo = glyph.xOffset,
+               yo = glyph.yOffset;
+        uint8_t xx, yy, bits = 0, bit = 0;
+        line_h = h;
+
         // Handle wrap around
         if (start.x + glyph.xAdvance > CONFIG_SCREEN_WIDTH)
         {
-            // Compute size of the first row in pixels
-            line_size = get_line_size(f, buf, len);
-            start.x = reset_x = get_reset_x(alignment, line_size, start.x);
+            // Compute size of the remaining text for this new line
+            line_size = get_line_size(f, &buf[i], len - i);
+            // Pass reset_x (the original start x) not start.x (current pos)
+            start.x = reset_x = get_reset_x(alignment, line_size, reset_x);
             start.y += f.yAdvance;
         }
 
@@ -532,7 +534,7 @@ point_t gfx_printBuffer(point_t start, fontSize_t size, textAlign_t alignment,
     // Calculate text size
     point_t text_size = {0, 0};
     text_size.x = line_size;
-    text_size.y = (saved_start_y - start.y) + line_h;
+    text_size.y = (start.y - saved_start_y) + line_h;
     return text_size;
 }
 

--- a/openrtx/src/core/graphics.c
+++ b/openrtx/src/core/graphics.c
@@ -395,14 +395,18 @@ void gfx_drawVLine(int16_t x, uint16_t width, color_t color)
  * @param f: font used as the source of glyphs
  * @param text: the input text
  * @param length: the length of the input text, used for boundary checking
+ * @param max_width: right-edge pixel limit for line measurement
  */
-static inline uint16_t get_line_size(GFXfont f, const char *text, uint16_t length)
+static inline uint16_t get_line_size(GFXfont f, const char *text,
+                                     uint16_t length, uint16_t max_width)
 {
     uint16_t line_size = 0;
     for(unsigned i = 0; i < length && text[i] != '\n' && text[i] != '\r'; i++)
     {
+        if(text[i] < f.first || text[i] > f.last)
+            continue;
         GFXglyph glyph = f.glyph[text[i] - f.first];
-        if (line_size + glyph.xAdvance < CONFIG_SCREEN_WIDTH)
+        if (line_size + glyph.xAdvance <= max_width)
             line_size += glyph.xAdvance;
         else
             break;
@@ -447,7 +451,7 @@ point_t gfx_printBuffer(point_t start, fontSize_t size, textAlign_t alignment,
     size_t len = strlen(buf);
 
     // Compute size of the first row in pixels
-    uint16_t line_size = get_line_size(f, buf, len);
+    uint16_t line_size = get_line_size(f, buf, len, CONFIG_SCREEN_WIDTH);
     uint16_t reset_x = get_reset_x(alignment, line_size, start.x);
     start.x = reset_x;
     // Save initial start.y value to calculate vertical size
@@ -468,7 +472,8 @@ point_t gfx_printBuffer(point_t start, fontSize_t size, textAlign_t alignment,
           }
           else
           {
-            line_size = get_line_size(f, &buf[i+1], len-(i+1));
+            line_size = get_line_size(f, &buf[i+1], len-(i+1),
+                                      CONFIG_SCREEN_WIDTH);
             start.x = reset_x = get_reset_x(alignment, line_size, start.x);
           }
           start.y += f.yAdvance;
@@ -494,7 +499,8 @@ point_t gfx_printBuffer(point_t start, fontSize_t size, textAlign_t alignment,
         if (start.x + glyph.xAdvance > CONFIG_SCREEN_WIDTH)
         {
             // Compute size of the remaining text for this new line
-            line_size = get_line_size(f, &buf[i], len - i);
+            line_size = get_line_size(f, &buf[i], len - i,
+                                      CONFIG_SCREEN_WIDTH);
             // Pass reset_x (the original start x) not start.x (current pos)
             start.x = reset_x = get_reset_x(alignment, line_size, reset_x);
             start.y += f.yAdvance;
@@ -536,6 +542,44 @@ point_t gfx_printBuffer(point_t start, fontSize_t size, textAlign_t alignment,
     text_size.x = line_size;
     text_size.y = (start.y - saved_start_y) + line_h;
     return text_size;
+}
+
+uint16_t gfx_measureText(fontSize_t size, const char *buf, uint16_t start_x,
+                         uint16_t max_x, size_t char_count)
+{
+    GFXfont f = fonts[size];
+    size_t len = strlen(buf);
+    if (char_count < len)
+        len = char_count;
+
+    uint16_t cur_x = start_x;
+    uint16_t cur_y = (uint16_t)f.yAdvance;
+
+    for (unsigned i = 0; i < len; i++) {
+        char c = buf[i];
+
+        if (c == '\n') {
+            cur_x = start_x;
+            cur_y += (uint16_t)f.yAdvance;
+            continue;
+        } else if (c == '\r') {
+            cur_x = start_x;
+            continue;
+        }
+
+        if (c < f.first || c > f.last)
+            continue;
+        GFXglyph glyph = f.glyph[c - f.first];
+
+        if (cur_x + glyph.xAdvance > max_x) {
+            cur_x = start_x;
+            cur_y += (uint16_t)f.yAdvance;
+        }
+
+        cur_x += glyph.xAdvance;
+    }
+
+    return cur_y;
 }
 
 point_t gfx_print(point_t start, fontSize_t size, textAlign_t alignment,

--- a/scripts/clang_format.sh
+++ b/scripts/clang_format.sh
@@ -128,6 +128,7 @@ tests/unit/ui_check_standby.cpp
 tests/unit/M17_metatext.cpp
 tests/unit/M17_packet.cpp
 tests/unit/dsp_oversampling.cpp
+tests/unit/gfx_text.cpp
 EOF
 )
 

--- a/tests/unit/gfx_text.cpp
+++ b/tests/unit/gfx_text.cpp
@@ -1,0 +1,119 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <cstddef>
+#include <climits>
+
+extern "C" {
+#include "core/graphics.h"
+}
+
+/*
+ * TomThumb (FONT_SIZE_5PT) has yAdvance = 6.  Tests that need a concrete
+ * line-height value use this constant rather than embedding magic numbers.
+ */
+static constexpr uint16_t TT_Y_ADVANCE = 6;
+
+/* A max_x wide enough that no ASCII string of a few characters will wrap. */
+static constexpr uint16_t WIDE = 4096;
+
+/* A max_x so narrow (1 px) that every printable glyph triggers a wrap. */
+static constexpr uint16_t NARROW = 1;
+
+TEST_CASE("gfx_measureText single-line strings", "[gfx][text]")
+{
+    SECTION("empty string occupies one line")
+    {
+        uint16_t h = gfx_measureText(FONT_SIZE_5PT, "", 0, WIDE, SIZE_MAX);
+        REQUIRE(h == TT_Y_ADVANCE);
+    }
+
+    SECTION("short string with no wrap occupies one line")
+    {
+        uint16_t h = gfx_measureText(FONT_SIZE_5PT, "Hello", 0, WIDE, SIZE_MAX);
+        REQUIRE(h == TT_Y_ADVANCE);
+    }
+
+    SECTION("char_count zero treats string as empty")
+    {
+        uint16_t h = gfx_measureText(FONT_SIZE_5PT, "Hello", 0, WIDE, 0);
+        REQUIRE(h == TT_Y_ADVANCE);
+    }
+}
+
+TEST_CASE("gfx_measureText multi-line via explicit newlines", "[gfx][text]")
+{
+    SECTION("one newline produces two lines")
+    {
+        uint16_t h = gfx_measureText(FONT_SIZE_5PT, "abc\ndef", 0, WIDE,
+                                     SIZE_MAX);
+        REQUIRE(h == 2 * TT_Y_ADVANCE);
+    }
+
+    SECTION("two newlines produce three lines")
+    {
+        uint16_t h = gfx_measureText(FONT_SIZE_5PT, "a\nb\nc", 0, WIDE,
+                                     SIZE_MAX);
+        REQUIRE(h == 3 * TT_Y_ADVANCE);
+    }
+
+    SECTION("trailing newline adds an extra line")
+    {
+        uint16_t h = gfx_measureText(FONT_SIZE_5PT, "abc\n", 0, WIDE, SIZE_MAX);
+        REQUIRE(h == 2 * TT_Y_ADVANCE);
+    }
+}
+
+TEST_CASE("gfx_measureText char_count truncation", "[gfx][text]")
+{
+    SECTION("truncate before newline stays on first line")
+    {
+        /* "abc\ndef" with char_count 3 — newline never reached */
+        uint16_t h = gfx_measureText(FONT_SIZE_5PT, "abc\ndef", 0, WIDE, 3);
+        REQUIRE(h == TT_Y_ADVANCE);
+    }
+
+    SECTION("truncate including newline advances to second line")
+    {
+        /* char_count 4 includes the '\\n' */
+        uint16_t h = gfx_measureText(FONT_SIZE_5PT, "abc\ndef", 0, WIDE, 4);
+        REQUIRE(h == 2 * TT_Y_ADVANCE);
+    }
+
+    SECTION("char_count larger than string length measures whole string")
+    {
+        uint16_t h_full = gfx_measureText(FONT_SIZE_5PT, "hi", 0, WIDE,
+                                          SIZE_MAX);
+        uint16_t h_over = gfx_measureText(FONT_SIZE_5PT, "hi", 0, WIDE, 999);
+        REQUIRE(h_over == h_full);
+    }
+}
+
+TEST_CASE("gfx_measureText word-wrap at max_x", "[gfx][text]")
+{
+    SECTION("each glyph wraps with max_x=1, height grows per character")
+    {
+        /*
+         * With max_x=1 every printable glyph triggers the wrap condition
+         * (cur_x + xAdvance > 1), adding one yAdvance per character.
+         * One character → initial line (yAdvance) + one wrap (yAdvance).
+         */
+        uint16_t h1 = gfx_measureText(FONT_SIZE_5PT, "A", 0, NARROW, SIZE_MAX);
+        uint16_t h2 = gfx_measureText(FONT_SIZE_5PT, "AB", 0, NARROW, SIZE_MAX);
+        REQUIRE(h1 == 2 * TT_Y_ADVANCE);
+        REQUIRE(h2 == h1 + TT_Y_ADVANCE);
+    }
+
+    SECTION("wide max_x prevents wrap for short string")
+    {
+        uint16_t h_wide = gfx_measureText(FONT_SIZE_5PT, "Hello", 0, WIDE,
+                                          SIZE_MAX);
+        uint16_t h_narrow = gfx_measureText(FONT_SIZE_5PT, "Hello", 0, NARROW,
+                                            SIZE_MAX);
+        REQUIRE(h_narrow > h_wide);
+    }
+}

--- a/tests/unit/gfx_text.cpp
+++ b/tests/unit/gfx_text.cpp
@@ -24,6 +24,50 @@ static constexpr uint16_t WIDE = 4096;
 /* A max_x so narrow (1 px) that every printable glyph triggers a wrap. */
 static constexpr uint16_t NARROW = 1;
 
+/* -----------------------------------------------------------------------
+ * gfx_printBuffer regression tests.
+ *
+ * These pin the behaviour fixed in the commit that corrected wrap logic,
+ * UB glyph access order, and the sign of text_size.y.
+ * ----------------------------------------------------------------------- */
+
+TEST_CASE("gfx_printBuffer text_size.y is positive", "[gfx][text]")
+{
+    color_t white = { 255, 255, 255, 255 };
+    point_t start = { 0, 10 };
+
+    point_t sz = gfx_printBuffer(start, FONT_SIZE_5PT, TEXT_ALIGN_LEFT, white,
+                                 "Hello");
+    REQUIRE(sz.y > 0);
+}
+
+TEST_CASE("gfx_printBuffer text_size.y grows with newlines", "[gfx][text]")
+{
+    color_t white = { 255, 255, 255, 255 };
+    point_t start = { 0, 10 };
+
+    point_t sz1 = gfx_printBuffer(start, FONT_SIZE_5PT, TEXT_ALIGN_LEFT, white,
+                                  "Hello");
+    point_t sz2 = gfx_printBuffer(start, FONT_SIZE_5PT, TEXT_ALIGN_LEFT, white,
+                                  "Hello\nHello");
+
+    REQUIRE(sz2.y > sz1.y);
+    REQUIRE((sz2.y - sz1.y) == TT_Y_ADVANCE);
+}
+
+TEST_CASE("gfx_printBuffer does not access glyph for newline", "[gfx][text]")
+{
+    /* If the UB glyph-access-before-newline-check bug were present, this
+     * would either crash or corrupt memory when '\\n' (0x0A) is below
+     * f.first.  Reaching REQUIRE without fault is the assertion. */
+    color_t white = { 255, 255, 255, 255 };
+    point_t start = { 0, 10 };
+
+    point_t sz = gfx_printBuffer(start, FONT_SIZE_5PT, TEXT_ALIGN_LEFT, white,
+                                 "a\nb\nc");
+    REQUIRE(sz.y > 0);
+}
+
 TEST_CASE("gfx_measureText single-line strings", "[gfx][text]")
 {
     SECTION("empty string occupies one line")
@@ -116,4 +160,165 @@ TEST_CASE("gfx_measureText word-wrap at max_x", "[gfx][text]")
                                             SIZE_MAX);
         REQUIRE(h_narrow > h_wide);
     }
+}
+
+/* -----------------------------------------------------------------------
+ * gfx_printBufferClipped return-value tests.
+ *
+ * gfx_setPixel is a no-op in the Linux platform test build, so we cannot
+ * verify pixel output.  We verify the returned text_size instead, which
+ * exercises the layout logic without display hardware.
+ * ----------------------------------------------------------------------- */
+
+TEST_CASE("gfx_printBufferClipped text_size.y for single-line text",
+          "[gfx][text]")
+{
+    color_t white = { 255, 255, 255, 255 };
+
+    /*
+     * Single-line: start.y does not advance, so text_size.y should equal
+     * the raw glyph height of the last character rendered (line_h).  It
+     * must be > 0 and <= TT_Y_ADVANCE.
+     */
+    point_t start = { 0, 20 };
+    point_t sz = gfx_printBufferClipped(start, FONT_SIZE_5PT, TEXT_ALIGN_LEFT,
+                                        white, "Hi", (uint16_t)WIDE, 0, 127);
+    REQUIRE(sz.y > 0);
+    REQUIRE(sz.y <= TT_Y_ADVANCE);
+}
+
+TEST_CASE("gfx_printBufferClipped text_size.y grows for two lines",
+          "[gfx][text]")
+{
+    color_t white = { 255, 255, 255, 255 };
+    point_t start = { 0, 20 };
+
+    point_t sz1 = gfx_printBufferClipped(start, FONT_SIZE_5PT, TEXT_ALIGN_LEFT,
+                                         white, "Hi", (uint16_t)WIDE, 0, 127);
+    point_t sz2 = gfx_printBufferClipped(start, FONT_SIZE_5PT, TEXT_ALIGN_LEFT,
+                                         white, "Hi\nHi", (uint16_t)WIDE, 0,
+                                         127);
+
+    /* Two lines must be taller than one. */
+    REQUIRE(sz2.y > sz1.y);
+    /* The difference should equal exactly one yAdvance. */
+    REQUIRE((sz2.y - sz1.y) == TT_Y_ADVANCE);
+}
+
+TEST_CASE("gfx_printBufferClipped negative start.y does not corrupt result",
+          "[gfx][text]")
+{
+    color_t white = { 255, 255, 255, 255 };
+
+    /* Scrolled position: top of text block is above the visible area. */
+    point_t start_neg = { 0, -10 };
+    point_t start_pos = { 0, 0 };
+
+    point_t sz_neg = gfx_printBufferClipped(start_neg, FONT_SIZE_5PT,
+                                            TEXT_ALIGN_LEFT, white, "Hi",
+                                            (uint16_t)WIDE, 0, 127);
+    point_t sz_pos = gfx_printBufferClipped(start_pos, FONT_SIZE_5PT,
+                                            TEXT_ALIGN_LEFT, white, "Hi",
+                                            (uint16_t)WIDE, 0, 127);
+
+    /* Layout is the same regardless of vertical scroll offset. */
+    REQUIRE(sz_neg.y == sz_pos.y);
+    REQUIRE(sz_neg.y > 0);
+}
+
+TEST_CASE("gfx_printBufferClipped negative clip_top_y does not corrupt result",
+          "[gfx][text]")
+{
+    color_t white = { 255, 255, 255, 255 };
+
+    /* Pixels above row 0 must be suppressed without corrupting layout. */
+    point_t start = { 0, 10 };
+    point_t sz = gfx_printBufferClipped(start, FONT_SIZE_5PT, TEXT_ALIGN_LEFT,
+                                        white, "Hi", (uint16_t)WIDE, -10, 127);
+    REQUIRE(sz.y > 0);
+    REQUIRE(sz.y <= TT_Y_ADVANCE);
+}
+
+TEST_CASE("get_line_size exact-fit glyph is included in line width",
+          "[gfx][text]")
+{
+    color_t white = { 255, 255, 255, 255 };
+    point_t start = { 0, 10 };
+
+    /* TomThumb 'A' xAdvance=4: with max_x=4 the glyph exactly fills the line. */
+    point_t sz = gfx_printBufferClipped(start, FONT_SIZE_5PT, TEXT_ALIGN_LEFT,
+                                        white, "A", 4, 0, 127);
+    REQUIRE(sz.x == 4);
+}
+
+TEST_CASE("gfx_printBufferClipped text_size.x is max line width, not last line",
+          "[gfx][text]")
+{
+    color_t white = { 255, 255, 255, 255 };
+    point_t start = { 0, 10 };
+
+    /*
+     * First line "Hello" is wider than second line "Hi".
+     * text_size.x must reflect the wider first line, not the shorter last.
+     */
+    point_t sz_wide = gfx_printBufferClipped(start, FONT_SIZE_5PT,
+                                             TEXT_ALIGN_LEFT, white, "Hello",
+                                             (uint16_t)WIDE, 0, 127);
+    point_t sz_multi =
+        gfx_printBufferClipped(start, FONT_SIZE_5PT, TEXT_ALIGN_LEFT, white,
+                               "Hello\nHi", (uint16_t)WIDE, 0, 127);
+    REQUIRE(sz_multi.x == sz_wide.x);
+}
+
+TEST_CASE("gfx_printBufferClipped text_size.x when second line is wider",
+          "[gfx][text]")
+{
+    color_t white = { 255, 255, 255, 255 };
+    point_t start = { 0, 10 };
+
+    /* Second line "Hello" is wider than first line "Hi". */
+    point_t sz_wide = gfx_printBufferClipped(start, FONT_SIZE_5PT,
+                                             TEXT_ALIGN_LEFT, white, "Hello",
+                                             (uint16_t)WIDE, 0, 127);
+    point_t sz_multi =
+        gfx_printBufferClipped(start, FONT_SIZE_5PT, TEXT_ALIGN_LEFT, white,
+                               "Hi\nHello", (uint16_t)WIDE, 0, 127);
+    REQUIRE(sz_multi.x == sz_wide.x);
+}
+
+TEST_CASE("gfx_printBufferClipped glyph at clip_bot_y baseline is not skipped",
+          "[gfx][text]")
+{
+    color_t white = { 255, 255, 255, 255 };
+
+    /* Baseline at clip_bot_y+1: all glyph pixels still fall within window. */
+    int16_t base_y = 20;
+    int16_t clip_bot = base_y - 1;
+    point_t start = { 0, base_y };
+
+    point_t sz = gfx_printBufferClipped(start, FONT_SIZE_5PT, TEXT_ALIGN_LEFT,
+                                        white, "A", (uint16_t)WIDE, 0,
+                                        clip_bot);
+    REQUIRE(sz.y > 0);
+}
+
+TEST_CASE("gfx_printBufferClipped TEXT_ALIGN_RIGHT resets per line",
+          "[gfx][text]")
+{
+    color_t white = { 255, 255, 255, 255 };
+    point_t start = { 0, 10 };
+
+    /*
+     * With TEXT_ALIGN_RIGHT each line's start.x should be computed from
+     * that line's own width.  The returned text_size.x must equal the
+     * width of the widest line, same as for LEFT alignment.
+     */
+    point_t sz_right =
+        gfx_printBufferClipped(start, FONT_SIZE_5PT, TEXT_ALIGN_RIGHT, white,
+                               "Hello\nHi", (uint16_t)WIDE, 0, 127);
+    point_t sz_left =
+        gfx_printBufferClipped(start, FONT_SIZE_5PT, TEXT_ALIGN_LEFT, white,
+                               "Hello\nHi", (uint16_t)WIDE, 0, 127);
+    /* Max line width is alignment-independent. */
+    REQUIRE(sz_right.x == sz_left.x);
 }


### PR DESCRIPTION
For the upcoming messaging functionalities, we need an improved way to print and layout text. This PR couples together a few improvements and bug fixes along with the introduction of new methods that facilitate showing of significantly long text within a more challenging UX, handling things like wrapping, scrolling offsets, and more precise placement to enable things like placing long text within boxes.