### PR TITLE
ui: fix VFO frequency display precision for 6.25 kHz steps

### DIFF
--- a/openrtx/src/ui/default/ui_main.c
+++ b/openrtx/src/ui/default/ui_main.c
@@ -223,8 +223,8 @@ void _ui_drawFrequency()
                                           : last_state.channel.rx_frequency;
 
     char freq_str[16] = {0};
-    sniprintf(freq_str, sizeof(freq_str), "%03lu.%04lu",
-              (freq / 1000000lu), (freq % 1000000lu) / 100);
+    sniprintf(freq_str, sizeof(freq_str), "%03lu.%05lu",
+              (freq / 1000000lu), (freq % 1000000lu) / 10);
 
     size_t len = strlen(freq_str);
     char main_str[16] = {0};


### PR DESCRIPTION
Fixup for my previous commit :sob: 