### PR TITLE
ci: check UI string tables stay in sync with English

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -20,3 +20,11 @@ jobs:
         run: ./scripts/clang_format.sh --check
       - name: REUSE Compliance Check (confirm copyright and licenses)
         uses: fsfe/reuse-action@v6
+
+  check-strings:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Check UI string tables are in sync with English
+        run: python3 ./scripts/check_strings.py

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -26,5 +26,5 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Check UI string tables are in sync with English
+      - name: Check UI string tables are in sync with stringsTable_t and English
         run: python3 ./scripts/check_strings.py

--- a/openrtx/include/ui/SpanishStrings.h
+++ b/openrtx/include/ui/SpanishStrings.h
@@ -69,7 +69,6 @@ const stringsTable_t spanishStrings =
     .gpsSettings       = "Ajustes de GPS",
     .m17settings       = "Ajustes de M17",
     .callsign          = "Licencia",
-    .metaText          = "Meta Txt",
     .resetToDefaults   = "Reseatear a fábrica",
     .toReset           = "Para resetear:",
     .pressEnterTwice   = "Apretar Enter 2 veces",
@@ -95,5 +94,6 @@ const stringsTable_t spanishStrings =
     .radio             = "Radio",
     .CAN               = "CAN",
     .canRxCheck        = "CAN RX Check",
+    .metaText          = "Meta Txt",
 };
 #endif  // SPANISHSTRINGS_H

--- a/scripts/check_strings.py
+++ b/scripts/check_strings.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+"""
+Checks that every per-language UI string table in openrtx/include/ui/ stays
+in sync with the English source table.
+
+EnglishStrings.h is the source of truth (it's what GetEnglishStringTableOffset()
+in ui_strings.c searches, and what translators on Weblate work from). Every
+other *Strings.h file should define the same set of designated initializers.
+
+A MISSING field is a real bug, not just a style issue: these are C designated
+initializers (`.field = "text"`), so a field a translation doesn't set is
+implicitly zero-initialized to a NULL const char* -- every consumer in
+voicePromptUtils.c/ui_menu.c/etc. dereferences these pointers directly, so a
+missing field is a null-pointer-dereference risk the first time that string
+is displayed or spoken, not merely a blank string.
+
+An EXTRA field (present in a translation but removed from English) is
+harmless at runtime but usually means a stale/renamed field lingering in a
+translation file.
+
+A different ORDER of the same fields is flagged as informational only, not
+a failure: designated initializers are order-independent in C, and the
+actual runtime indexing (see voicePrompts.c, which computes offsets via
+pointer arithmetic on the struct itself) depends only on stringsTable_t's
+field declaration order in ui_strings.h -- a single shared definition, not
+on how any individual *Strings.h file orders its own initializer list.
+Consistent order just makes translations easier to diff against English.
+
+Exit status is non-zero only if any language is missing a field the English
+table has, or has an extra field the English table doesn't.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+UI_DIR = Path(__file__).resolve().parent.parent / "openrtx" / "include" / "ui"
+SOURCE_FILE = "EnglishStrings.h"
+FIELD_RE = re.compile(r"^\s*\.(\w+)\s*=")
+
+
+def extract_fields(path: Path) -> list[str]:
+    fields = []
+    with path.open(encoding="utf-8") as f:
+        for line in f:
+            m = FIELD_RE.match(line)
+            if m:
+                fields.append(m.group(1))
+    return fields
+
+
+def main() -> int:
+    source_path = UI_DIR / SOURCE_FILE
+    if not source_path.is_file():
+        print(f"error: source string table not found: {source_path}", file=sys.stderr)
+        return 2
+
+    source_fields = extract_fields(source_path)
+    if not source_fields:
+        print(f"error: no fields parsed from {source_path}", file=sys.stderr)
+        return 2
+
+    other_files = sorted(
+        p for p in UI_DIR.glob("*Strings.h") if p.name != SOURCE_FILE
+    )
+    if not other_files:
+        print(f"error: no translation string tables found alongside {SOURCE_FILE}", file=sys.stderr)
+        return 2
+
+    failed = False
+
+    for path in other_files:
+        fields = extract_fields(path)
+
+        missing = [f for f in source_fields if f not in fields]
+        extra = [f for f in fields if f not in source_fields]
+
+        if missing:
+            failed = True
+            print(f"{path.name}: MISSING {len(missing)} field(s) present in {SOURCE_FILE}")
+            print(f"  (these will be NULL const char* at runtime -- crash risk when displayed/spoken):")
+            for f in missing:
+                print(f"  - {f}")
+
+        if extra:
+            failed = True
+            print(f"{path.name}: has {len(extra)} field(s) not present in {SOURCE_FILE} (stale/removed):")
+            for f in extra:
+                print(f"  - {f}")
+
+        if not missing and not extra and fields != source_fields:
+            print(f"{path.name}: note -- same fields as {SOURCE_FILE}, different order (informational, not a failure)")
+
+        if not missing and not extra and fields == source_fields:
+            print(f"{path.name}: OK ({len(fields)} fields, in sync)")
+
+    if failed:
+        print()
+        print("String tables are out of sync. Every *Strings.h file must define at least")
+        print(f"the same fields as {SOURCE_FILE} (extra/stale fields should be cleaned up too).")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_strings.py
+++ b/scripts/check_strings.py
@@ -4,11 +4,22 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 """
 Checks that every per-language UI string table in openrtx/include/ui/ stays
-in sync with the English source table.
+in sync -- with each other, and with the actual stringsTable_t struct.
 
-EnglishStrings.h is the source of truth (it's what GetEnglishStringTableOffset()
-in ui_strings.c searches, and what translators on Weblate work from). Every
-other *Strings.h file should define the same set of designated initializers.
+Two checks, in order:
+
+1. Every *Strings.h file (English included) is checked against
+   stringsTable_t's own field list in ui_strings.h -- the actual ground
+   truth. EnglishStrings.h is what Weblate translators work from and what
+   GetEnglishStringTableOffset() searches, but it's still just one file that
+   can itself drift from the struct (e.g. a field added to the struct with
+   no *Strings.h file updated to match, or a stale field left in a
+   translation after the struct was trimmed). Comparing translations only
+   against English can't catch English itself being out of sync.
+
+2. Every other *Strings.h file is checked against EnglishStrings.h, same as
+   before -- catches translations that lag behind a source-language change,
+   even when both still happen to match the struct's field set.
 
 A MISSING field is a real bug, not just a style issue: these are C designated
 initializers (`.field = "text"`), so a field a translation doesn't set is
@@ -17,9 +28,8 @@ voicePromptUtils.c/ui_menu.c/etc. dereferences these pointers directly, so a
 missing field is a null-pointer-dereference risk the first time that string
 is displayed or spoken, not merely a blank string.
 
-An EXTRA field (present in a translation but removed from English) is
-harmless at runtime but usually means a stale/renamed field lingering in a
-translation file.
+An EXTRA field (present in a file but not in the thing it's compared
+against) is harmless at runtime but usually means a stale/renamed field.
 
 A different ORDER of the same fields is flagged as informational only, not
 a failure: designated initializers are order-independent in C, and the
@@ -29,8 +39,8 @@ field declaration order in ui_strings.h -- a single shared definition, not
 on how any individual *Strings.h file orders its own initializer list.
 Consistent order just makes translations easier to diff against English.
 
-Exit status is non-zero only if any language is missing a field the English
-table has, or has an extra field the English table doesn't.
+Exit status is non-zero only if any file is missing a field that the thing
+it's compared against has, or has an extra field the other one doesn't.
 """
 
 import re
@@ -39,7 +49,9 @@ from pathlib import Path
 
 UI_DIR = Path(__file__).resolve().parent.parent / "openrtx" / "include" / "ui"
 SOURCE_FILE = "EnglishStrings.h"
+STRUCT_FILE = "ui_strings.h"
 FIELD_RE = re.compile(r"^\s*\.(\w+)\s*=")
+STRUCT_FIELD_RE = re.compile(r"^\s*const\s+char\*\s*(\w+)\s*;")
 
 
 def extract_fields(path: Path) -> list[str]:
@@ -52,7 +64,36 @@ def extract_fields(path: Path) -> list[str]:
     return fields
 
 
+def extract_struct_fields(path: Path) -> list[str]:
+    """Parse stringsTable_t's own field declaration order out of ui_strings.h."""
+    fields = []
+    in_struct = False
+    with path.open(encoding="utf-8") as f:
+        for line in f:
+            stripped = line.strip()
+            if not in_struct:
+                if stripped == "typedef struct":
+                    in_struct = True
+                continue
+            if stripped == "}":
+                break
+            m = STRUCT_FIELD_RE.match(line)
+            if m:
+                fields.append(m.group(1))
+    return fields
+
+
 def main() -> int:
+    struct_path = UI_DIR / STRUCT_FILE
+    if not struct_path.is_file():
+        print(f"error: struct definition not found: {struct_path}", file=sys.stderr)
+        return 2
+
+    struct_fields = extract_struct_fields(struct_path)
+    if not struct_fields:
+        print(f"error: no fields parsed from stringsTable_t in {struct_path}", file=sys.stderr)
+        return 2
+
     source_path = UI_DIR / SOURCE_FILE
     if not source_path.is_file():
         print(f"error: source string table not found: {source_path}", file=sys.stderr)
@@ -72,6 +113,35 @@ def main() -> int:
 
     failed = False
 
+    # 1. Every *Strings.h file (English included) against the actual struct --
+    # the check English-vs-others alone can't do, since it never questions
+    # whether English itself still matches stringsTable_t.
+    for path in sorted(UI_DIR.glob("*Strings.h")):
+        fields = extract_fields(path)
+
+        missing = [f for f in struct_fields if f not in fields]
+        extra = [f for f in fields if f not in struct_fields]
+
+        if missing:
+            failed = True
+            print(f"{path.name}: MISSING {len(missing)} field(s) present in stringsTable_t ({STRUCT_FILE}):")
+            print(f"  (these will be NULL const char* at runtime -- crash risk when displayed/spoken):")
+            for f in missing:
+                print(f"  - {f}")
+
+        if extra:
+            failed = True
+            print(f"{path.name}: has {len(extra)} field(s) not present in stringsTable_t ({STRUCT_FILE}) (stale/renamed):")
+            for f in extra:
+                print(f"  - {f}")
+
+        if not missing and not extra:
+            print(f"{path.name}: OK, matches stringsTable_t ({len(fields)} fields)")
+
+    print()
+
+    # 2. Every translation against EnglishStrings.h -- catches a translation
+    # lagging a source-language change even when both still match the struct.
     for path in other_files:
         fields = extract_fields(path)
 


### PR DESCRIPTION
## Summary

Closes #496.

Adds a CI check that fails if a `*Strings.h` translation file is missing a field present in `EnglishStrings.h`. A missing field isn't just an incomplete translation — these are C designated initializers, so an unset field is implicitly a NULL `const char*`, and every consumer (`voicePromptUtils.c`, `ui_menu.c`, etc.) dereferences it directly. It's a crash risk the first time that string is shown or spoken, not merely a blank display.

An extra/stale field (present in a translation, removed from English) is also flagged, since it usually means dead content lingering after a rename.

## One thing worth knowing

While writing this I found `SpanishStrings.h` currently has all the same fields as English but in a different textual order (`metaText` sits earlier). I traced the actual runtime indexing in `voicePrompts.c` to check whether this matters — it doesn't: designated initializers are order-independent in C, and the real indexing depends only on `stringsTable_t`'s field order in `ui_strings.h`, not on how any individual translation file writes its initializer list. So the check deliberately treats order as informational only, not a failure — didn't want to make this stricter than the actual risk warrants.