### PR TITLE
CI hardening: branch names with slashes, devcontainer cache, Miosix pin

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -37,8 +37,15 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends \
   && rm -rf /var/lib/apt/lists/*
 
 # compile miosix compiler
-RUN git clone --depth 1 https://github.com/fedetft/miosix-kernel.git \
-  && cd miosix-kernel/tools/compiler/gcc-9.2.0-mp3.2 \
+# Pinned to Miosix v3.01: upstream layout changes have broken this build
+# before (see issue #469), bump the SHA deliberately.
+ARG MIOSIX_KERNEL_SHA=361e8c35b09ad73c15ded5332dff21ce8c9a711d
+RUN git init miosix-kernel \
+  && cd miosix-kernel \
+  && git remote add origin https://github.com/fedetft/miosix-kernel.git \
+  && git fetch --depth 1 origin ${MIOSIX_KERNEL_SHA} \
+  && git checkout FETCH_HEAD \
+  && cd tools/compiler/gcc-9.2.0-mp3.2 \
   && sh download.sh \
   && bash install-script.sh -j`nproc`
 

--- a/.github/workflows/build-devcontainer.yml
+++ b/.github/workflows/build-devcontainer.yml
@@ -1,6 +1,11 @@
 name: "Build devcontainer"
 on:
   workflow_dispatch:
+  # Rebuild weekly: this image is the layer cache for the "Build and test"
+  # workflow and goes stale whenever the ubuntu:24.04 base image is updated
+  # upstream, forcing every CI run to rebuild the full toolchain.
+  schedule:
+    - cron: '30 4 * * 1'
   push:
     branches:
       - master
@@ -17,8 +22,6 @@ on:
       - '.devcontainer/devcontainer.json'
 
 env:
-  RADIO_TOOL_VERSION: 0.2.2
-  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   DEVCONTAINER_NAME: ghcr.io/openrtx/openrtx-devcontainer
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,12 +5,18 @@ on:
   pull_request:
 
 env:
-  RADIO_TOOL_VERSION: 0.2.2
-  BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
   DEVCONTAINER_NAME: ghcr.io/openrtx/openrtx-devcontainer
+
+# Cancel superseded runs of the same PR, keep all runs on branches
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   unit-test:
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -47,6 +53,7 @@ jobs:
           cat build/coverage/coverage.md >> $GITHUB_STEP_SUMMARY
   build-zephyr:
     runs-on: ubuntu-22.04
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -80,6 +87,7 @@ jobs:
             app/build/openrtx_*.uf2
   build:
     runs-on: ubuntu-24.04
+    timeout-minutes: 120
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,6 +85,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: Replace slashes in branch name
+        run: echo "BRANCH_NAME=$(echo "$BRANCH_NAME" | tr '/' '-')" >> "$GITHUB_ENV"
       - name: Compile using devcontainer
         uses: devcontainers/ci@v0.3
         with:


### PR DESCRIPTION
Sorry for opening two PRs at once as my first contributions, but I wouldn't
sleep well leaving this unfinished :)

Both failures I hit on #490 were CI issues. First the build job failed because
my branch name contained a slash and the artifact renaming `mv` treated it as
a directory path. Then the re-run died downloading a toolchain tarball while
rebuilding the devcontainer image from scratch. The rebuild happens because
the ghcr cache image is only refreshed when devcontainer files change (last on
May 26), while the `ubuntu:24.04` base moved on Jul 2, so every run since gets
a cache miss and rebuilds the Miosix toolchain (about 40 minutes).

Commits:

**ci: replace slashes in branch name used for artifact file names**
This PR intentionally comes from a branch with a slash, as a live test.

**devcontainer: pin miosix-kernel to Miosix v3.01** (fixes #469)
Fetch a fixed SHA instead of upstream HEAD, bump deliberately.

**ci: rebuild devcontainer image on a weekly schedule**
Keeps the layer cache in sync with the floating base image.

**ci: cancel superseded PR runs and add job timeouts**
A push to a PR cancels the previous run; branches are never cancelled.

Happy to adjust or drop any of these. Side note: `openrtx_md9600_wrap` is
compiled by CI but never uploaded as an artifact. Is that intentional?
