### PR TITLE
drivers: NVM: fix out-of-bounds access in settings block rollover

### DIFF
--- a/platform/drivers/NVM/nvmem_settings_MDx.c
+++ b/platform/drivers/NVM/nvmem_settings_MDx.c
@@ -8,6 +8,7 @@
 #include <string.h>
 #include "core/cps.h"
 #include "core/crc.h"
+#include "core/utils.h"
 #include "flash.h"
 
 /*
@@ -118,7 +119,7 @@ int nvm_writeSettingsAndVfo(const settings_t *settings, const channel_t *vfo)
      * On STM32F405 the settings are saved in sector 11, starting at address
      * 0x08060000.
      */
-    if((block < 0) || (block >= 2047))
+    if((block < 0) || ((uint32_t)block >= ARRAY_SIZE(memory->data)))
     {
         flash_eraseSector(11);
         addr = ((uint32_t) &(memory->magic));


### PR DESCRIPTION
Replace hard-coded block limit (2047) with ARRAY_SIZE(memory->data) to correctly bound access to the 1024-entry NVM data array.
Fixes #472 