### PR TITLE
Vfo freq display

### DIFF
--- a/openrtx/include/core/graphics.h
+++ b/openrtx/include/core/graphics.h
@@ -236,6 +236,15 @@ uint16_t gfx_measureText(fontSize_t size, const char *buf, uint16_t start_x,
                          uint16_t max_x, size_t char_count);
 
 /**
+ * Measures the pixel width of a single line of text.
+ *
+ * @param size: text font size.
+ * @param buf: NUL-terminated string.
+ * @return width in pixels of the text line.
+ */
+uint16_t gfx_getTextWidth(fontSize_t size, const char *buf);
+
+/**
  * Prints text from a char buffer into a clipped rectangular region.
  *
  * Like gfx_printBuffer but with an explicit right-edge limit and a

--- a/openrtx/src/core/graphics.c
+++ b/openrtx/src/core/graphics.c
@@ -431,6 +431,12 @@ uint8_t gfx_getFontHeight(fontSize_t size)
     return glyph.height;
 }
 
+uint16_t gfx_getTextWidth(fontSize_t size, const char *buf)
+{
+    GFXfont f = fonts[size];
+    return get_line_size(f, buf, strlen(buf), CONFIG_SCREEN_WIDTH);
+}
+
 point_t gfx_printBuffer(point_t start, fontSize_t size, textAlign_t alignment,
                         color_t color, const char *buf)
 {

--- a/openrtx/src/ui/default/ui_main.c
+++ b/openrtx/src/ui/default/ui_main.c
@@ -222,13 +222,34 @@ void _ui_drawFrequency()
     freq_t freq = platform_getPttStatus() ? last_state.channel.tx_frequency
                                           : last_state.channel.rx_frequency;
 
-    // Print big numbers frequency
     char freq_str[16] = {0};
-    sniprintf(freq_str, sizeof(freq_str), "%lu.%06lu", (freq / 1000000lu), (freq % 1000000lu));
-    stripTrailingZeroes(freq_str);
+    sniprintf(freq_str, sizeof(freq_str), "%03lu.%04lu",
+              (freq / 1000000lu), (freq % 1000000lu) / 100);
 
-    gfx_print(layout.line3_large_pos, layout.line3_large_font, TEXT_ALIGN_CENTER,
-              color_white, "%s", freq_str);
+    size_t len = strlen(freq_str);
+    char main_str[16] = {0};
+    char small_str[3] = {0};
+    strncpy(main_str, freq_str, len - 2);
+    strncpy(small_str, freq_str + len - 2, 2);
+
+    fontSize_t small_font = FONT_SIZE_5PT;
+    if (layout.line3_large_font > FONT_SIZE_6PT)
+    {
+        small_font = (fontSize_t)(layout.line3_large_font - 2);
+    }
+
+    uint16_t main_width = gfx_getTextWidth(layout.line3_large_font, main_str);
+    uint16_t small_width = gfx_getTextWidth(small_font, small_str);
+    uint16_t total_width = main_width + small_width;
+    int16_t start_x = (CONFIG_SCREEN_WIDTH - total_width) / 2;
+
+    point_t main_pos = { (uint16_t)start_x, layout.line3_large_pos.y };
+    gfx_print(main_pos, layout.line3_large_font, TEXT_ALIGN_LEFT,
+              color_white, "%s", main_str);
+
+    point_t small_pos = { (uint16_t)(start_x + main_width), layout.line3_large_pos.y };
+    gfx_print(small_pos, small_font, TEXT_ALIGN_LEFT,
+              color_white, "%s", small_str);
 }
 
 void _ui_drawVFOMiddleInput(ui_state_t* ui_state)


### PR DESCRIPTION
Show VFO freq with full precision always, and make the last 2 digits smaller to help the user focus on the primary numbers.

This was previously discussed [here](https://discord.com/channels/802861646816083978/802861646816083981/1496583968521457855).

<img width="580" height="558" alt="Screenshot From 2026-06-08 12-24-53" src="https://github.com/user-attachments/assets/0d4b8804-ad61-4078-9df9-eef5197a4a9a" />
<img width="580" height="558" alt="Screenshot From 2026-06-08 12-25-07" src="https://github.com/user-attachments/assets/cfd97107-e6d7-4ecb-a3b2-bfd64ed5d518" />

