### PR TITLE
Add audio sink on linux

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -341,12 +341,14 @@ linux_src = ['platform/targets/linux/emulator/emulator.c',
              'platform/drivers/baseband/radio_linux.cpp',
              'platform/drivers/audio/audio_linux.c',
              'platform/drivers/audio/file_source.c',
+             'platform/drivers/audio/audio_sdl.cpp',
              'platform/targets/linux/platform.c',
              'platform/drivers/CPS/cps_io_libc.c',
              'platform/drivers/NVM/posix_file.c']
 
 linux_inc = ['platform/targets/linux',
-             'platform/targets/linux/emulator']
+             'platform/targets/linux/emulator',
+             'platform/drivers/audio']
 
 linux_def = {'PLATFORM_LINUX': '', 'VP_USE_FILESYSTEM':''}
 

--- a/meson.build
+++ b/meson.build
@@ -343,12 +343,14 @@ linux_src = ['platform/targets/linux/emulator/emulator.c',
              'platform/drivers/audio/file_source.c',
              'platform/drivers/audio/audio_sdl.cpp',
              'platform/targets/linux/platform.c',
+             'platform/drivers/tones/toneGenerator_sdl.cpp',
              'platform/drivers/CPS/cps_io_libc.c',
              'platform/drivers/NVM/posix_file.c']
 
 linux_inc = ['platform/targets/linux',
              'platform/targets/linux/emulator',
-             'platform/drivers/audio']
+             'platform/drivers/audio',
+             'platform/drivers/tones']
 
 linux_def = {'PLATFORM_LINUX': '', 'VP_USE_FILESYSTEM':''}
 

--- a/openrtx/include/interfaces/audio.h
+++ b/openrtx/include/interfaces/audio.h
@@ -20,33 +20,29 @@ extern "C" {
  * audio driver.
  */
 
-enum AudioSource
-{
-    SOURCE_MIC = 0,    ///< Receive audio signal from the microphone
-    SOURCE_RTX = 1,    ///< Receive audio signal from the transceiver
-    SOURCE_MCU = 2     ///< Receive audio signal from a memory buffer
+enum AudioSource {
+    SOURCE_MIC = 0, ///< Receive audio signal from the microphone
+    SOURCE_RTX = 1, ///< Receive audio signal from the transceiver
+    SOURCE_MCU = 2  ///< Receive audio signal from a memory buffer
 };
 
-enum AudioSink
-{
-    SINK_SPK = 0,      ///< Send audio signal to the speaker
-    SINK_RTX = 1,      ///< Send audio signal to the transceiver
-    SINK_MCU = 2       ///< Send audio signal to a memory buffer
+enum AudioSink {
+    SINK_SPK = 0, ///< Send audio signal to the speaker
+    SINK_RTX = 1, ///< Send audio signal to the transceiver
+    SINK_MCU = 2  ///< Send audio signal to a memory buffer
 };
 
-enum AudioPriority
-{
-    PRIO_BEEP = 1,     ///< Priority level of system beeps
-    PRIO_RX,           ///< Priority level of incoming audio from RX stage
-    PRIO_PROMPT,       ///< Priority level of voice prompts
-    PRIO_TX            ///< Priority level of outward audio directed to TX stage
+enum AudioPriority {
+    PRIO_BEEP = 1, ///< Priority level of system beeps
+    PRIO_RX,       ///< Priority level of incoming audio from RX stage
+    PRIO_PROMPT,   ///< Priority level of voice prompts
+    PRIO_TX        ///< Priority level of outward audio directed to TX stage
 };
 
-enum BufMode
-{
-    BUF_LINEAR = 1,    ///< Linear buffer mode, conversion stops when full.
-    BUF_CIRC_DOUBLE    ///< Circular double buffer mode, conversion never stops,
-                       ///  thread woken up whenever half of the buffer is full.
+enum BufMode {
+    BUF_LINEAR = 1, ///< Linear buffer mode, conversion stops when full.
+    BUF_CIRC_DOUBLE ///< Circular double buffer mode, conversion never stops,
+                    ///  thread woken up whenever half of the buffer is full.
 };
 
 typedef int16_t stream_sample_t;
@@ -55,23 +51,20 @@ typedef int16_t stream_sample_t;
  * Data structure for audio stream context, to be used to configure audio
  * devices.
  */
-struct streamCtx
-{
-    void            *priv;       ///< Pointer to audio device private data.
-    stream_sample_t *buffer;     ///< Pointer to audio data buffer.
-    size_t           bufSize;    ///< Size of the audio data buffer, in elements.
-    uint8_t          bufMode;    ///< Buffer handling mode, linear or circular double.
-    uint32_t         sampleRate; ///< Sample rate, in Hz.
-    uint8_t          running;    ///< Audio device status, set to 1 when active.
-}
-__attribute__((packed));
+struct streamCtx {
+    void *priv;              ///< Pointer to audio device private data.
+    stream_sample_t *buffer; ///< Pointer to audio data buffer.
+    size_t bufSize;          ///< Size of the audio data buffer, in elements.
+    uint8_t bufMode;     ///< Buffer handling mode, linear or circular double.
+    uint32_t sampleRate; ///< Sample rate, in Hz.
+    uint8_t running;     ///< Audio device status, set to 1 when active.
+} __attribute__((packed));
 
 /**
  * Driver interface for a generic audio device, either an input or output device,
  * bound to a specific input.
  */
-struct audioDriver
-{
+struct audioDriver {
     /**
      * Start an audio stream to or from the device.
      *
@@ -80,7 +73,8 @@ struct audioDriver
      * @param ctx: pointer to audio stream context.
      * @return zero on success, a negative error code on failure.
      */
-    int (*start)(const uint8_t instance, const void *config, struct streamCtx *ctx);
+    int (*start)(const uint8_t instance, const void *config,
+                 struct streamCtx *ctx);
 
     /**
      * Get a pointer to the "free" data section, when running in circular double
@@ -126,14 +120,12 @@ struct audioDriver
  * Audio device descriptor, grouping an audio driver, its configuration and
  * its input/output endpoint.
  */
-struct audioDevice
-{
-    const struct audioDriver *driver;    ///< Audio driver functions
-    const void               *config;    ///< Driver configuration
-    const uint8_t             instance;  ///< Driver instance number
-    const uint8_t             endpoint;  ///< Driver sink or source endpoint
-}
-__attribute__((packed));
+struct audioDevice {
+    const struct audioDriver *driver; ///< Audio driver functions
+    const void *config;               ///< Driver configuration
+    const uint8_t instance;           ///< Driver instance number
+    const uint8_t endpoint;           ///< Driver sink or source endpoint
+} __attribute__((packed, aligned(8)));
 
 extern const struct audioDevice inputDevices[];
 extern const struct audioDevice outputDevices[];
@@ -174,9 +166,9 @@ void audio_disconnect(const enum AudioSource source, const enum AudioSink sink);
  * @param p2Sink: identifier of the output audio peripheral of the second path.
  */
 bool audio_checkPathCompatibility(const enum AudioSource p1Source,
-                                  const enum AudioSink   p1Sink,
+                                  const enum AudioSink p1Sink,
                                   const enum AudioSource p2Source,
-                                  const enum AudioSink   p2Sink);
+                                  const enum AudioSink p2Sink);
 
 #ifdef __cplusplus
 }

--- a/platform/drivers/audio/audio_linux.c
+++ b/platform/drivers/audio/audio_linux.c
@@ -7,101 +7,121 @@
 #include "interfaces/audio.h"
 #include "hwconfig.h"
 #include "file_source.h"
+#include "audio_sdl.h"
 
-static const uint8_t pathCompatibilityMatrix[9][9] =
-{
+static const uint8_t pathCompatibilityMatrix[9][9] = {
     // MIC-SPK MIC-RTX MIC-MCU RTX-SPK RTX-RTX RTX-MCU MCU-SPK MCU-RTX MCU-MCU
-    {    0   ,   0   ,   0   ,   1   ,   0   ,   1   ,   1   ,   0   ,   1   },  // MIC-RTX
-    {    0   ,   0   ,   0   ,   0   ,   1   ,   1   ,   0   ,   1   ,   1   },  // MIC-SPK
-    {    0   ,   0   ,   0   ,   1   ,   1   ,   0   ,   1   ,   1   ,   0   },  // MIC-MCU
-    {    0   ,   1   ,   1   ,   0   ,   0   ,   0   ,   0   ,   1   ,   1   },  // RTX-SPK
-    {    1   ,   0   ,   1   ,   0   ,   0   ,   0   ,   1   ,   0   ,   1   },  // RTX-RTX
-    {    1   ,   1   ,   0   ,   0   ,   0   ,   0   ,   1   ,   1   ,   0   },  // RTX-MCU
-    {    0   ,   1   ,   1   ,   0   ,   1   ,   1   ,   0   ,   0   ,   0   },  // MCU-SPK
-    {    1   ,   0   ,   1   ,   1   ,   0   ,   1   ,   0   ,   0   ,   0   },  // MCU-RTX
-    {    1   ,   1   ,   0   ,   1   ,   1   ,   0   ,   0   ,   0   ,   0   }   // MCU-MCU
+    { 0, 0, 0, 1, 0, 1, 1, 0, 1 }, // MIC-RTX
+    { 0, 0, 0, 0, 1, 1, 0, 1, 1 }, // MIC-SPK
+    { 0, 0, 0, 1, 1, 0, 1, 1, 0 }, // MIC-MCU
+    { 0, 1, 1, 0, 0, 0, 0, 1, 1 }, // RTX-SPK
+    { 1, 0, 1, 0, 0, 0, 1, 0, 1 }, // RTX-RTX
+    { 1, 1, 0, 0, 0, 0, 1, 1, 0 }, // RTX-MCU
+    { 0, 1, 1, 0, 1, 1, 0, 0, 0 }, // MCU-SPK
+    { 1, 0, 1, 1, 0, 1, 0, 0, 0 }, // MCU-RTX
+    { 1, 1, 0, 1, 1, 0, 0, 0, 0 }  // MCU-MCU
 };
 
-const struct audioDevice outputDevices[] =
-{
-    {NULL, 0, 0, SINK_MCU},
-    {NULL, 0, 0, SINK_RTX},
-    {NULL, 0, 0, SINK_SPK},
+const struct audioDevice outputDevices[] = {
+    { NULL, 0, 0, SINK_MCU },
+    { NULL, 0, 0, SINK_RTX },
+    { &sdl_play_audio_driver, NULL, 0, SINK_SPK },
 };
 
-const struct audioDevice inputDevices[] =
-{
-    {NULL,                      0,                   0, SOURCE_MCU},
-    {&file_source_audio_driver, "/tmp/baseband.raw", 0, SOURCE_RTX},
-    {NULL,                      0,                   0, SOURCE_MIC},
+const struct audioDevice inputDevices[] = {
+    { NULL, 0, 0, SOURCE_MCU },
+    { &file_source_audio_driver, "/tmp/baseband.raw", 0, SOURCE_RTX },
+    { NULL, 0, 0, SOURCE_MIC },
 };
 
 void audio_init()
 {
-
 }
 
 void audio_terminate()
 {
-
 }
 
 void audio_connect(const enum AudioSource source, const enum AudioSink sink)
 {
-    #ifdef VERBOSE
+#ifdef VERBOSE
     printf("Connect ");
-    switch(source)
-    {
-        case SOURCE_MIC: printf("MIC"); break;
-        case SOURCE_RTX: printf("RTX"); break;
-        case SOURCE_MCU: printf("MCU"); break;
-        default:                        break;
+    switch (source) {
+        case SOURCE_MIC:
+            printf("MIC");
+            break;
+        case SOURCE_RTX:
+            printf("RTX");
+            break;
+        case SOURCE_MCU:
+            printf("MCU");
+            break;
+        default:
+            break;
     }
 
     printf(" with ");
-    switch(sink)
-    {
-        case SINK_SPK: printf("SPK\n"); break;
-        case SINK_RTX: printf("RTX\n"); break;
-        case SINK_MCU: printf("MCU\n"); break;
-        default:                        break;
+    switch (sink) {
+        case SINK_SPK:
+            printf("SPK\n");
+            break;
+        case SINK_RTX:
+            printf("RTX\n");
+            break;
+        case SINK_MCU:
+            printf("MCU\n");
+            break;
+        default:
+            break;
     }
-    #else
-    (void) source;
-    (void) sink;
-    #endif
+#else
+    (void)source;
+    (void)sink;
+#endif
 }
 
 void audio_disconnect(const enum AudioSource source, const enum AudioSink sink)
 {
-    #ifdef VERBOSE
+#ifdef VERBOSE
     printf("Disconnect ");
-    switch(source)
-    {
-        case SOURCE_MIC: printf("MIC"); break;
-        case SOURCE_RTX: printf("RTX"); break;
-        case SOURCE_MCU: printf("MCU"); break;
-        default:                        break;
+    switch (source) {
+        case SOURCE_MIC:
+            printf("MIC");
+            break;
+        case SOURCE_RTX:
+            printf("RTX");
+            break;
+        case SOURCE_MCU:
+            printf("MCU");
+            break;
+        default:
+            break;
     }
 
     printf(" from ");
-    switch(sink)
-    {
-        case SINK_SPK: printf("SPK\n"); break;
-        case SINK_RTX: printf("RTX\n"); break;
-        case SINK_MCU: printf("MCU\n"); break;
-        default:                        break;
+    switch (sink) {
+        case SINK_SPK:
+            printf("SPK\n");
+            break;
+        case SINK_RTX:
+            printf("RTX\n");
+            break;
+        case SINK_MCU:
+            printf("MCU\n");
+            break;
+        default:
+            break;
     }
-    #else
-    (void) source;
-    (void) sink;
-    #endif
+#else
+    (void)source;
+    (void)sink;
+#endif
 }
 
 bool audio_checkPathCompatibility(const enum AudioSource p1Source,
-                                  const enum AudioSink   p1Sink,
+                                  const enum AudioSink p1Sink,
                                   const enum AudioSource p2Source,
-                                  const enum AudioSink   p2Sink)
+                                  const enum AudioSink p2Sink)
 
 {
     uint8_t p1Index = (p1Source * 3) + p1Sink;

--- a/platform/drivers/audio/audio_sdl.cpp
+++ b/platform/drivers/audio/audio_sdl.cpp
@@ -1,0 +1,308 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <stdlib.h>
+#include <math.h>
+#include <errno.h>
+#include <pthread.h>
+#include "SDL2/SDL.h"
+#include "audio_sdl.h"
+
+/*
+ * The playback driver uses the SDL queue API rather than an audio callback: the
+ * callback model would fire on an SDL-owned thread (and, under Emscripten's
+ * PROXY_TO_PTHREAD, on the wrong side of the worker/main-thread split), whereas
+ * SDL_QueueAudio maps cleanly onto the blocking data()/sync() contract expected
+ * by the stream manager.
+ */
+
+// Number of extra queued chunks tolerated before a playback sync() blocks. Keeps
+// output latency bounded to a few audio periods.
+#define PLAY_QUEUE_SLACK 2
+
+// Upper bound on the playback drain loops, in ms. Comfortably above any real
+// drain time, but ensures a suspended device (e.g. an Emscripten audio context
+// awaiting a user gesture) cannot block the producing thread forever.
+#define PLAY_DRAIN_TIMEOUT_MS 2000
+
+/*
+ * SDL's audio subsystem is initialised exactly once for the whole process:
+ * either the playback or the beep path can be the first to touch audio, and they
+ * run on different threads, so the init must be race-free. pthread_once gives us
+ * that; the subsystem is intentionally never de-initialised, matching the
+ * process-lifetime nature of the audio devices.
+ */
+static pthread_once_t sdlAudioOnce = PTHREAD_ONCE_INIT;
+static int sdlAudioReady = 0;
+
+static void sdlAudioInit(void)
+{
+    sdlAudioReady = (SDL_InitSubSystem(SDL_INIT_AUDIO) == 0) ? 1 : 0;
+}
+
+struct sdlPlayState {
+    SDL_AudioDeviceID dev;
+    int idleHalf;
+};
+
+/**
+ * \internal
+ * Open the SDL playback device in the stream's format. allowed_changes is 0 so
+ * SDL hands us exactly the requested format and performs any rate/format
+ * conversion to the underlying hardware internally.
+ */
+static SDL_AudioDeviceID openDevice(const struct streamCtx *ctx)
+{
+    pthread_once(&sdlAudioOnce, sdlAudioInit);
+    if (sdlAudioReady == 0)
+        return 0;
+
+    SDL_AudioSpec want;
+    SDL_AudioSpec have;
+    SDL_zero(want);
+    want.freq = (int)ctx->sampleRate;
+    want.format = AUDIO_S16SYS;
+    want.channels = 1;
+    want.samples = 256;
+
+    return SDL_OpenAudioDevice(NULL, 0, &want, &have, 0);
+}
+
+static int sdlPlay_start(const uint8_t instance, const void *config,
+                         struct streamCtx *ctx)
+{
+    (void)instance;
+    (void)config;
+
+    if (ctx == NULL)
+        return -EINVAL;
+
+    if (ctx->running != 0)
+        return -EBUSY;
+
+    struct sdlPlayState *state =
+        static_cast<struct sdlPlayState *>(malloc(sizeof(struct sdlPlayState)));
+    if (state == NULL)
+        return -ENOMEM;
+
+    state->dev = openDevice(ctx);
+    if (state->dev == 0) {
+        free(state);
+        return -EIO;
+    }
+
+    state->idleHalf = 0;
+    ctx->priv = state;
+    ctx->running = 1;
+    SDL_PauseAudioDevice(state->dev, 0);
+
+    return 0;
+}
+
+static int sdlPlay_data(struct streamCtx *ctx, stream_sample_t **buf)
+{
+    if (ctx->running == 0)
+        return -1;
+
+    struct sdlPlayState *state = (struct sdlPlayState *)ctx->priv;
+    size_t size = ctx->bufSize;
+    if (ctx->bufMode == BUF_CIRC_DOUBLE)
+        size /= 2;
+
+    *buf = ctx->buffer + (state->idleHalf * size);
+
+    return (int)size;
+}
+
+static int sdlPlay_sync(struct streamCtx *ctx, uint8_t dirty)
+{
+    if (ctx->running == 0)
+        return -1;
+
+    struct sdlPlayState *state = (struct sdlPlayState *)ctx->priv;
+    size_t size = ctx->bufSize;
+    if (ctx->bufMode == BUF_CIRC_DOUBLE)
+        size /= 2;
+
+    Uint32 bytes = (Uint32)(size * sizeof(stream_sample_t));
+
+    if (dirty != 0) {
+        stream_sample_t *half = ctx->buffer + (state->idleHalf * size);
+        SDL_QueueAudio(state->dev, half, bytes);
+
+        // Only double-buffered mode alternates halves; in linear mode the idle
+        // half is always the (single) buffer, so leaving idleHalf at 0 keeps
+        // data() from indexing one buffer past the end.
+        if (ctx->bufMode == BUF_CIRC_DOUBLE)
+            state->idleHalf ^= 1;
+    }
+
+    // Block until the queued audio drains back below the slack threshold. This
+    // paces the producing thread to the audio device, mirroring how a hardware
+    // driver blocks on its DMA syncpoint. Bounded so a stalled device cannot
+    // wedge the producer indefinitely.
+    int guard = 0;
+    while ((SDL_GetQueuedAudioSize(state->dev) > (PLAY_QUEUE_SLACK * bytes))
+           && (guard < PLAY_DRAIN_TIMEOUT_MS)) {
+        SDL_Delay(1);
+        guard += 1;
+    }
+
+    return 0;
+}
+
+static void sdlPlay_stop(struct streamCtx *ctx)
+{
+    if (ctx->running == 0)
+        return;
+
+    struct sdlPlayState *state = (struct sdlPlayState *)ctx->priv;
+
+    // Graceful stop: let the already-queued tail play out before closing, but
+    // bound the wait so a suspended device does not hang the caller. On timeout
+    // we fall through and close anyway, dropping whatever remains queued.
+    int guard = 0;
+    while ((SDL_GetQueuedAudioSize(state->dev) > 0)
+           && (guard < PLAY_DRAIN_TIMEOUT_MS)) {
+        SDL_Delay(1);
+        guard += 1;
+    }
+
+    SDL_CloseAudioDevice(state->dev);
+    free(state);
+    ctx->priv = NULL;
+    ctx->running = 0;
+}
+
+static void sdlPlay_halt(struct streamCtx *ctx)
+{
+    if (ctx->running == 0)
+        return;
+
+    struct sdlPlayState *state = (struct sdlPlayState *)ctx->priv;
+
+    SDL_ClearQueuedAudio(state->dev);
+    SDL_CloseAudioDevice(state->dev);
+    free(state);
+    ctx->priv = NULL;
+    ctx->running = 0;
+}
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Wc++20-extensions"
+const struct audioDriver sdl_play_audio_driver = {
+    .start = sdlPlay_start,
+    .data = sdlPlay_data,
+    .sync = sdlPlay_sync,
+    .stop = sdlPlay_stop,
+    .terminate = sdlPlay_halt,
+};
+#pragma GCC diagnostic pop
+
+/*
+ * Beep tone generator. Beeps are a path separate from the SINK_SPK stream
+ * (platform_beepStart/Stop), so they get their own persistent device driven by
+ * a dedicated thread that synthesizes a phase-continuous sine wave.
+ */
+
+#define BEEP_RATE 48000
+#define BEEP_CHUNK (BEEP_RATE / 50) // 20 ms of samples
+#define BEEP_AMPLITUDE 8000
+
+static pthread_t beepThread;
+static pthread_once_t beepOnce = PTHREAD_ONCE_INIT;
+static pthread_mutex_t beepMutex = PTHREAD_MUTEX_INITIALIZER;
+static int beepActive = 0;
+static uint16_t beepFreq = 0;
+
+static void *beepThreadFunc(void *arg)
+{
+    (void)arg;
+
+    pthread_once(&sdlAudioOnce, sdlAudioInit);
+    if (sdlAudioReady == 0)
+        return NULL;
+
+    SDL_AudioSpec want;
+    SDL_AudioSpec have;
+    SDL_zero(want);
+    want.freq = BEEP_RATE;
+    want.format = AUDIO_S16SYS;
+    want.channels = 1;
+    want.samples = 512;
+
+    SDL_AudioDeviceID dev = SDL_OpenAudioDevice(NULL, 0, &want, &have, 0);
+    if (dev == 0)
+        return NULL;
+
+    stream_sample_t chunk[BEEP_CHUNK];
+    double phase = 0.0;
+    int playing = 0;
+
+    for (;;) {
+        pthread_mutex_lock(&beepMutex);
+        int active = beepActive;
+        uint16_t freq = beepFreq;
+        pthread_mutex_unlock(&beepMutex);
+
+        if (active != 0) {
+            if (playing == 0) {
+                SDL_ClearQueuedAudio(dev);
+                SDL_PauseAudioDevice(dev, 0);
+                playing = 1;
+            }
+
+            double step = (2.0 * M_PI * (double)freq) / (double)BEEP_RATE;
+            for (size_t i = 0; i < BEEP_CHUNK; i++) {
+                chunk[i] = (stream_sample_t)(BEEP_AMPLITUDE * sin(phase));
+                phase += step;
+                if (phase >= (2.0 * M_PI))
+                    phase -= (2.0 * M_PI);
+            }
+
+            Uint32 chunkBytes = (Uint32)sizeof(chunk);
+            while (SDL_GetQueuedAudioSize(dev)
+                   > (PLAY_QUEUE_SLACK * chunkBytes))
+                SDL_Delay(1);
+
+            SDL_QueueAudio(dev, chunk, chunkBytes);
+        } else {
+            if (playing != 0) {
+                SDL_ClearQueuedAudio(dev);
+                SDL_PauseAudioDevice(dev, 1);
+                playing = 0;
+                phase = 0.0;
+            }
+
+            SDL_Delay(5);
+        }
+    }
+
+    return NULL;
+}
+
+static void beepThreadStart(void)
+{
+    pthread_create(&beepThread, NULL, beepThreadFunc, NULL);
+}
+
+void sdlBeep_start(uint16_t freq)
+{
+    pthread_once(&beepOnce, beepThreadStart);
+
+    pthread_mutex_lock(&beepMutex);
+    beepFreq = freq;
+    beepActive = 1;
+    pthread_mutex_unlock(&beepMutex);
+}
+
+void sdlBeep_stop(void)
+{
+    pthread_mutex_lock(&beepMutex);
+    beepActive = 0;
+    pthread_mutex_unlock(&beepMutex);
+}

--- a/platform/drivers/audio/audio_sdl.cpp
+++ b/platform/drivers/audio/audio_sdl.cpp
@@ -5,9 +5,7 @@
  */
 
 #include <stdlib.h>
-#include <math.h>
 #include <errno.h>
-#include <pthread.h>
 #include "SDL2/SDL.h"
 #include "audio_sdl.h"
 
@@ -28,21 +26,6 @@
 // awaiting a user gesture) cannot block the producing thread forever.
 #define PLAY_DRAIN_TIMEOUT_MS 2000
 
-/*
- * SDL's audio subsystem is initialised exactly once for the whole process:
- * either the playback or the beep path can be the first to touch audio, and they
- * run on different threads, so the init must be race-free. pthread_once gives us
- * that; the subsystem is intentionally never de-initialised, matching the
- * process-lifetime nature of the audio devices.
- */
-static pthread_once_t sdlAudioOnce = PTHREAD_ONCE_INIT;
-static int sdlAudioReady = 0;
-
-static void sdlAudioInit(void)
-{
-    sdlAudioReady = (SDL_InitSubSystem(SDL_INIT_AUDIO) == 0) ? 1 : 0;
-}
-
 struct sdlPlayState {
     SDL_AudioDeviceID dev;
     int idleHalf;
@@ -56,10 +39,6 @@ struct sdlPlayState {
  */
 static SDL_AudioDeviceID openDevice(const struct streamCtx *ctx)
 {
-    pthread_once(&sdlAudioOnce, sdlAudioInit);
-    if (sdlAudioReady == 0)
-        return 0;
-
     SDL_AudioSpec want;
     SDL_AudioSpec have;
     SDL_zero(want);
@@ -194,7 +173,7 @@ static void sdlPlay_halt(struct streamCtx *ctx)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"
 #pragma GCC diagnostic ignored "-Wc++20-extensions"
-const struct audioDriver sdl_play_audio_driver = {
+const struct audioDriver sdl_play_audio_driver __attribute__((aligned(8))) = {
     .start = sdlPlay_start,
     .data = sdlPlay_data,
     .sync = sdlPlay_sync,
@@ -202,107 +181,3 @@ const struct audioDriver sdl_play_audio_driver = {
     .terminate = sdlPlay_halt,
 };
 #pragma GCC diagnostic pop
-
-/*
- * Beep tone generator. Beeps are a path separate from the SINK_SPK stream
- * (platform_beepStart/Stop), so they get their own persistent device driven by
- * a dedicated thread that synthesizes a phase-continuous sine wave.
- */
-
-#define BEEP_RATE 48000
-#define BEEP_CHUNK (BEEP_RATE / 50) // 20 ms of samples
-#define BEEP_AMPLITUDE 8000
-
-static pthread_t beepThread;
-static pthread_once_t beepOnce = PTHREAD_ONCE_INIT;
-static pthread_mutex_t beepMutex = PTHREAD_MUTEX_INITIALIZER;
-static int beepActive = 0;
-static uint16_t beepFreq = 0;
-
-static void *beepThreadFunc(void *arg)
-{
-    (void)arg;
-
-    pthread_once(&sdlAudioOnce, sdlAudioInit);
-    if (sdlAudioReady == 0)
-        return NULL;
-
-    SDL_AudioSpec want;
-    SDL_AudioSpec have;
-    SDL_zero(want);
-    want.freq = BEEP_RATE;
-    want.format = AUDIO_S16SYS;
-    want.channels = 1;
-    want.samples = 512;
-
-    SDL_AudioDeviceID dev = SDL_OpenAudioDevice(NULL, 0, &want, &have, 0);
-    if (dev == 0)
-        return NULL;
-
-    stream_sample_t chunk[BEEP_CHUNK];
-    double phase = 0.0;
-    int playing = 0;
-
-    for (;;) {
-        pthread_mutex_lock(&beepMutex);
-        int active = beepActive;
-        uint16_t freq = beepFreq;
-        pthread_mutex_unlock(&beepMutex);
-
-        if (active != 0) {
-            if (playing == 0) {
-                SDL_ClearQueuedAudio(dev);
-                SDL_PauseAudioDevice(dev, 0);
-                playing = 1;
-            }
-
-            double step = (2.0 * M_PI * (double)freq) / (double)BEEP_RATE;
-            for (size_t i = 0; i < BEEP_CHUNK; i++) {
-                chunk[i] = (stream_sample_t)(BEEP_AMPLITUDE * sin(phase));
-                phase += step;
-                if (phase >= (2.0 * M_PI))
-                    phase -= (2.0 * M_PI);
-            }
-
-            Uint32 chunkBytes = (Uint32)sizeof(chunk);
-            while (SDL_GetQueuedAudioSize(dev)
-                   > (PLAY_QUEUE_SLACK * chunkBytes))
-                SDL_Delay(1);
-
-            SDL_QueueAudio(dev, chunk, chunkBytes);
-        } else {
-            if (playing != 0) {
-                SDL_ClearQueuedAudio(dev);
-                SDL_PauseAudioDevice(dev, 1);
-                playing = 0;
-                phase = 0.0;
-            }
-
-            SDL_Delay(5);
-        }
-    }
-
-    return NULL;
-}
-
-static void beepThreadStart(void)
-{
-    pthread_create(&beepThread, NULL, beepThreadFunc, NULL);
-}
-
-void sdlBeep_start(uint16_t freq)
-{
-    pthread_once(&beepOnce, beepThreadStart);
-
-    pthread_mutex_lock(&beepMutex);
-    beepFreq = freq;
-    beepActive = 1;
-    pthread_mutex_unlock(&beepMutex);
-}
-
-void sdlBeep_stop(void)
-{
-    pthread_mutex_lock(&beepMutex);
-    beepActive = 0;
-    pthread_mutex_unlock(&beepMutex);
-}

--- a/platform/drivers/audio/audio_sdl.h
+++ b/platform/drivers/audio/audio_sdl.h
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef AUDIO_SDL_H
+#define AUDIO_SDL_H
+
+#include "interfaces/audio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * SDL2-backed audio playback and beep for the host (Linux) and WebAssembly
+ * emulator targets. On native builds SDL routes to ALSA/PulseAudio/PipeWire;
+ * under Emscripten it routes to the Web Audio API.
+ *
+ * Samples are 16 bit, signed, mono, at the stream sample rate. The playback
+ * driver uses the SDL queue API (SDL_QueueAudio) so that it maps directly onto
+ * the blocking data()/sync() driver contract without an audio callback thread.
+ */
+
+/**
+ * Output driver: plays the audio stream on the default output device.
+ */
+extern const struct audioDriver sdl_play_audio_driver;
+
+/**
+ * Start a continuous beep tone at the given frequency on a dedicated output
+ * device. Calling it again while a beep is active retunes it.
+ *
+ * @param freq: beep frequency, in Hz.
+ */
+void sdlBeep_start(uint16_t freq);
+
+/**
+ * Stop an ongoing beep tone.
+ */
+void sdlBeep_stop(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AUDIO_SDL_H */

--- a/platform/drivers/tones/toneGenerator_sdl.cpp
+++ b/platform/drivers/tones/toneGenerator_sdl.cpp
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include <math.h>
+#include <pthread.h>
+#include "SDL2/SDL.h"
+#include "toneGenerator_sdl.h"
+#include "interfaces/audio.h"
+
+#define BEEP_RATE 48000
+#define BEEP_CHUNK (BEEP_RATE / 50) // 20 ms of samples
+#define BEEP_AMPLITUDE 8000
+
+// Number of extra queued chunks tolerated before a playback sync() blocks.
+#define PLAY_QUEUE_SLACK 2
+
+static pthread_t beepThread;
+static pthread_once_t beepOnce = PTHREAD_ONCE_INIT;
+static pthread_mutex_t beepMutex = PTHREAD_MUTEX_INITIALIZER;
+static int beepActive = 0;
+static uint16_t beepFreq = 0;
+
+static void *beepThreadFunc(void *arg)
+{
+    (void)arg;
+
+    SDL_AudioSpec want;
+    SDL_AudioSpec have;
+    SDL_zero(want);
+    want.freq = BEEP_RATE;
+    want.format = AUDIO_S16SYS;
+    want.channels = 1;
+    want.samples = 512;
+
+    SDL_AudioDeviceID dev = SDL_OpenAudioDevice(NULL, 0, &want, &have, 0);
+    if (dev == 0)
+        return NULL;
+
+    stream_sample_t chunk[BEEP_CHUNK];
+    double phase = 0.0;
+    int playing = 0;
+
+    for (;;) {
+        pthread_mutex_lock(&beepMutex);
+        int active = beepActive;
+        uint16_t freq = beepFreq;
+        pthread_mutex_unlock(&beepMutex);
+
+        if (active != 0) {
+            if (playing == 0) {
+                SDL_ClearQueuedAudio(dev);
+                SDL_PauseAudioDevice(dev, 0);
+                playing = 1;
+            }
+
+            double step = (2.0 * M_PI * (double)freq) / (double)BEEP_RATE;
+            for (size_t i = 0; i < BEEP_CHUNK; i++) {
+                chunk[i] = (stream_sample_t)(BEEP_AMPLITUDE * sin(phase));
+                phase += step;
+                if (phase >= (2.0 * M_PI))
+                    phase -= (2.0 * M_PI);
+            }
+
+            Uint32 chunkBytes = (Uint32)sizeof(chunk);
+            while (SDL_GetQueuedAudioSize(dev)
+                   > (PLAY_QUEUE_SLACK * chunkBytes))
+                SDL_Delay(1);
+
+            SDL_QueueAudio(dev, chunk, chunkBytes);
+        } else {
+            if (playing != 0) {
+                SDL_ClearQueuedAudio(dev);
+                SDL_PauseAudioDevice(dev, 1);
+                playing = 0;
+                phase = 0.0;
+            }
+
+            SDL_Delay(5);
+        }
+    }
+
+    return NULL;
+}
+
+static void beepThreadStart(void)
+{
+    pthread_create(&beepThread, NULL, beepThreadFunc, NULL);
+}
+
+void toneGen_sdl_start(uint16_t freq)
+{
+    pthread_once(&beepOnce, beepThreadStart);
+
+    pthread_mutex_lock(&beepMutex);
+    beepFreq = freq;
+    beepActive = 1;
+    pthread_mutex_unlock(&beepMutex);
+}
+
+void toneGen_sdl_stop(void)
+{
+    pthread_mutex_lock(&beepMutex);
+    beepActive = 0;
+    pthread_mutex_unlock(&beepMutex);
+}

--- a/platform/drivers/tones/toneGenerator_sdl.h
+++ b/platform/drivers/tones/toneGenerator_sdl.h
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef TONE_GENERATOR_SDL_H
+#define TONE_GENERATOR_SDL_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * SDL2-backed beep tone generator for the Linux emulator and WebAssembly
+ * targets. Drives a dedicated audio device on a background thread that
+ * synthesizes a phase-continuous sine wave.
+ */
+
+/**
+ * Start a continuous beep tone at the given frequency on a dedicated output
+ * device. Calling it again while a beep is active retunes the tone.
+ *
+ * @param freq: beep frequency, in Hz.
+ */
+void toneGen_sdl_start(uint16_t freq);
+
+/**
+ * Stop an ongoing beep tone.
+ */
+void toneGen_sdl_stop(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TONE_GENERATOR_SDL_H */

--- a/platform/targets/linux/emulator/sdl_engine.c
+++ b/platform/targets/linux/emulator/sdl_engine.c
@@ -10,22 +10,20 @@
 #include "sdl_engine.h"
 #include "emulator.h"
 
-chan_t fb_sync;                 // Shared channel to receive frame buffer updates
-Uint32 SDL_Screenshot_Event;    // Shared custom SDL event to request a screenshot
-Uint32 SDL_Backlight_Event;     // Shared custom SDL event to change backlight
+chan_t fb_sync;              // Shared channel to receive frame buffer updates
+Uint32 SDL_Screenshot_Event; // Shared custom SDL event to request a screenshot
+Uint32 SDL_Backlight_Event;  // Shared custom SDL event to change backlight
 
-static SDL_Window   *window;
+static SDL_Window *window;
 static SDL_Renderer *renderer;
-static SDL_Texture  *displayTexture;
+static SDL_Texture *displayTexture;
 
-static bool       ready = false;  // Signal if the main loop is ready
-static keyboard_t sdl_keys;       // Store the keyboard status
-
+static bool ready = false;  // Signal if the main loop is ready
+static keyboard_t sdl_keys; // Store the keyboard status
 
 static bool sdk_key_code_to_key(SDL_Keycode sym, keyboard_t *key)
 {
-    switch (sym)
-    {
+    switch (sym) {
         case SDLK_0:
             *key = KEY_0;
             return true;
@@ -128,7 +126,7 @@ static int screenshot_display(const char *filename)
      * rather than as a parameter
      */
     SDL_Renderer *ren = renderer;
-    SDL_Texture  *tex = displayTexture;
+    SDL_Texture *tex = displayTexture;
     int err = 0;
 
     SDL_Texture *ren_tex;
@@ -139,16 +137,15 @@ static int screenshot_display(const char *filename)
     int format;
     void *pixels;
 
-    pixels  = NULL;
-    surf    = NULL;
+    pixels = NULL;
+    surf = NULL;
     ren_tex = NULL;
-    format  = SDL_PIXELFORMAT_RGBA32;
+    format = SDL_PIXELFORMAT_RGBA32;
 
     /* Get information about texture we want to save */
     st = SDL_QueryTexture(tex, NULL, NULL, &w, &h);
 
-    if (st != 0)
-    {
+    if (st != 0) {
         SDL_Log("Failed querying texture: %s\n", SDL_GetError());
         err++;
         goto cleanup;
@@ -156,8 +153,7 @@ static int screenshot_display(const char *filename)
 
     ren_tex = SDL_CreateTexture(ren, format, SDL_TEXTUREACCESS_TARGET, w, h);
 
-    if (!ren_tex)
-    {
+    if (!ren_tex) {
         SDL_Log("Failed creating render texture: %s\n", SDL_GetError());
         err++;
         goto cleanup;
@@ -169,8 +165,7 @@ static int screenshot_display(const char *filename)
      */
     st = SDL_SetRenderTarget(ren, ren_tex);
 
-    if (st != 0)
-    {
+    if (st != 0) {
         SDL_Log("Failed setting render target: %s\n", SDL_GetError());
         err++;
         goto cleanup;
@@ -180,8 +175,7 @@ static int screenshot_display(const char *filename)
     SDL_RenderClear(ren);
     st = SDL_RenderCopy(ren, tex, NULL, NULL);
 
-    if (st != 0)
-    {
+    if (st != 0) {
         SDL_Log("Failed copying texture data: %s\n", SDL_GetError());
         err++;
         goto cleanup;
@@ -190,8 +184,7 @@ static int screenshot_display(const char *filename)
     /* Create buffer to hold texture data and load it */
     pixels = malloc(w * h * SDL_BYTESPERPIXEL(format));
 
-    if (!pixels)
-    {
+    if (!pixels) {
         SDL_Log("Failed allocating memory\n");
         err++;
         goto cleanup;
@@ -199,8 +192,7 @@ static int screenshot_display(const char *filename)
 
     st = SDL_RenderReadPixels(ren, NULL, format, pixels,
                               w * SDL_BYTESPERPIXEL(format));
-    if (st != 0)
-    {
+    if (st != 0) {
         SDL_Log("Failed reading pixel data: %s\n", SDL_GetError());
         err++;
         goto cleanup;
@@ -211,8 +203,7 @@ static int screenshot_display(const char *filename)
                                               SDL_BITSPERPIXEL(format),
                                               w * SDL_BYTESPERPIXEL(format),
                                               format);
-    if (!surf)
-    {
+    if (!surf) {
         SDL_Log("Failed creating new surface: %s\n", SDL_GetError());
         err++;
         goto cleanup;
@@ -221,8 +212,7 @@ static int screenshot_display(const char *filename)
     /* Save result to an image */
     st = SDL_SaveBMP(surf, filename);
 
-    if (st != 0)
-    {
+    if (st != 0) {
         SDL_Log("Failed saving image: %s\n", SDL_GetError());
         err++;
         goto cleanup;
@@ -248,10 +238,9 @@ static bool set_brightness(uint8_t brightness)
      * Color modulation is not always supported by the renderer;
      * it will return -1 if color modulation is not supported.
      */
-    int colMod = SDL_SetTextureColorMod(displayTexture,
-                                        brightness,
-                                        brightness,
-                                        brightness) == 0;
+    int colMod = SDL_SetTextureColorMod(displayTexture, brightness, brightness,
+                                        brightness)
+              == 0;
 
     SDL_RenderCopy(renderer, displayTexture, NULL, NULL);
     SDL_RenderPresent(renderer);
@@ -259,35 +248,36 @@ static bool set_brightness(uint8_t brightness)
     return colMod;
 }
 
-
-
 void sdlEngine_init()
 {
-    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS) < 0)
-    {
+    // Set audio stream name hints before any SDL subsystem init so they take
+    // effect when the first audio device is opened. SDL_HINT_APP_NAME works on
+    // macOS (Core Audio); the DEVICE hints are Linux-specific but harmless.
+    SDL_SetHint(SDL_HINT_APP_NAME, "OpenRTX");
+    SDL_SetHint(SDL_HINT_AUDIO_DEVICE_APP_NAME, "OpenRTX");
+    SDL_SetHint(SDL_HINT_AUDIO_DEVICE_STREAM_ROLE, "Communications");
+
+    if (SDL_Init(SDL_INIT_VIDEO | SDL_INIT_EVENTS | SDL_INIT_AUDIO) < 0) {
         printf("SDL video init error!!\n");
         exit(1);
     }
 
     // Register SDL custom events to handle screenshot requests and backlight
     SDL_Screenshot_Event = SDL_RegisterEvents(2);
-    SDL_Backlight_Event = SDL_Screenshot_Event+1;
+    SDL_Backlight_Event = SDL_Screenshot_Event + 1;
 
     chan_init(&fb_sync);
 
-    window = SDL_CreateWindow("OpenRTX",
-                              SDL_WINDOWPOS_UNDEFINED,
-                              SDL_WINDOWPOS_UNDEFINED,
-                              CONFIG_SCREEN_WIDTH * 3, CONFIG_SCREEN_HEIGHT * 3,
-                              SDL_WINDOW_SHOWN );
+    window = SDL_CreateWindow("OpenRTX", SDL_WINDOWPOS_UNDEFINED,
+                              SDL_WINDOWPOS_UNDEFINED, CONFIG_SCREEN_WIDTH * 3,
+                              CONFIG_SCREEN_HEIGHT * 3, SDL_WINDOW_SHOWN);
 
     renderer = SDL_CreateRenderer(window, -1, 0);
-    SDL_RenderSetLogicalSize(renderer, CONFIG_SCREEN_WIDTH, CONFIG_SCREEN_HEIGHT);
-    displayTexture = SDL_CreateTexture(renderer,
-                                       PIXEL_FORMAT,
-                                       SDL_TEXTUREACCESS_STREAMING,
-                                       CONFIG_SCREEN_WIDTH,
-                                       CONFIG_SCREEN_HEIGHT);
+    SDL_RenderSetLogicalSize(renderer, CONFIG_SCREEN_WIDTH,
+                             CONFIG_SCREEN_HEIGHT);
+    displayTexture =
+        SDL_CreateTexture(renderer, PIXEL_FORMAT, SDL_TEXTUREACCESS_STREAMING,
+                          CONFIG_SCREEN_WIDTH, CONFIG_SCREEN_HEIGHT);
     SDL_RenderClear(renderer);
 
     // Setting brightness also triggers a render
@@ -303,55 +293,45 @@ void sdlEngine_run()
 
     SDL_Event ev = { 0 };
 
-    while (!emulator_state.powerOff)
-    {
+    while (!emulator_state.powerOff) {
         keyboard_t key = 0;
 
-        if (SDL_PollEvent(&ev) == 1)
-        {
-            switch (ev.type)
-            {
+        if (SDL_PollEvent(&ev) == 1) {
+            switch (ev.type) {
                 case SDL_QUIT:
                     emulator_state.powerOff = true;
                     break;
 
                 case SDL_KEYDOWN:
-                    if (sdk_key_code_to_key(ev.key.keysym.sym, &key))
-                    {
+                    if (sdk_key_code_to_key(ev.key.keysym.sym, &key)) {
                         sdl_keys |= key;
                     }
                     break;
 
                 case SDL_KEYUP:
-                    if (sdk_key_code_to_key(ev.key.keysym.sym, &key))
-                    {
+                    if (sdk_key_code_to_key(ev.key.keysym.sym, &key)) {
                         sdl_keys ^= key;
                     }
                     break;
             }
 
-            if (ev.type == SDL_Screenshot_Event)
-            {
+            if (ev.type == SDL_Screenshot_Event) {
                 char *filename = (char *)ev.user.data1;
                 screenshot_display(filename);
                 free(ev.user.data1);
-            }
-            else if (ev.type == SDL_Backlight_Event)
-            {
-                set_brightness(*((uint8_t*)ev.user.data1));
+            } else if (ev.type == SDL_Backlight_Event) {
+                set_brightness(*((uint8_t *)ev.user.data1));
                 free(ev.user.data1);
             }
         }
 
         // we update the window only if there is a something ready to render
-        if (chan_can_send(&fb_sync))
-        {
+        if (chan_can_send(&fb_sync)) {
             PIXEL_SIZE *pixels;
             int pitch = 0;
 
-            if (SDL_LockTexture(displayTexture, NULL,
-                                (void **) &pixels, &pitch) < 0)
-            {
+            if (SDL_LockTexture(displayTexture, NULL, (void **)&pixels, &pitch)
+                < 0) {
                 SDL_Log("SDL_lock failed: %s", SDL_GetError());
             }
 

--- a/platform/targets/linux/platform.c
+++ b/platform/targets/linux/platform.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include "core/gps.h"
 #include "emulator.h"
+#include "toneGenerator_sdl.h"
 
 /*
  * Create the data structure holding Module17 calibration data to make the
@@ -19,19 +20,14 @@
  */
 mod17Calib_t mod17CalData;
 
-
-static const hwInfo_t hwInfo =
-{
-    .vhf_maxFreq = 174,
-    .vhf_minFreq = 136,
-    .vhf_band    = 1,
-    .uhf_maxFreq = 480,
-    .uhf_minFreq = 400,
-    .uhf_band    = 1,
-    .name        = "Linux",
-    .hw_version  = 1
-};
-
+static const hwInfo_t hwInfo = { .vhf_maxFreq = 174,
+                                 .vhf_minFreq = 136,
+                                 .vhf_band = 1,
+                                 .uhf_maxFreq = 480,
+                                 .uhf_minFreq = 400,
+                                 .uhf_band = 1,
+                                 .name = "Linux",
+                                 .hw_version = 1 };
 
 void platform_init()
 {
@@ -49,27 +45,33 @@ void platform_terminate()
 uint16_t platform_getVbat()
 {
     float voltage = emulator_state.vbat;
-    if(voltage < 0.0f)  voltage = 0.0f;
-    if(voltage > 65.0f) voltage = 65.0f;
-    return ((uint16_t) (voltage * 1000.0f));
+    if (voltage < 0.0f)
+        voltage = 0.0f;
+    if (voltage > 65.0f)
+        voltage = 65.0f;
+    return ((uint16_t)(voltage * 1000.0f));
 }
 
 uint8_t platform_getMicLevel()
 {
     float level = emulator_state.micLevel;
-    if(level < 0.0f)   level = 0.0f;
-    if(level > 255.0f) level = 255.0f;
+    if (level < 0.0f)
+        level = 0.0f;
+    if (level > 255.0f)
+        level = 255.0f;
 
-    return ((uint8_t) level);
+    return ((uint8_t)level);
 }
 
 uint8_t platform_getVolumeLevel()
 {
     float level = emulator_state.volumeLevel;
-    if(level < 0.0f)   level = 0.0f;
-    if(level > 255.0f) level = 255.0f;
+    if (level < 0.0f)
+        level = 0.0f;
+    if (level > 255.0f)
+        level = 255.0f;
 
-    return ((uint8_t) level);
+    return ((uint8_t)level);
 }
 
 int8_t platform_getChSelector()
@@ -96,22 +98,22 @@ bool platform_pwrButtonStatus()
 
 void platform_ledOn(led_t led)
 {
-    (void) led;
+    (void)led;
 }
 
 void platform_ledOff(led_t led)
 {
-    (void) led;
+    (void)led;
 }
 
 void platform_beepStart(uint16_t freq)
 {
-    printf("platform_beepStart(%u)\n", freq);
+    toneGen_sdl_start(freq);
 }
 
 void platform_beepStop()
 {
-    printf("platform_beepStop()\n");
+    toneGen_sdl_stop();
 }
 
 datetime_t platform_getCurrentTime()
@@ -119,10 +121,10 @@ datetime_t platform_getCurrentTime()
     datetime_t t;
 
     time_t rawtime;
-    struct tm * timeinfo;
-    time ( &rawtime );
+    struct tm *timeinfo;
+    time(&rawtime);
     // radio expects time to be TZ-less, so use gmtime instead of localtime.
-    timeinfo = gmtime ( &rawtime );
+    timeinfo = gmtime(&rawtime);
 
     t.hour = timeinfo->tm_hour;
     t.minute = timeinfo->tm_min;
@@ -138,7 +140,7 @@ datetime_t platform_getCurrentTime()
 
 void platform_setTime(datetime_t t)
 {
-    (void) t;
+    (void)t;
 
     printf("rtc_setTime(t)\n");
 }


### PR DESCRIPTION
This change implements an audio sink for the linux emulator. This is helpful for testing and evaluating the sound design as well as accessibility features. It leverages SDL rather than a lower level library like libalsa, which offers better compatibility for future explorations likee android's ndk and web emscripten.

I did not implement a source, because that implementation seems to require more work (my naive try resulted in jitters and hangs, and its not critical for my testing today).