### PR TITLE
drivers: NVM: add missing spi_acquire in W25Qx write path

### DIFF
--- a/platform/drivers/NVM/W25Qx.c
+++ b/platform/drivers/NVM/W25Qx.c
@@ -241,6 +241,8 @@ static ssize_t W25Qx_writePage(const struct nvmDevice *dev, uint32_t addr,
         writeLen = PAGE_SIZE - addrRange;
     }
 
+    spi_acquire(cfg->spi);
+
     // Write enable bit has to be set before each page program
     enableWrite(cfg);
 


### PR DESCRIPTION
I'm getting familiar with the codebase (planning to work on rtxlink/CAT next), so
I picked a small open issue as a starter.

`W25Qx_writePage()` calls `spi_release()` at the end of the transaction but
never `spi_acquire()`. Unlike every other bus transaction in this driver.

This is a regression: the lock was lost in 404e8403 when the WREN sequence was
refactored into `enableWrite()`. It went unnoticed because the flash SPI mutex
is NULL on all targets except MD-9600, and the write path is currently not
used at runtime. But this becomes important once external-flash writes are used
(persistence rework, rtxlink DAT).

The fix mirrors `nvm_api_erase()`: acquire before WREN, release after status
polling stays where it was.

Testing: `openrtx_mduv3x0` and `openrtx_md9600` build cleanly (cross_cm4).

Fixes #476

Note: this replaces #489, which I closed because of a CI limitation. The build
workflow fails on branch names containing a slash (the artifact-renaming step
interprets them as a directory path). Same change, resubmitted from a slash-free
branch.