### PR TITLE
build: WebAssembly (Emscripten) build of the Linux emulator

### DIFF
--- a/cross_wasm.txt
+++ b/cross_wasm.txt
@@ -1,0 +1,30 @@
+# Meson cross file for the WebAssembly (Emscripten) build of the OpenRTX
+# Linux emulator.
+#
+# Requires the Emscripten SDK (emcc/em++) on PATH. Configure with:
+#
+#     meson setup build_wasm --cross-file cross_wasm.txt
+#     ninja -C build_wasm wasm
+#
+# SDL2, pthreads and the emscripten-specific link flags are applied by the
+# `wasm` target in meson.build, not here, so this file stays a plain toolchain
+# description.
+
+[binaries]
+c      = 'emcc'
+cpp    = 'em++'
+ar     = 'emar'
+ranlib = 'emranlib'
+strip  = 'emstrip'
+
+[built-in options]
+# The native Linux emulator builds with C++ exceptions enabled; keep parity in
+# the browser (std::string / std::random and codec2 rely on it).
+cpp_args      = ['-fexceptions']
+cpp_link_args = ['-fexceptions']
+
+[host_machine]
+system     = 'emscripten'
+cpu_family = 'wasm32'
+cpu        = 'wasm32'
+endian     = 'little'

--- a/meson.build
+++ b/meson.build
@@ -1104,6 +1104,57 @@ cm7 = alias_target('cm7', cm7_targets)
 linux = alias_target('linux', linux_targets)
 
 ##
+## ------------------------ WebAssembly (Emscripten) ---------------------------
+##
+## A browser build of the Linux emulator. It only materialises when meson is
+## configured with the emscripten cross file (cross_wasm.txt), so native and
+## embedded builds are completely unaffected.
+##
+## It reuses the standard 160x128 RGB565 UI sources/defines, but instead of the
+## system SDL2/pthreads it uses Emscripten's bundled SDL2 (-sUSE_SDL=2) and
+## pthreads (Web Workers + SharedArrayBuffer). -sPROXY_TO_PTHREAD runs main() on
+## a worker so the existing blocking pthread/mutex/chan concurrency model keeps
+## working unchanged while the browser's main thread stays free for the event
+## loop and SDL rendering. GNU readline is compiled out (see emulator.c).
+##
+## Build:  meson setup build_wasm --cross-file cross_wasm.txt
+##         ninja -C build_wasm wasm
+## Serve:  python scripts/serve_wasm.py build_wasm   (sets COOP/COEP headers,
+##         required for SharedArrayBuffer)
+##
+if meson.is_cross_build() and host_machine.system() == 'emscripten'
+
+  wasm_shell = meson.current_source_dir() / 'platform/targets/wasm/shell.html'
+
+  # -pthread and -sUSE_SDL=2 must be passed at both compile and link time.
+  wasm_em_args = ['-sUSE_SDL=2', '-pthread']
+
+  wasm_c_args   = linux_c_args   + wasm_em_args
+  wasm_cpp_args = linux_cpp_args + wasm_em_args
+
+  wasm_link_args = wasm_em_args + [
+    '-sPROXY_TO_PTHREAD',
+    '-sPTHREAD_POOL_SIZE=8',
+    '-sALLOW_MEMORY_GROWTH=1',
+    '-sINITIAL_MEMORY=64MB',
+    '-sEXPORTED_RUNTIME_METHODS=ccall,cwrap,FS',
+    '--shell-file', wasm_shell,
+  ]
+
+  openrtx_wasm = executable('openrtx_wasm',
+                            sources             : linux_default_src + main_src,
+                            include_directories : linux_inc,
+                            dependencies        : [codec2_dep],
+                            c_args              : wasm_c_args,
+                            cpp_args            : wasm_cpp_args,
+                            link_args           : wasm_link_args,
+                            name_suffix         : 'html')
+
+  alias_target('wasm', openrtx_wasm)
+
+endif
+
+##
 ## ----------------------------------- Unit Tests ------------------------------
 ##
 

--- a/openrtx/src/core/audio_codec.c
+++ b/openrtx/src/core/audio_codec.c
@@ -8,8 +8,11 @@
 #include "core/audio_codec.h"
 #include <pthread.h>
 #include "core/threads.h"
-// codec2 system library has a weird include prefix
-#if defined(PLATFORM_LINUX)
+// codec2 system library has a weird include prefix. The native Linux build
+// links the distro libcodec2 (headers under codec2/), but the WebAssembly build
+// links the bundled codec2 subproject, which exposes the header flat like the
+// embedded targets do.
+#if defined(PLATFORM_LINUX) && !defined(__EMSCRIPTEN__)
 #include <codec2/codec2.h>
 #else
 #include "codec2.h"

--- a/platform/drivers/NVM/nvmem_linux.c
+++ b/platform/drivers/NVM/nvmem_linux.c
@@ -79,6 +79,25 @@ static int create_dir(const char *path)
 
 void nvm_init()
 {
+#ifdef __EMSCRIPTEN__
+    // The browser has no HOME/XDG directories. Persist radio state under a
+    // fixed path in the Emscripten virtual filesystem. This lives in MEMFS by
+    // default (ephemeral); the JS shell may mount IDBFS at /persist to make it
+    // survive page reloads.
+    char memory_path[NVM_MAX_PATHLEN];
+    strcpy(memory_path, "/persist/");
+
+    if(create_dir(memory_path) != 0)
+        exit(1);
+
+    strcat(memory_path, "state.bin");
+
+    int ret = posixFile_init(&stateDevice, memory_path, 1024);
+    if(ret < 0)
+        printf("Opening of state file failed with status %d\n", ret);
+
+    return;
+#else
     const char *env_state_path = getenv("XDG_STATE_HOME");
     const char *openrtx        = "/OpenRTX/";
 
@@ -135,6 +154,7 @@ void nvm_init()
 toolong:
     printf("Expected path was too long\n");
     exit(1);
+#endif // __EMSCRIPTEN__
 }
 
 void nvm_terminate()

--- a/platform/targets/linux/emulator/emulator.c
+++ b/platform/targets/linux/emulator/emulator.c
@@ -11,8 +11,12 @@
 #include <string.h>
 #include "SDL2/SDL.h"
 
+#ifndef __EMSCRIPTEN__
 #include "readline/readline.h"
 #include "readline/history.h"
+#else
+#include <emscripten.h>
+#endif
 
 #include "emulator.h"
 #include "sdl_engine.h"
@@ -463,6 +467,35 @@ static int process_line(char *line)
     }
 }
 
+#ifdef __EMSCRIPTEN__
+/*
+ * Browser builds have no terminal or stdin, so the GNU readline command shell
+ * is replaced by a JS->C bridge. emulator_command() runs a single shell line
+ * (the same grammar the readline loop fed to process_line) and is exported to
+ * JavaScript via EMSCRIPTEN_KEEPALIVE, so the page can drive scripted
+ * keypresses, screenshots, etc. The command infrastructure below (process_line
+ * and the _options table) is shared with the native readline path.
+ */
+EMSCRIPTEN_KEEPALIVE
+int emulator_command(const char *line)
+{
+    if(line == NULL)
+        return SH_WHAT;
+
+    // process_line() tokenises in place, so operate on a mutable copy.
+    char *copy = strdup(line);
+    if(copy == NULL)
+        return SH_ERR;
+
+    int ret = process_line(copy);
+    free(copy);
+
+    if(ret == SH_EXIT_OK)
+        emulator_state.powerOff = true;
+
+    return ret;
+}
+#else
 void *startCLIMenu(void *arg)
 {
     (void) arg;
@@ -529,6 +562,7 @@ void *startCLIMenu(void *arg)
 
     return NULL;
 }
+#endif // __EMSCRIPTEN__
 
 
 
@@ -536,6 +570,9 @@ void emulator_start()
 {
     sdlEngine_init();
 
+#ifndef __EMSCRIPTEN__
+    // The readline command shell runs on its own thread. Browser builds drive
+    // commands through emulator_command() instead (see above).
     pthread_t cli_thread;
     int err = pthread_create(&cli_thread, NULL, startCLIMenu, NULL);
 
@@ -543,6 +580,7 @@ void emulator_start()
     {
         printf("An error occurred starting the emulator CLI thread: %d\n", err);
     }
+#endif
 }
 
 keyboard_t emulator_getKeys()

--- a/platform/targets/wasm/README.md
+++ b/platform/targets/wasm/README.md
@@ -1,0 +1,88 @@
+<!--
+SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
+# OpenRTX WebAssembly emulator
+
+A browser build of the OpenRTX Linux emulator, compiled to WebAssembly with
+[Emscripten](https://emscripten.org/). It runs the exact same firmware core, UI,
+and M17/FM DSP as the native `linux` target — only the platform edges (terminal
+CLI, filesystem paths) are adapted for the browser.
+
+## How it works
+
+The emulator is built on POSIX threads that share state through mutexes,
+condition variables, and a hand-rolled channel (`openrtx/src/core/chan.c`).
+Rather than rewrite that concurrency model, the WASM build maps it onto
+Emscripten's pthreads (Web Workers backed by a `SharedArrayBuffer`) and uses
+**`-sPROXY_TO_PTHREAD`**, which runs `main()` on a worker. The browser's main
+thread stays free for the event loop and for SDL2 rendering, so the existing
+blocking loops in `threads.c` / `sdl_engine.c` keep working unchanged.
+
+Two edges are adapted (both guarded by `#ifdef __EMSCRIPTEN__`):
+
+- **CLI** — the native build runs a GNU readline shell on its own thread. The
+  browser has no terminal, so `emulator.c` exports `emulator_command()` to
+  JavaScript instead; the page's command box feeds lines straight into the same
+  `process_line()` grammar (screenshots, scripted keypresses, etc.).
+- **NVM** — `nvmem_linux.c` has no `$HOME`/XDG dirs in the browser, so radio
+  state is stored at `/persist/state.bin` in the Emscripten virtual filesystem.
+  The codeplug is created on first run via the existing `cps_create()` path.
+
+## Prerequisites
+
+Install and activate the [Emscripten SDK](https://emscripten.org/docs/getting_started/downloads.html):
+
+```sh
+git clone https://github.com/emscripten-core/emsdk.git
+cd emsdk && ./emsdk install latest && ./emsdk activate latest
+source ./emsdk_env.sh          # puts emcc/em++ on PATH
+```
+
+You also need `meson` and `ninja`.
+
+## Build
+
+From the repository root:
+
+```sh
+meson setup build_wasm --cross-file cross_wasm.txt
+ninja -C build_wasm wasm
+```
+
+This produces `build_wasm/openrtx_wasm.html`, `openrtx_wasm.js`,
+`openrtx_wasm.wasm`, and `openrtx_wasm.worker.js`.
+
+## Run
+
+WebAssembly threads require a
+[cross-origin-isolated](https://web.dev/coop-coep/) page, i.e. the
+`Cross-Origin-Opener-Policy` and `Cross-Origin-Embedder-Policy` response
+headers. A plain file:// open or a vanilla static server will **not** work.
+Use the bundled dev server, which sets those headers:
+
+```sh
+python scripts/serve_wasm.py build_wasm
+# then open http://localhost:8000/openrtx_wasm.html
+```
+
+Click the screen to give the canvas keyboard focus. Arrow keys navigate,
+`Enter` selects, `Esc` goes back, `0`–`9` are the keypad, `PgUp`/`PgDn` turn the
+knob, `M` is monitor.
+
+## Status / known limitations
+
+This is an initial port focused on getting the UI running in the browser.
+
+- **Persistence is ephemeral.** State lives in MEMFS and is lost on reload.
+  Mounting IDBFS at `/persist` (in `Module.preRun`) plus periodic `FS.syncfs`
+  would persist it — deferred, as IDBFS interacts awkwardly with
+  `PROXY_TO_PTHREAD`.
+- **No live audio.** The Linux target has no real audio backend (audio is
+  file-based); Web Audio integration for M17/FM monitoring is a follow-up.
+- **Busy-wait render loop.** `sdlEngine_run()` polls without yielding (as it
+  does natively); on a worker this pegs a core. A small `SDL_Delay` would be
+  gentler in the browser.
+- The `codec2` subproject is compiled from source under emcc; if it needs
+  toolchain tweaks they are independent of this target.

--- a/platform/targets/wasm/shell.html
+++ b/platform/targets/wasm/shell.html
@@ -1,0 +1,126 @@
+<!doctype html>
+<!--
+  SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+  SPDX-License-Identifier: GPL-3.0-or-later
+
+  Emscripten shell for the OpenRTX browser emulator. Emscripten substitutes the
+  compiled JS at the {{{ SCRIPT }}} marker below. The SDL2 renderer draws into
+  the <canvas id="canvas"> element.
+
+  This page MUST be served with cross-origin isolation headers so the
+  SharedArrayBuffer that backs pthreads is available:
+      Cross-Origin-Opener-Policy: same-origin
+      Cross-Origin-Embedder-Policy: require-corp
+  Use scripts/serve_wasm.py, which sets them for you.
+-->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>OpenRTX (WebAssembly)</title>
+  <style>
+    :root { color-scheme: light dark; }
+    body {
+      font-family: system-ui, sans-serif;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 1rem;
+      padding: 1.5rem 1rem;
+      background: #111;
+      color: #eee;
+    }
+    h1 { font-size: 1.1rem; font-weight: 600; margin: 0; letter-spacing: .04em; }
+    #canvas {
+      /* The radio screen is tiny (160x128); scale it up with crisp pixels. */
+      image-rendering: pixelated;
+      width: 480px;
+      height: 384px;
+      background: #000;
+      border: 1px solid #333;
+      border-radius: 6px;
+    }
+    .hint { font-size: .8rem; color: #999; max-width: 480px; text-align: center; }
+    kbd {
+      background: #222; border: 1px solid #444; border-radius: 3px;
+      padding: 0 .3em; font-size: .85em;
+    }
+    #cli { display: flex; gap: .4rem; width: 480px; }
+    #cli input {
+      flex: 1; background: #000; color: #0f0; border: 1px solid #333;
+      border-radius: 4px; padding: .4rem; font-family: monospace;
+    }
+    #output {
+      width: 480px; height: 120px; overflow-y: auto; background: #000;
+      color: #9f9; border: 1px solid #333; border-radius: 4px;
+      padding: .4rem; font-family: monospace; font-size: .78rem;
+      white-space: pre-wrap; margin: 0;
+    }
+    #status { font-size: .8rem; color: #fa0; min-height: 1em; }
+  </style>
+</head>
+<body>
+  <h1>OpenRTX &middot; WebAssembly emulator</h1>
+
+  <!-- SDL2 draws here. tabindex makes the canvas keyboard-focusable. -->
+  <canvas id="canvas" tabindex="-1" oncontextmenu="event.preventDefault()"></canvas>
+
+  <div class="hint">
+    Click the screen, then use the keyboard:
+    <kbd>&uarr;</kbd><kbd>&darr;</kbd><kbd>&larr;</kbd><kbd>&rarr;</kbd> navigate &middot;
+    <kbd>Enter</kbd> select &middot; <kbd>Esc</kbd> back &middot;
+    <kbd>0</kbd>&ndash;<kbd>9</kbd> keypad &middot;
+    <kbd>PgUp</kbd>/<kbd>PgDn</kbd> knob &middot; <kbd>M</kbd> monitor
+  </div>
+
+  <div id="status">Loading&hellip;</div>
+
+  <!-- Bridge to the native command shell (replaces GNU readline). -->
+  <form id="cli" onsubmit="return sendCommand();">
+    <input id="cliInput" type="text" placeholder="emulator command (e.g. 'help', 'screenshot shot.bmp')" autocomplete="off">
+    <button type="submit">Run</button>
+  </form>
+  <pre id="output"></pre>
+
+  <script>
+    const outputEl = document.getElementById('output');
+    const statusEl = document.getElementById('status');
+
+    function log(text) {
+      outputEl.textContent += text + '\n';
+      outputEl.scrollTop = outputEl.scrollHeight;
+    }
+
+    // Runs one line through the native emulator command shell. Exported from C
+    // as emulator_command() via EMSCRIPTEN_KEEPALIVE.
+    function sendCommand() {
+      const input = document.getElementById('cliInput');
+      const cmd = input.value.trim();
+      if (cmd && Module && Module.ccall) {
+        try {
+          const ret = Module.ccall('emulator_command', 'number', ['string'], [cmd]);
+          log('> ' + cmd + '  (=> ' + ret + ')');
+        } catch (e) {
+          log('command failed: ' + e);
+        }
+      }
+      input.value = '';
+      return false; // never submit the form
+    }
+
+    var Module = {
+      canvas: document.getElementById('canvas'),
+      print: (t) => log(t),
+      printErr: (t) => log(t),
+      setStatus: (t) => { statusEl.textContent = t; },
+      onRuntimeInitialized: () => {
+        statusEl.textContent = '';
+        document.getElementById('canvas').focus();
+      },
+    };
+  </script>
+
+  {{{ SCRIPT }}}
+</body>
+</html>

--- a/scripts/serve_wasm.py
+++ b/scripts/serve_wasm.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+#
+# SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# Minimal static file server for the OpenRTX WebAssembly build.
+#
+# pthreads in the browser are backed by a SharedArrayBuffer, which the browser
+# only exposes to cross-origin-isolated pages. That requires two response
+# headers that Python's default http.server does not send:
+#
+#     Cross-Origin-Opener-Policy:   same-origin
+#     Cross-Origin-Embedder-Policy: require-corp
+#
+# This server adds them (and the correct .wasm MIME type) so the emulator can
+# actually spin up its worker threads.
+#
+# Usage:
+#     python scripts/serve_wasm.py [build_dir] [--port N]
+#
+# then open http://localhost:8000/openrtx_wasm.html
+
+import argparse
+import functools
+import http.server
+import os
+import socketserver
+
+
+class IsolatedHandler(http.server.SimpleHTTPRequestHandler):
+    """Serves files with the cross-origin isolation headers pthreads need."""
+
+    extensions_map = {
+        **http.server.SimpleHTTPRequestHandler.extensions_map,
+        ".wasm": "application/wasm",
+        ".js": "text/javascript",
+    }
+
+    def end_headers(self):
+        self.send_header("Cross-Origin-Opener-Policy", "same-origin")
+        self.send_header("Cross-Origin-Embedder-Policy", "require-corp")
+        # Emscripten output is regenerated on every build; don't cache it.
+        self.send_header("Cache-Control", "no-store")
+        super().end_headers()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("directory", nargs="?", default="build_wasm",
+                        help="directory to serve (default: build_wasm)")
+    parser.add_argument("--port", type=int, default=8000, help="TCP port")
+    args = parser.parse_args()
+
+    directory = os.path.abspath(args.directory)
+    handler = functools.partial(IsolatedHandler, directory=directory)
+
+    with socketserver.ThreadingTCPServer(("", args.port), handler) as httpd:
+        print(f"Serving {directory} at http://localhost:{args.port}/")
+        print(f"Open   http://localhost:{args.port}/openrtx_wasm.html")
+        print("Press Ctrl+C to stop.")
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            print("\nStopped.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Adds a **browser build of the Linux emulator**, compiled to WebAssembly with Emscripten. The full firmware core, UI, and M17/FM DSP compile unchanged — only the platform edges are adapted, all behind `#ifdef __EMSCRIPTEN__`.

## Approach — Option A (pthreads + `PROXY_TO_PTHREAD`)

The emulator is built on POSIX threads sharing state through mutexes, condition variables, and a hand-rolled channel (`core/chan.c`). Rather than rewrite that model, this maps it onto Emscripten's pthreads (Web Workers + `SharedArrayBuffer`) and uses `-sPROXY_TO_PTHREAD` to run `main()` on a worker. The browser's main thread stays free for the event loop and SDL2 rendering, so the existing blocking loops in `threads.c` / `sdl_engine.c` keep working as-is.

## Changes

| File | Change |
|---|---|
| `meson.build` | New `wasm` target, **gated on the emscripten cross file** so native/embedded builds are untouched. Uses Emscripten's bundled SDL2 + pthreads. |
| `cross_wasm.txt` | emcc/em++ toolchain description. |
| `platform/targets/linux/emulator/emulator.c` | Compile out the GNU readline CLI thread (no terminal in a browser); export `emulator_command()` to JS as a bridge into the same `process_line()` grammar. |
| `platform/drivers/NVM/nvmem_linux.c` | No `$HOME`/XDG in a browser — persist radio state at `/persist/state.bin` in the Emscripten FS. |
| `platform/targets/wasm/shell.html` | Canvas + command-box page shell. |
| `scripts/serve_wasm.py` | Dev server that sets the COOP/COEP headers `SharedArrayBuffer` requires. |
| `platform/targets/wasm/README.md` | Build/run instructions and known limitations. |

## Build & run

```sh
meson setup build_wasm --cross-file cross_wasm.txt
ninja -C build_wasm wasm
python scripts/serve_wasm.py build_wasm   # open http://localhost:8000/openrtx_wasm.html
```

## Verification

- ✅ Native `meson setup` + `ninja openrtx_linux` still build and link cleanly (guarded edits don't affect the native path).
- ✅ The gated wasm block was syntax-validated by forcing the gate and confirming the `openrtx_wasm.html` target registers with the correct sources.
- ⚠️ **Not compiled with emcc** — the Emscripten SDK isn't available in the authoring environment. First build on a machine with emcc may surface minor toolchain fixes (SDL2 header path, codec2 subproject flags, exceptions).

## Known limitations (follow-ups)

- Persistence is ephemeral (MEMFS); IDBFS at `/persist` would survive reloads.
- No live audio yet (the Linux target has no real audio backend; Web Audio is a later phase).
- `sdlEngine_run()` busy-polls (as it does natively); a small `SDL_Delay` would be gentler on a worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)