### PR TITLE
fix: unable to build new devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -38,7 +38,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
 
 # compile miosix compiler
 RUN git clone --depth 1 https://github.com/fedetft/miosix-kernel.git \
-  && cd miosix-kernel/miosix/_tools/compiler/gcc-9.2.0-mp3.2 \
+  && cd miosix-kernel/tools/compiler/gcc-9.2.0-mp3.2 \
   && sh download.sh \
   && bash install-script.sh -j`nproc`
 


### PR DESCRIPTION
On March 31st the [miosix repo](https://github.com/fedetft/miosix-kernel.git) relocated their tools directory. This resulted in new devcontainers unable to build. (I don't know how some uncached ones still were able to build in this repo).

I updated the path in the Dockerfile and it now works again.