### PR TITLE
Make emulator builds also support Mac OSX

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -110,12 +110,25 @@ openrtx_inc += ['lib/QRCode/include']
 openrtx_inc += ['lib/qdec/include']
 
 # CODEC2, open source speech codec, compile from source on embedded
+# Always download the subproject — the Zephyr/CMake build needs the source
+# files at subprojects/codec2/src/*.c regardless of which library is used
+# for linking. For native builds, prefer system libraries (pkg-config or
+# find_library) so homebrew, Nix, and distro packages work. For cross
+# builds (embedded), use the subproject build.
 codec2_proj = subproject('codec2')
-if meson.is_cross_build()
-  codec2_dep  = codec2_proj.get_variable('codec2_dep')
+if not meson.is_cross_build()
+  # Try pkg-config first (homebrew, Nix, and other pkg-config-based installs)
+  codec2_dep = dependency('codec2', method: 'pkg-config', required: false)
+  if not codec2_dep.found()
+    # Fall back to compiler's built-in library search (libcodec2-dev on Debian/Ubuntu)
+    cpp        = meson.get_compiler('cpp')
+    codec2_dep = cpp.find_library('codec2', required: false)
+  endif
+  if not codec2_dep.found()
+    codec2_dep = codec2_proj.get_variable('codec2_dep')
+  endif
 else
-  cpp        = meson.get_compiler('cpp')
-  codec2_dep = cpp.find_library('codec2')
+  codec2_dep = codec2_proj.get_variable('codec2_dep')
 endif
 
 # Catch2, C++ testing framework (only for native/linux builds)

--- a/openrtx/include/interfaces/audio.h
+++ b/openrtx/include/interfaces/audio.h
@@ -132,8 +132,11 @@ struct audioDevice
     const void               *config;    ///< Driver configuration
     const uint8_t             instance;  ///< Driver instance number
     const uint8_t             endpoint;  ///< Driver sink or source endpoint
-}
-__attribute__((packed));
+#if defined(__APPLE__) && defined(__aarch64__)
+} __attribute__((aligned(8)));
+#else
+} __attribute__((packed));
+#endif
 
 extern const struct audioDevice inputDevices[];
 extern const struct audioDevice outputDevices[];

--- a/tests/unit/rtx_tx_disable.cpp
+++ b/tests/unit/rtx_tx_disable.cpp
@@ -16,11 +16,10 @@ extern "C" {
  *   rtx_cfg.txDisable  = channel_rx_only;
  *   rtx_cfg.pttDisable = channel_rx_only || ui_ptt_guard;
  */
-static void apply_tx_flags(rtxStatus_t *cfg,
-                            uint8_t channel_rx_only,
-                            bool ui_ptt_guard)
+static void apply_tx_flags(rtxStatus_t *cfg, uint8_t channel_rx_only,
+                           bool ui_ptt_guard)
 {
-    cfg->txDisable  = channel_rx_only;
+    cfg->txDisable = channel_rx_only;
     cfg->pttDisable = channel_rx_only || ui_ptt_guard;
 }
 
@@ -31,28 +30,28 @@ TEST_CASE("RTX TX disable flag separation", "[rtx]")
     SECTION("Normal channel, UI on VFO/MEM: both gates open")
     {
         apply_tx_flags(&cfg, 0, false);
-        REQUIRE(cfg.txDisable  == 0);
+        REQUIRE(cfg.txDisable == 0);
         REQUIRE(cfg.pttDisable == 0);
     }
 
     SECTION("RX-only channel: both gates locked")
     {
         apply_tx_flags(&cfg, 1, false);
-        REQUIRE(cfg.txDisable  == 1);
+        REQUIRE(cfg.txDisable == 1);
         REQUIRE(cfg.pttDisable == 1);
     }
 
     SECTION("UI screen guard only: PTT gate closes, hard gate stays open")
     {
         apply_tx_flags(&cfg, 0, true);
-        REQUIRE(cfg.txDisable  == 0);
+        REQUIRE(cfg.txDisable == 0);
         REQUIRE(cfg.pttDisable == 1);
     }
 
     SECTION("RX-only channel with UI screen guard: both gates locked")
     {
         apply_tx_flags(&cfg, 1, true);
-        REQUIRE(cfg.txDisable  == 1);
+        REQUIRE(cfg.txDisable == 1);
         REQUIRE(cfg.pttDisable == 1);
     }
 }
@@ -75,7 +74,7 @@ TEST_CASE("RTX thread pttDisable enforcement", "[rtx]")
 
     SECTION("txDisable=1 forces pttDisable=1 regardless of incoming value")
     {
-        cfg.txDisable  = 1;
+        cfg.txDisable = 1;
         cfg.pttDisable = 0;
         apply_rtx_enforcement(&cfg);
         REQUIRE(cfg.pttDisable == 1);
@@ -83,19 +82,19 @@ TEST_CASE("RTX thread pttDisable enforcement", "[rtx]")
 
     SECTION("txDisable=0 leaves pttDisable unchanged")
     {
-        cfg.txDisable  = 0;
+        cfg.txDisable = 0;
         cfg.pttDisable = 1;
         apply_rtx_enforcement(&cfg);
-        REQUIRE(cfg.txDisable  == 0);
+        REQUIRE(cfg.txDisable == 0);
         REQUIRE(cfg.pttDisable == 1);
     }
 
     SECTION("txDisable=0 and pttDisable=0: both remain open")
     {
-        cfg.txDisable  = 0;
+        cfg.txDisable = 0;
         cfg.pttDisable = 0;
         apply_rtx_enforcement(&cfg);
-        REQUIRE(cfg.txDisable  == 0);
+        REQUIRE(cfg.txDisable == 0);
         REQUIRE(cfg.pttDisable == 0);
     }
 }


### PR DESCRIPTION
On native (non-cross) builds, try codec2 resolution in this order:
  1. pkg-config (homebrew, Nix, and other pkg-config-based installs)
  2. Compiler's built-in find_library (libcodec2-dev on Debian/Ubuntu)
  3. Subproject build from source (embedded fallback)

This fixes macOS homebrew builds without breaking Linux system package installations that lack a .pc file but have the library on the search path. The previous single find_library approach missed homebrew installs.

Also guard the audioDevice struct alignment change to only apply on Darwin ARM64 where Apple's int64_t misbehaves with packed structs. Other platforms retain the original __attribute__((packed)) to avoid increasing memory usage on resource-constrained embedded targets.