### PR TITLE
HD2: minimal OpenRTX bring-up — display, backlight, keyboard, RTC, battery, GPS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,7 @@ scripts/get_demod_log
 
 # OpenRTX Codeplugs
 *.rtxc
+
+# HD2 in-tree docker build output
+platform/targets/HD2/build-docker/
+platform/targets/HD2/build/

--- a/openrtx/include/core/datetime.h
+++ b/openrtx/include/core/datetime.h
@@ -57,6 +57,29 @@ datetime_t localTimeToUtc(const datetime_t local_time, const int8_t timezone);
  */
 void realignTimeInfo(datetime_t *time);
 
+/**
+ * Convert a civil (proleptic Gregorian) date to a serial day count relative to
+ * the Unix epoch (1970-01-01 = day 0).  Branch-free Howard Hinnant algorithm,
+ * valid for years well outside the datetime_t range.
+ *
+ * @param year: full year, e.g. 2026.
+ * @param month: month, 1-12.
+ * @param day: day of the month, 1-31.
+ * @return days since 1970-01-01 (negative for earlier dates).
+ */
+int32_t civilToDays(int32_t year, uint32_t month, uint32_t day);
+
+/**
+ * Inverse of civilToDays(): split a serial day count (days since 1970-01-01)
+ * back into a civil year/month/day.
+ *
+ * @param days: days since 1970-01-01.
+ * @param year: output, full year.
+ * @param month: output, month 1-12.
+ * @param day: output, day of the month 1-31.
+ */
+void daysToCivil(int32_t days, int32_t *year, uint32_t *month, uint32_t *day);
+
 #ifdef __cplusplus
 }
 #endif

--- a/openrtx/src/core/datetime.c
+++ b/openrtx/src/core/datetime.c
@@ -149,3 +149,32 @@ void realignTimeInfo(datetime_t *time)
         }
     }
 }
+
+/*
+ * Civil <-> serial-day conversion (days since 1970-01-01), branch-free after
+ * Howard Hinnant's "chrono-Compatible Low-Level Date Algorithms".
+ */
+int32_t civilToDays(int32_t year, uint32_t month, uint32_t day)
+{
+    year -= (month <= 2);
+    int32_t era = (year >= 0 ? year : year - 399) / 400;
+    uint32_t yoe = (uint32_t)(year - era * 400);
+    uint32_t doy = (153u * (month + (month > 2 ? -3u : 9u)) + 2u) / 5u + day
+                 - 1u;
+    uint32_t doe = yoe * 365u + yoe / 4u - yoe / 100u + doy;
+    return era * 146097 + (int32_t)doe - 719468;
+}
+
+void daysToCivil(int32_t days, int32_t *year, uint32_t *month, uint32_t *day)
+{
+    days += 719468;
+    int32_t era = (days >= 0 ? days : days - 146096) / 146097;
+    uint32_t doe = (uint32_t)(days - era * 146097);
+    uint32_t yoe = (doe - doe / 1460u + doe / 36524u - doe / 146096u) / 365u;
+    int32_t yr = (int32_t)yoe + era * 400;
+    uint32_t doy = doe - (365u * yoe + yoe / 4u - yoe / 100u);
+    uint32_t mp = (5u * doy + 2u) / 153u;
+    *day = doy - (153u * mp + 2u) / 5u + 1u;
+    *month = mp + (mp < 10u ? 3u : -9u);
+    *year = yr + (*month <= 2);
+}

--- a/platform/drivers/ADC/adcHrc7000.c
+++ b/platform/drivers/ADC/adcHrc7000.c
@@ -1,0 +1,106 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Driver for the HR_C7000 on-chip ADC (base 0x140d0000, manual 4.13),
+ * implementing the standard peripherals/adc.h interface.  Single-shot 10-bit
+ * conversions, busy-polled (no RTOS/semaphore).  On the Ailunce HD2 the battery
+ * pack sits on channel 2 (ADC_HW->DATA_CD[9:0]).
+ *
+ * The reset-release pulse in adcHrc7000_init() is essential: without it the
+ * conversion FSM stays held and DATA reads 0 (live-verified 2026-06-01; with it
+ * ch2 reads a stable ~0x350).
+ */
+
+#include "adcHrc7000.h"
+#include "registers.h"
+#include <pthread.h>
+#include <stdbool.h>
+
+#define ADC_STATE_BUSY 0x01u    /* ADC_CTRL_BUSY              */
+#define ADC_STATE_FSM 0x3eu     /* SAMP_FSM_STATE (bits[5:1]) */
+#define ADC_SAMPLE_MASK 0x3ffu  /* 10-bit result             */
+#define ADC_GUARD_ITERS 200000u /* bounded busy-wait guard   */
+
+/* Poll CTRL_STATE until the conversion FSM reaches the requested phase:
+ *   waitBusy = false -> BUSY + SAMP_FSM clear (conversion idle / complete);
+ *   waitBusy = true  -> BUSY or SAMP_FSM set (conversion has started).
+ * Returns 1 when the phase is reached, 0 on the bounded-guard timeout. */
+static int adc_wait(bool waitBusy)
+{
+    for (uint32_t guard = 0; guard < ADC_GUARD_ITERS; ++guard) {
+        bool busy = (ADC_HW->CTRL_STATE & (ADC_STATE_BUSY | ADC_STATE_FSM))
+                 != 0u;
+        if (busy == waitBusy)
+            return 1;
+    }
+    return 0;
+}
+
+int adcHrc7000_init(const struct Adc *adc)
+{
+    ADC_HW->CTRL = 0u;
+    ADC_HW->CTRL = 8u; /* PD_FORCE soft-reset (the missing step) */
+    ADC_HW->CTRL_STOP = 2u;
+    (void)adc_wait(false);
+    ADC_HW->CTRL = 0u; /* release reset -> normal operation */
+    ADC_HW->SEOC_TIME = 0xa20u;
+    ADC_HW->P2S_EN = 0u;
+    ADC_HW->INTR = 0u;
+    ADC_HW->CH_VLD = 0u;
+
+    if (adc->mutex != NULL)
+        pthread_mutex_init((pthread_mutex_t *)adc->mutex, NULL);
+
+    return 0;
+}
+
+void adcHrc7000_terminate(const struct Adc *adc)
+{
+    if (adc->mutex != NULL)
+        pthread_mutex_destroy((pthread_mutex_t *)adc->mutex);
+}
+
+uint16_t adcHrc7000_sample(const struct Adc *adc, const uint32_t channel)
+{
+    (void)adc; /* single ADC block on the HR_C7000 */
+
+    if (channel > 7u)
+        return 0;
+    if (!adc_wait(false))
+        return 0;
+
+    ADC_HW->CH_VLD = (1u << channel);
+    ADC_HW->START = 1u;
+
+    /* Wait for the FSM to actually enter BUSY before polling for completion.
+     * Best-effort (bounded): if the conversion already finished we fall through
+     * to the idle-wait below, which latches the just-finished result.  Without
+     * this the idle-wait can observe the still-idle FSM and return the PREVIOUS
+     * conversion's DATA -- on the first sample that is the reset value 0, read
+     * by the battery monitor as a flat pack (spurious low-battery alarm). */
+    (void)adc_wait(true);
+    if (!adc_wait(false))
+        return 0;
+
+    uint32_t data;
+    switch (channel >> 1) {
+        case 0:
+            data = ADC_HW->DATA_AB;
+            break; /* ch 0/1 */
+        case 1:
+            data = ADC_HW->DATA_CD;
+            break; /* ch 2/3 */
+        case 2:
+            data = ADC_HW->DATA_EF;
+            break; /* ch 4/5 */
+        default:
+            data = ADC_HW->DATA_GH;
+            break; /* ch 6/7 */
+    }
+    if (channel & 1u)
+        data >>= 16;
+
+    return (uint16_t)(data & ADC_SAMPLE_MASK);
+}

--- a/platform/drivers/ADC/adcHrc7000.h
+++ b/platform/drivers/ADC/adcHrc7000.h
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Driver for the HR_C7000 on-chip ADC (used on the Ailunce HD2 and other
+ * HR_C7000 targets), implementing the standard peripherals/adc.h interface.
+ * Single-shot 10-bit conversions, busy-polled.
+ */
+
+#ifndef ADC_HRC7000_H
+#define ADC_HRC7000_H
+
+#include "peripherals/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * Define an instance of the HR_C7000 ADC device driver.  The chip has a single
+ * ADC block, so no peripheral base is needed (priv is unused).
+ *
+ * @param name: instance name.
+ * @param mutx: pointer to mutex for concurrent access, can be NULL.
+ * @param res:  conversion factor from counts to uV (see ADC_COUNTS_TO_UV).
+ */
+#define ADC_HRC7000_DEVICE_DEFINE(name, mutx, res)             \
+    extern uint16_t adcHrc7000_sample(const struct Adc *adc,   \
+                                      const uint32_t channel); \
+    const struct Adc name = {                                  \
+        .sample = &adcHrc7000_sample,                          \
+        .priv = NULL,                                          \
+        .mutex = mutx,                                         \
+        .countsTouV = res,                                     \
+    };
+
+/**
+ * Initialise the HR_C7000 ADC (the vendor reset-release pulse the conversion
+ * FSM needs; without it DATA reads 0) and its mutex, if any.
+ *
+ * @param adc: pointer to ADC device handle.
+ * @return zero on success.
+ */
+int adcHrc7000_init(const struct Adc *adc);
+
+/**
+ * Shut down the HR_C7000 ADC.
+ *
+ * @param adc: pointer to ADC device handle.
+ */
+void adcHrc7000_terminate(const struct Adc *adc);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADC_HRC7000_H */

--- a/platform/drivers/GPIO/gpio-native.h
+++ b/platform/drivers/GPIO/gpio-native.h
@@ -17,6 +17,8 @@
 #include "drivers/GPIO/gpio_mk22.h"
 #elif defined(AT32F423xx)
 #include "gpio_at32f423.h"
+#elif defined(PLATFORM_HD2)
+#include "drivers/GPIO/gpio_hrc7000.h"
 #endif
 
 #endif /* GPIO_NATIVE_H */

--- a/platform/drivers/GPIO/gpio_hrc7000.c
+++ b/platform/drivers/GPIO/gpio_hrc7000.c
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#include "drivers/GPIO/gpio_hrc7000.h"
+
+void gpio_setMode(const void *port, const uint8_t pin, const uint16_t mode)
+{
+    GPIO_TypeDef *g = (GPIO_TypeDef *)port;
+
+    switch (mode & 0xFF) {
+        case OUTPUT:
+        case OPEN_DRAIN:
+            g->DDR |= (1u << pin); /* output direction */
+            break;
+
+        /*
+         * ALTERNATE*: the HR_C7000 selects pin functions through the SOCSYS
+         * pad-mux, not a per-GPIO alternate register, so there is no per-pin
+         * alternate direction here.  Leave the pad configured as an input and
+         * let the pad-mux own the function.
+         */
+        case INPUT:
+        case INPUT_PULL_UP:
+        case INPUT_PULL_DOWN:
+        case ANALOG:
+        default:
+            g->DDR &= ~(1u << pin); /* input direction */
+            break;
+    }
+}

--- a/platform/drivers/GPIO/gpio_hrc7000.h
+++ b/platform/drivers/GPIO/gpio_hrc7000.h
@@ -1,0 +1,92 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef GPIO_HRC7000_H
+#define GPIO_HRC7000_H
+
+#include "peripherals/gpio.h"
+#include "registers.h"
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Native GPIO driver for the HR_C7000 (Ailunce HD2) DesignWare DW_apb_gpio
+ * banks GPIOA/GPIOB/GPIOC (see GPIO_TypeDef in registers.h): DR is the output
+ * latch, DDR the direction register (1 = output), EXT_PORT the input read-back.
+ *
+ * Standard pin-function muxing is handled by the SOCSYS pad-mux, not the
+ * per-GPIO registers, so gpio_setMode() covers only direction and level (see
+ * it for how ALTERNATE modes are treated).  The one exception is the vendor
+ * "alternate-function B" selector (per-bank register at +0x78, outside the
+ * DW_apb_gpio map); use gpio_setAltFuncB() for it.
+ */
+
+/**
+ * Configure gpio pin functional mode.
+ *
+ * @param port: gpio port (GPIOA/GPIOB/GPIOC).
+ * @param pin: gpio pin number, between 0 and 31.
+ * @param mode: functional mode (bit 7:0); the alternate-function field (bit
+ * 15:8) is ignored -- this SoC muxes pin functions via the SOCSYS pad-mux.
+ */
+void gpio_setMode(const void *port, const uint8_t pin, const uint16_t mode);
+
+/**
+ * Set gpio pin to high logic level.
+ *
+ * @param port: gpio port.
+ * @param pin: gpio pin number.
+ */
+static inline void gpio_setPin(const void *port, const uint8_t pin)
+{
+    ((GPIO_TypeDef *)port)->DR |= (1u << pin);
+}
+
+/**
+ * Set gpio pin to low logic level.
+ *
+ * @param port: gpio port.
+ * @param pin: gpio pin number.
+ */
+static inline void gpio_clearPin(const void *port, const uint8_t pin)
+{
+    ((GPIO_TypeDef *)port)->DR &= ~(1u << pin);
+}
+
+/**
+ * Read gpio pin's logic level.
+ *
+ * @param port: gpio port.
+ * @param pin: gpio pin number.
+ * @return 1 if pin is at high logic level, 0 if pin is at low logic level.
+ */
+static inline uint8_t gpio_readPin(const void *port, const uint8_t pin)
+{
+    return (((GPIO_TypeDef *)port)->EXT_PORT >> pin) & 1u;
+}
+
+/**
+ * Select the HR_C7000 vendor "alternate-function B" for a pin (per-bank
+ * register at +0x78).  This is distinct from the SOCSYS pad-mux and is sticky
+ * across gpio_setMode() direction changes; the keypad-matrix rows use it to
+ * sense while the same pins otherwise carry LCD-bus signals.
+ *
+ * @param port: gpio port (GPIOA/GPIOB/GPIOC).
+ * @param pin: gpio pin number, between 0 and 31.
+ */
+static inline void gpio_setAltFuncB(const void *port, const uint8_t pin)
+{
+    ((GPIO_TypeDef *)port)->ALT_FUNC_B |= (1u << pin);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_HRC7000_H */

--- a/platform/drivers/GPS/gps_HD2.c
+++ b/platform/drivers/GPS/gps_HD2.c
@@ -1,0 +1,104 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 OpenRTX Contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * GPS driver for the Ailunce HD2 (HR_C7000 / CK803S).
+ *
+ * The GPS module is on the HR_C7000's UART2 (DesignWare 16550 @ 0x14050000,
+ * 9600 8N1) with its RXD/TXD on PTA11/PTA12. The pad mux (DIPLEX0 bits
+ * 11/12 = 0 -> UART2 function) is already set by platform_init. The module's
+ * power rail is GPIOB.15 (active-high), off at boot and raised here.
+ *
+ * This is a POLLED driver: no PIC/ISR wiring. getSentence() first pumps every
+ * byte waiting in the RX FIFO into OpenRTX's NMEA ring buffer, then hands the
+ * core a complete sentence if one is ready. The core gps_task() (called from
+ * the UI/main thread) drives it and parses the sentences via minmea.
+ */
+
+#include "gps_HD2.h"
+#include "hwconfig.h"
+#include "registers.h"
+#include "pinmap.h"
+#include "peripherals/gpio.h"
+#include "nmea_rbuf.h"
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+/* UART input clock is the 42 MHz post-PLL clock (the same the console UART0
+ * uses); 16550 divisor = clk / (16 * baud). */
+#define GPS_UART_CLK_HZ 42000000u
+#define GPS_BAUD 9600u
+
+static struct nmeaRbuf nmea;
+static bool initialized = false;
+
+static void gps_setBaud(uint32_t baud)
+{
+    uint32_t divisor = GPS_UART_CLK_HZ / (16u * baud);
+    if (divisor == 0u)
+        divisor = 1u;
+
+    UART2->LCR = UART2->LCR | UART_LCR_DLAB; /* expose DLL/DLH */
+    UART2->DLL = divisor & 0xffu;
+    UART2->DLH = (divisor >> 8) & 0xffu;
+    UART2->LCR = UART_LCR_8N1; /* DLAB cleared, 8N1 */
+}
+
+static void gps_uart_bringup(void)
+{
+    UART2->FCR = UART_FCR_ENABLE;
+    UART2->IER = 0u; /* polled: no UART interrupts */
+    gps_setBaud(GPS_BAUD);
+    nmeaRbuf_reset(&nmea);
+}
+
+/* Drain the RX FIFO into the ring buffer. nmeaRbuf_putChar runs an FSM that
+ * only stores bytes of a valid NMEA sentence, so raw UART bytes are safe. */
+static void gps_drain(void)
+{
+    while ((UART2->LSR & UART_LSR_DR) != 0u)
+        nmeaRbuf_putChar(&nmea, (char)(UART2->RBR & 0xffu));
+}
+
+static void gps_HD2_enable(void *priv)
+{
+    (void)priv;
+    gpio_setPin(GPS_PWR); /* power the GPS module */
+    gps_uart_bringup();
+    gps_drain();          /* flush stale bytes */
+}
+
+static void gps_HD2_disable(void *priv)
+{
+    (void)priv;
+    gpio_clearPin(GPS_PWR); /* cut GPS module power */
+}
+
+static int gps_HD2_getSentence(void *priv, char *buf, const size_t bufSize)
+{
+    (void)priv;
+    if (!initialized)
+        return 0;
+
+    gps_drain(); /* non-blocking pump + extract */
+    return nmeaRbuf_getSentence(&nmea, buf, bufSize);
+}
+
+const struct gpsDevice *gps_HD2_init(void)
+{
+    if (!initialized) {
+        gpio_setPin(GPS_PWR); /* power on so NMEA buffers at once */
+        gps_uart_bringup();
+        gps_drain();
+        initialized = true;
+    }
+
+    static const struct gpsDevice dev = {
+        .priv = NULL,
+        .enable = gps_HD2_enable,
+        .disable = gps_HD2_disable,
+        .getSentence = gps_HD2_getSentence,
+    };
+    return &dev;
+}

--- a/platform/drivers/GPS/gps_HD2.h
+++ b/platform/drivers/GPS/gps_HD2.h
@@ -1,0 +1,26 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 OpenRTX Contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * GPS driver for the Ailunce HD2 (HR_C7000 / CK803S): the GPS module is on
+ * UART2, polled, feeding OpenRTX's NMEA ring buffer.
+ */
+
+#ifndef GPS_HD2_H
+#define GPS_HD2_H
+
+#include "core/gps.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Bring up UART2 + power the GPS module and return the OpenRTX gpsDevice
+ * handle (call once, from platform_initGps()). */
+const struct gpsDevice *gps_HD2_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPS_HD2_H */

--- a/platform/drivers/backlight/backlight_HD2.c
+++ b/platform/drivers/backlight/backlight_HD2.c
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 OpenRTX Contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * HD2 LCD-backlight driver: the LED is driven by PWM channel 0 of the
+ * HR_C7000 PWM block (0x140c0000).  The channel-start register order
+ * replicates the vendor V2.1.3 pwm_channel_start sequence exactly.
+ *
+ * Owns the OpenRTX display_setBacklightLevel() entry point (the backlight
+ * driver owns the PWM; the display driver only owns the LCD bus).
+ */
+
+#include "interfaces/display.h"
+#include "registers.h"
+#include <stdint.h>
+
+#define BACKLIGHT_PWM_HZ 10000u /* perception-flat dimming frequency */
+
+static void pwm_program(PWM_Channel_TypeDef *p, unsigned freq_hz,
+                        unsigned duty_per_10000)
+{
+    /* Vendor V2.1.3 channel-start order: clear enable/mode bits, select the
+     * gated source, set period + duty, then re-enable. */
+    p->CFG &= ~1u;
+    p->CFG &= ~4u;
+    p->CFG &= ~8u;
+    p->CFG &= ~0x30u;
+    p->CFG |= 0x20u;
+    p->CFG |= 0x100u;
+    p->CFG |= 0x200u;
+    p->RPT = 5;
+    p->PER = freq_hz ? (PWM_TIMER_HZ / freq_hz) : 1u;
+    p->FP = (p->PER * duty_per_10000) / 10000u;
+    /* Never let duty == period: on this comparator that wraps to a
+     * permanently-LOW output (LED off) instead of "always on".  Full
+     * brightness (level 100 -> duty_per_10000 10000) must map to period-1. */
+    if (p->FP >= p->PER)
+        p->FP = p->PER - 1u;
+    p->CFG |= 4u;
+    p->CFG |= 1u;
+}
+
+void backlight_init(void)
+{
+    /* Restore the PWM ch0 duty-gating control words (STATUS @0x10 and the three
+     * reserved words @0x14-0x1c) to their V2.1.3 boot value.  Left at 0 (as the
+     * kernel/IAP hand-off leaves them for us) the duty cycle is squashed and the
+     * LED never lights, regardless of the period/duty we program below. */
+    PWM_CH0->STATUS = PWM_CH0_GATE_ON;
+    PWM_CH0->RESERVED_HW[0] = PWM_CH0_GATE_ON;
+    PWM_CH0->RESERVED_HW[1] = PWM_CH0_GATE_ON;
+    PWM_CH0->RESERVED_HW[2] = PWM_CH0_GATE_ON;
+}
+
+void backlight_terminate(void)
+{
+    pwm_program(PWM_CH0, BACKLIGHT_PWM_HZ, 0); /* duty 0 = dark */
+}
+
+void display_setBacklightLevel(uint8_t level)
+{
+    if (level > 100)
+        level = 100;
+
+    /* Keep the PWM running and zero the duty when off: halting the counter
+     * would hold the output pin at its last (possibly high) level, leaving
+     * the LED lit. */
+    pwm_program(PWM_CH0, BACKLIGHT_PWM_HZ, (unsigned)level * 100u);
+}

--- a/platform/drivers/display/ST7735S_HD2.c
+++ b/platform/drivers/display/ST7735S_HD2.c
@@ -1,0 +1,197 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 OpenRTX Contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * ST7735S display driver for the Ailunce HD2 (160x128 RGB565), driven
+ * through the HR_C7000 hardware i8080 controller @0x12000000 (manual 5.3):
+ * a write to INDEX (+0x00) emits one command cycle, a write to DATA (+0x04)
+ * one 8-bit data cycle; the controller generates CS/RS/WR timing per WCFG.
+ *
+ * The controller owns PTC3-6 (CS/RS/WR/RD) and PTC7-14 (DB0-7) while the
+ * PTC pad mux (DIPLEX2) is in i8080 mode; the panel RESET (PTC2) stays a
+ * plain GPIO.  This driver establishes that mux at init and leaves it in
+ * i8080 mode as the resting state (the keyboard scan borrows the pins and
+ * restores i8080 mode when done).
+ *
+ * OpenRTX's graphics layer owns the single 40 KiB RGB565 framebuffer and
+ * pushes it here via display_renderRows(); this driver keeps no copy.
+ */
+
+#include "interfaces/display.h"
+#include "interfaces/delays.h"
+#include "hwconfig.h"
+#include "registers.h"
+#include "pinmap.h"
+#include "peripherals/gpio.h"
+#include <stdint.h>
+#include <stddef.h>
+#include "drivers/backlight/backlight.h"
+
+/* i8080 write-strobe timing (moved out of the SoC registers.h -- it belongs to
+ * the ST7735S driver, not the HR_C7000 register map).  The panel RESET pin
+ * (PTC2, GPIO, active-low) is driven via LCD_RST from pinmap.h. */
+#define LCD_WCFG_DEFAULT 0x020202u /* 2/2/2 strobes ~143 ns */
+
+/* ST7735S command opcodes used by the init sequence. */
+enum {
+    ST7735_SLPOUT = 0x11,
+    ST7735_DISPON = 0x29,
+    ST7735_CASET = 0x2a,
+    ST7735_RASET = 0x2b,
+    ST7735_RAMWR = 0x2c,
+    ST7735_MADCTL = 0x36,
+    ST7735_COLMOD = 0x3a,
+};
+
+static inline void send_cmd(uint8_t cmd)
+{
+    LCD_HW->INDEX = cmd;
+}
+static inline void send_data(uint8_t d)
+{
+    LCD_HW->DATA = d;
+}
+
+static void set_window(uint8_t x0, uint8_t x1, uint8_t y0, uint8_t y1)
+{
+    send_cmd(ST7735_CASET);
+    send_data(0);
+    send_data(x0);
+    send_data(0);
+    send_data(x1);
+    send_cmd(ST7735_RASET);
+    send_data(0);
+    send_data(y0);
+    send_data(0);
+    send_data(y1);
+}
+
+void display_init(void)
+{
+    /* Claim the PTC pads for the i8080 controller and make the panel-reset
+     * pin (PTC2) a GPIO output.  DIPLEX2 upper bits are write-only -- always
+     * write the whole-register constant, never read-modify-write.  GPIOC DDR
+     * marks PTC2..14 (reset + LCD bus) as outputs: this is the resting state
+     * the keyboard scan saves and restores around borrowing the shared pins. */
+    GPIOC->DDR = 0x00007ffcu;
+    SOCSYS->IO_DIPLEX2 = HD2_DIPLEX2_LCD_I80;
+    gpio_setMode(LCD_RST, OUTPUT);
+    LCD_HW->WCFG = LCD_WCFG_DEFAULT; /* 2/2/2 write strobes (~143 ns) */
+
+    /* Reset pulse (active-low) to ST7735S datasheet timing. */
+    LCD_HW->INDEX; /* (barrier: ensure mux write posted) */
+    gpio_setPin(LCD_RST);
+    delayMs(10);
+    gpio_clearPin(LCD_RST);
+    delayMs(10);
+    gpio_setPin(LCD_RST);
+    delayMs(120);
+
+    send_cmd(ST7735_SLPOUT);
+    delayMs(120);
+
+    /* Frame rate (vendor V2.1.3 values). */
+    send_cmd(0xb1);
+    send_data(5);
+    send_data(0x3c);
+    send_data(0x3c);
+    send_cmd(0xb2);
+    send_data(5);
+    send_data(0x3c);
+    send_data(0x3c);
+    send_cmd(0xb3);
+    send_data(5);
+    send_data(0x3c);
+    send_data(0x3c);
+    send_data(5);
+    send_data(0x3c);
+    send_data(0x3c);
+    send_cmd(0xb4);
+    send_data(3);
+
+    /* Power control. */
+    send_cmd(0xc0);
+    send_data(0x28);
+    send_data(8);
+    send_data(4);
+    send_cmd(0xc1);
+    send_data(0xc0);
+    send_cmd(0xc2);
+    send_data(0x0d);
+    send_data(0);
+    send_cmd(0xc3);
+    send_data(0x8d);
+    send_data(0x2a);
+    send_cmd(0xc4);
+    send_data(0x8d);
+    send_data(0xee);
+    send_cmd(0xc5);
+    send_data(0x1a);
+
+    /* Gamma (positive / negative), 16 bytes each. */
+    static const uint8_t gp[16] = {
+        0x04, 0x22, 0x07, 0x0a, 0x2e, 0x30, 0x25, 0x2a,
+        0x28, 0x26, 0x2e, 0x3a, 0x00, 0x01, 0x03, 0x13,
+    };
+    send_cmd(0xe0);
+    for (unsigned i = 0; i < sizeof gp; i++)
+        send_data(gp[i]);
+
+    static const uint8_t gn[16] = {
+        0x04, 0x16, 0x06, 0x0d, 0x2d, 0x26, 0x23, 0x27,
+        0x27, 0x25, 0x2d, 0x3b, 0x00, 0x01, 0x04, 0x13,
+    };
+    send_cmd(0xe1);
+    for (unsigned i = 0; i < sizeof gn; i++)
+        send_data(gn[i]);
+
+    send_cmd(ST7735_MADCTL);
+    send_data(0xa0); /* landscape, RGB order */
+    send_cmd(ST7735_COLMOD);
+    send_data(0x05); /* RGB565 */
+
+    /* Blank GRAM to black (full-window RAMWR + zeros). */
+    set_window(0, CONFIG_SCREEN_WIDTH - 1, 0, CONFIG_SCREEN_HEIGHT - 1);
+    send_cmd(ST7735_RAMWR);
+    for (size_t i = 0; i < (size_t)CONFIG_SCREEN_WIDTH * CONFIG_SCREEN_HEIGHT;
+         ++i) {
+        LCD_HW->DATA = 0;
+        LCD_HW->DATA = 0;
+    }
+
+    send_cmd(ST7735_DISPON);
+
+    backlight_init(); /* explicit init; the core sets the level (openrtx.c) */
+}
+
+void display_terminate(void)
+{
+    /* Framebuffer is owned by the graphics layer; nothing to free. */
+}
+
+void display_renderRows(uint8_t startRow, uint8_t endRow, void *fb)
+{
+    if (endRow > CONFIG_SCREEN_HEIGHT)
+        endRow = CONFIG_SCREEN_HEIGHT;
+    if (startRow >= endRow)
+        return;
+
+    set_window(0, CONFIG_SCREEN_WIDTH - 1, startRow, endRow - 1);
+    send_cmd(ST7735_RAMWR);
+
+    const uint16_t *p = (const uint16_t *)fb
+                      + (size_t)startRow * CONFIG_SCREEN_WIDTH;
+    const size_t n = (size_t)(endRow - startRow) * CONFIG_SCREEN_WIDTH;
+
+    /* Big-endian RGB565, one byte per DATA write. */
+    for (size_t i = 0; i < n; ++i) {
+        uint16_t v = p[i];
+        LCD_HW->DATA = (uint32_t)(v >> 8);
+        LCD_HW->DATA = (uint32_t)(v & 0xffu);
+    }
+}
+
+void display_render(void *fb)
+{
+    display_renderRows(0, CONFIG_SCREEN_HEIGHT, fb);
+}

--- a/platform/drivers/keyboard/keyboard_HD2.c
+++ b/platform/drivers/keyboard/keyboard_HD2.c
@@ -1,0 +1,145 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 OpenRTX Contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * HD2 keypad driver -- implements OpenRTX keyboard.h (kbd_init /
+ * kbd_terminate / kbd_getKeys).
+ *
+ * The 4x4 matrix shares the LCD data pins on GPIOC (rows PTC7-10, cols
+ * PTC11-14).  A scan momentarily swaps the PTC pad mux (DIPLEX2) from the
+ * i8080 LCD controller to GPIO and back, and saves/restores GPIOC DR+DDR,
+ * so the LCD bus is preserved across calls.  Rows sense through the vendor
+ * alternate-function-B selector (gpio_setAltFuncB), set once in kbd_init.
+ *
+ * Because the matrix and the LCD share pins, a scan must NOT interleave
+ * with a display_render(); OpenRTX runs the UI on a single thread that
+ * scans then renders, so they never overlap.
+ *
+ * Matrix cell map, side keys (GPIOB.9 = SK1, GPIOB.7 = EMER) and the SK2
+ * "row0 in every column" phantom are live-verified on the V2.1.3 hardware.
+ * The rotary-encoder lines (GPIOA.0/1) are a first-cut poll and may need
+ * revisiting.
+ */
+
+#include "interfaces/keyboard.h"
+#include "interfaces/delays.h"
+#include "registers.h"
+#include "pinmap.h"
+#include "peripherals/gpio.h"
+#include <stdint.h>
+
+/* SK2 grounds the row0 sense line, so a scan reads row0 low in EVERY
+ * column (bit col*4+row0 for all 4 cols).  Unique -> report KEY_F3.
+ * (Matrix geometry and pin labels live in pinmap.h.) */
+#define KBD_ROW0_ALL_COLS 0x1111u
+
+/* Matrix (row, col) -> key.  Live-verified: the matrix column is the
+ * physical key column {1,2,3}/{4,5,6}/{7,8,9}, col3 = nav keys. */
+static const keyboard_t keymap[KBD_ROW_COUNT][KBD_COL_COUNT] = {
+    { KEY_1, KEY_4, KEY_7, KEY_ENTER },     /* row0 */
+    { KEY_2, KEY_5, KEY_8, KEY_UP },        /* row1 */
+    { KEY_3, KEY_6, KEY_9, KEY_DOWN },      /* row2 */
+    { KEY_STAR, KEY_0, KEY_HASH, KEY_ESC }, /* row3 */
+};
+
+static uint8_t rot_prev = 0;
+
+void kbd_init()
+{
+    /* Route the row pins (GPIOC 7..10) to the alt-func-B keypad sense path;
+     * without this they read 0 (they are LCD-bus outputs otherwise). */
+    for (uint8_t row = 0; row < KBD_ROW_COUNT; ++row)
+        gpio_setAltFuncB(KBD_ROW(row));
+
+    /* Side keys + rotary are inputs. */
+    gpio_setMode(SK1_SW, INPUT);
+    gpio_setMode(EMER_SW, INPUT);
+    gpio_setMode(ROT_A, INPUT);
+    gpio_setMode(ROT_B, INPUT);
+
+    rot_prev = (uint8_t)(gpio_readPin(ROT_A) | (gpio_readPin(ROT_B) << 1));
+}
+
+void kbd_terminate()
+{
+    /* DR/DDR are restored per scan; nothing to release. */
+}
+
+/* Raw matrix scan: 4 nibbles (one per col), each bit = one row read.
+ * bit=1 -> row high (no key); bit=0 -> key pressed in that (row, col). */
+static uint16_t scan_matrix(void)
+{
+    /* Whole-register save/restore of the shared LCD bus: no per-pin API can
+     * snapshot the entire port, so these stay direct register accesses. */
+    uint32_t saved_dr = GPIOC->DR;
+    uint32_t saved_ddr = GPIOC->DDR;
+
+    /* Borrow the shared PTC pads from the i8080 LCD controller. */
+    SOCSYS->IO_DIPLEX2 = HD2_DIPLEX2_PTC_GPIO;
+
+    /* rows (7..10) input, cols (11..14) output, cols idle high */
+    for (unsigned row = 0; row < KBD_ROW_COUNT; ++row)
+        gpio_setMode(KBD_ROW(row), INPUT);
+    for (unsigned col = 0; col < KBD_COL_COUNT; ++col) {
+        gpio_setMode(KBD_COL(col), OUTPUT);
+        gpio_setPin(KBD_COL(col));
+    }
+
+    uint16_t out = 0;
+    for (unsigned col = 0; col < KBD_COL_COUNT; ++col) {
+        gpio_clearPin(KBD_COL(col)); /* drive this col low */
+        delayUs(10);                 /* let the driven column + rows settle */
+        uint32_t rows = 0;
+        for (unsigned row = 0; row < KBD_ROW_COUNT; ++row)
+            rows |= (uint32_t)gpio_readPin(KBD_ROW(row)) << row;
+        out |= (uint16_t)(rows << (col * 4));
+        gpio_setPin(KBD_COL(col)); /* restore high before next */
+    }
+
+    GPIOC->DR = saved_dr;
+    GPIOC->DDR = saved_ddr;
+    SOCSYS->IO_DIPLEX2 = HD2_DIPLEX2_LCD_I80; /* hand pads back to the LCD */
+    return out;
+}
+
+static keyboard_t rotary_step(void)
+{
+    uint8_t now = (uint8_t)(gpio_readPin(ROT_A) | (gpio_readPin(ROT_B) << 1));
+    uint8_t prev = rot_prev;
+    rot_prev = now;
+
+    static const int8_t qdec[16] = {
+        0, +1, -1, 0, -1, 0, 0, +1, +1, 0, 0, -1, 0, -1, +1, 0,
+    };
+    int8_t step = qdec[(prev << 2) | now];
+    if (step > 0)
+        return KNOB_RIGHT;
+    if (step < 0)
+        return KNOB_LEFT;
+    return 0;
+}
+
+keyboard_t kbd_getKeys()
+{
+    keyboard_t keys = 0;
+
+    uint16_t raw = scan_matrix();
+    if (raw != 0 && (raw & KBD_ROW0_ALL_COLS) == 0u) {
+        keys |= KEY_F3; /* SK2: row0 low in every column */
+    } else if (raw != 0) {
+        for (unsigned col = 0; col < KBD_COL_COUNT; ++col) {
+            uint8_t rows_high = (raw >> (col * 4)) & 0xfu;
+            for (unsigned row = 0; row < KBD_ROW_COUNT; ++row)
+                if ((rows_high & (1u << row)) == 0u) /* active-low */
+                    keys |= keymap[row][col];
+        }
+    }
+
+    if (gpio_readPin(SK1_SW) == 0u)
+        keys |= KEY_F1;
+    if (gpio_readPin(EMER_SW) == 0u)
+        keys |= KEY_F2;
+
+    keys |= rotary_step();
+    return keys;
+}

--- a/platform/mcu/HR_C7000/drivers/delays.cpp
+++ b/platform/mcu/HR_C7000/drivers/delays.cpp
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * OpenRTX interfaces/delays.h implementation for the HR_C7000 (CK803S), built
+ * on the tickless vendor Miosix kernel: getTime() returns nanoseconds (it
+ * replaces the old getTick), and sleepUntil is nanoSleepUntil(absNs).  OpenRTX
+ * works in milliseconds (TICK_FREQ=1000), so convert at the boundary.  Modeled
+ * on the per-MCU delays.cpp of the other targets (e.g. mcu/STM32F4xx/drivers).
+ */
+
+#include "interfaces/delays.h"
+#include <miosix.h>
+
+/* The kernel's busy-wait delays live in namespace miosix; the OpenRTX interface
+ * (interfaces/delays.h, extern "C") declares the GLOBAL delayMs/delayUs. */
+namespace miosix
+{
+void delayMs(unsigned int);
+void delayUs(unsigned int);
+}
+
+void delayUs(unsigned int useconds)
+{
+    miosix::delayUs(useconds);
+}
+
+void delayMs(unsigned int mseconds)
+{
+    miosix::delayMs(mseconds);
+}
+
+void sleepFor(unsigned int seconds, unsigned int mseconds)
+{
+    miosix::Thread::sleep(seconds * 1000u + mseconds);
+}
+
+void sleepUntil(long long timestamp)
+{
+    /* OpenRTX passes an absolute millisecond timestamp; the tickless kernel
+     * wants absolute nanoseconds. */
+    miosix::Thread::nanoSleepUntil(timestamp * 1000000LL);
+}
+
+long long getTick(void)
+{
+    return miosix::getTime() / 1000000LL; /* ns -> ms (TICK_FREQ=1000) */
+}

--- a/platform/mcu/HR_C7000/drivers/i2c_hrc7000.c
+++ b/platform/mcu/HR_C7000/drivers/i2c_hrc7000.c
@@ -1,0 +1,164 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * HR_C7000 DesignWare DW_apb_i2c master driver (peripherals/i2c.h).  See the
+ * header for the IC_START-trigger quirk and the stop-flag semantics.
+ */
+
+#include "drivers/i2c_hrc7000.h"
+#include "registers.h"
+#include <pthread.h>
+#include <stddef.h>
+
+#define I2C_SPIN_LIMIT 0x40000
+
+/* Bounded busy-wait: spin until (*reg & mask) matches `set`.  Used for both the
+ * IC_STATUS FIFO/bus bits and the IC_ENABLE_STATUS settle bit. */
+static void wait_bits(volatile uint32_t *reg, uint32_t mask, bool set)
+{
+    for (int spin = I2C_SPIN_LIMIT; spin; --spin) {
+        if (((*reg & mask) != 0u) == set)
+            return;
+    }
+}
+
+/* Base controller config (master, 7-bit, fast-mode, restart-enabled).  IC_CON /
+ * timing can only change while disabled, so leave the controller OFF here; the
+ * first transfer sets IC_TAR and enables it (ensure_target). */
+static void configure(I2C_TypeDef *hw)
+{
+    hw->IC_ENABLE = 0u;
+    wait_bits(&hw->IC_ENABLE_STATUS, 1u, false);
+    hw->IC_CON = I2C_CON_MASTER_FS;
+    hw->IC_FS_SCL_HCNT = I2C_SCL_HCNT;
+    hw->IC_FS_SCL_LCNT = I2C_SCL_LCNT;
+    hw->IC_INTR_MASK = 0x40u;
+    hw->IC_RX_TL = 6u;
+    hw->IC_TX_TL = 6u;
+}
+
+/* Point the master at `addr`, enabling it if needed.  IC_TAR only changes while
+ * disabled, so toggle enable ONLY when the target actually differs -- toggling
+ * it around every transfer corrupts the FIFO/command alignment (live-verified).
+ * A single-slave bus (e.g. the RTC) thus configures the target exactly once. */
+static void ensure_target(I2C_TypeDef *hw, uint8_t addr)
+{
+    if ((hw->IC_ENABLE_STATUS & 1u) && (hw->IC_TAR == addr))
+        return;
+
+    hw->IC_ENABLE = 0u;
+    wait_bits(&hw->IC_ENABLE_STATUS, 1u, false);
+    hw->IC_TAR = addr;
+    hw->IC_ENABLE = 1u;
+    wait_bits(&hw->IC_ENABLE_STATUS, 1u, true);
+}
+
+/* Post-transfer health check: a clean transfer leaves the TX FIFO empty, the
+ * bus idle and no abort latched.  Otherwise clear the abort and reconfigure
+ * (the next transfer re-sets IC_TAR and re-enables). */
+static void recover(I2C_TypeDef *hw)
+{
+    if ((hw->IC_STATUS & I2C_STA_TFE) && !(hw->IC_STATUS & I2C_STA_ACTIVITY)
+        && (hw->IC_TX_ABRT_SRC == 0u))
+        return;
+    (void)hw->IC_CLR_TX_ABRT;
+    configure(hw);
+}
+
+/* Trigger the accumulated transfer and wait for it to drain + the bus to idle. */
+static void trigger(I2C_TypeDef *hw)
+{
+    hw->IC_START = 1u; /* HR_C7000 explicit transfer trigger */
+    wait_bits(&hw->IC_STATUS, I2C_STA_TFE, true);
+    wait_bits(&hw->IC_STATUS, I2C_STA_ACTIVITY, false);
+    hw->IC_START = 0u;
+    recover(hw);
+}
+
+static int i2c_hrc7000_write(const struct i2cDevice *dev, const uint8_t addr,
+                             const void *data, const size_t len,
+                             const bool stop)
+{
+    I2C_TypeDef *hw = (I2C_TypeDef *)dev->periph;
+    const uint8_t *bytes = (const uint8_t *)data;
+
+    if ((hw == NULL) || ((len != 0u) && (bytes == NULL)))
+        return -1;
+
+    ensure_target(hw, addr);
+
+    for (size_t i = 0; i < len; ++i) {
+        wait_bits(&hw->IC_STATUS, I2C_STA_TFNF, true);
+        uint32_t cmd = bytes[i];
+        if (stop && (i == (len - 1u)))
+            cmd |= I2C_CMD_STOP;
+        hw->IC_DATA_CMD = cmd;
+    }
+
+    /* stop=false -> keep the bytes queued for a following (repeated-START)
+     * read/write; the transfer is triggered only when a stop is requested. */
+    if (stop)
+        trigger(hw);
+
+    return 0;
+}
+
+static int i2c_hrc7000_read(const struct i2cDevice *dev, const uint8_t addr,
+                            void *data, const size_t len, const bool stop)
+{
+    I2C_TypeDef *hw = (I2C_TypeDef *)dev->periph;
+    uint8_t *bytes = (uint8_t *)data;
+
+    if ((hw == NULL) || (len == 0u) || (bytes == NULL))
+        return -1;
+
+    ensure_target(hw, addr);
+
+    /* Queue one read command per byte (flushes any pending write bytes ahead of
+     * them as a repeated-START), then trigger and drain the RX FIFO. */
+    for (size_t i = 0; i < len; ++i) {
+        wait_bits(&hw->IC_STATUS, I2C_STA_TFNF, true);
+        uint32_t cmd = I2C_CMD_READ;
+        if (stop && (i == (len - 1u)))
+            cmd |= I2C_CMD_STOP;
+        hw->IC_DATA_CMD = cmd;
+    }
+
+    hw->IC_START = 1u;
+    for (size_t i = 0; i < len; ++i) {
+        wait_bits(&hw->IC_STATUS, I2C_STA_RFNE, true);
+        bytes[i] = (uint8_t)hw->IC_DATA_CMD;
+    }
+    wait_bits(&hw->IC_STATUS, I2C_STA_ACTIVITY, false);
+    hw->IC_START = 0u;
+    recover(hw);
+
+    return 0;
+}
+
+const struct i2cApi i2cHrc7000_driver = {
+    .read = i2c_hrc7000_read,
+    .write = i2c_hrc7000_write,
+};
+
+int i2c_init(const struct i2cDevice *dev, const uint8_t speed)
+{
+    (void)speed; /* fixed vendor fast-mode timing */
+    if ((dev == NULL) || (dev->periph == NULL))
+        return -1;
+
+    if (dev->mutex != NULL)
+        pthread_mutex_init((pthread_mutex_t *)dev->mutex, NULL);
+
+    configure((I2C_TypeDef *)dev->periph);
+    return 0;
+}
+
+void i2c_terminate(const struct i2cDevice *dev)
+{
+    if ((dev == NULL) || (dev->periph == NULL))
+        return;
+    ((I2C_TypeDef *)dev->periph)->IC_ENABLE = 0u;
+}

--- a/platform/mcu/HR_C7000/drivers/i2c_hrc7000.h
+++ b/platform/mcu/HR_C7000/drivers/i2c_hrc7000.h
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * I2C master driver for the HR_C7000's DesignWare DW_apb_i2c blocks (I2C0..2),
+ * implementing the standard peripherals/i2c.h interface.  One driver serves
+ * every instance; the bus is selected by the i2cDevice's `periph` (an
+ * I2C_TypeDef base).
+ *
+ * HR_C7000 quirk (manual 5.1.6.27): unlike stock DesignWare, the master does
+ * NOT auto-start when the TX FIFO has data -- it waits for an explicit IC_START
+ * (+0xa0) write.  This driver therefore treats `stop`:
+ *   - false -> queue the bytes into the TX FIFO but do NOT trigger yet;
+ *   - true  -> queue (last byte flagged STOP) and trigger the whole accumulated
+ *              transfer with one IC_START.
+ * That reproduces the combined repeated-START register read (write the pointer
+ * with stop=false, then read with stop=true) as a single hardware transfer.
+ */
+
+#ifndef I2C_HRC7000_H
+#define I2C_HRC7000_H
+
+#include "peripherals/i2c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Device driver API for the HR_C7000 DesignWare I2C master. */
+extern const struct i2cApi i2cHrc7000_driver;
+
+/**
+ * Instantiate an HR_C7000 I2C master device.
+ *
+ * @param name: device name.
+ * @param peripheral: underlying I2C base (e.g. I2C2).
+ * @param mutx: pointer to mutex, or NULL.
+ */
+#define I2C_HRC7000_DEVICE_DEFINE(name, peripheral, mutx) \
+    const struct i2cDevice name = {                       \
+        .driver = &i2cHrc7000_driver,                     \
+        .periph = peripheral,                             \
+        .mutex = mutx,                                    \
+    };
+
+/**
+ * Initialise an HR_C7000 I2C peripheral.  The timing is the fixed vendor
+ * fast-mode setup (the `speed` argument is accepted for interface conformance
+ * but not yet used).  Does not configure any pads -- the RTC's I2C2 is an
+ * internal bus; external instances must have their pads muxed by app code.
+ *
+ * @param dev: device driver handle.
+ * @param speed: bus speed (see enum I2CSpeed); currently ignored.
+ * @return zero on success, a negative error code otherwise.
+ */
+int i2c_init(const struct i2cDevice *dev, const uint8_t speed);
+
+/**
+ * Shut down an HR_C7000 I2C peripheral.
+ *
+ * @param dev: device driver handle.
+ */
+void i2c_terminate(const struct i2cDevice *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* I2C_HRC7000_H */

--- a/platform/mcu/HR_C7000/drivers/rtc_hd2.c
+++ b/platform/mcu/HR_C7000/drivers/rtc_hd2.c
@@ -1,0 +1,162 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 OpenRTX Contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * RTC driver for the Ailunce HD2 (HR_C7000 / CK803S), implementing
+ * OpenRTX peripherals/rtc.h.
+ *
+ * The HR_C7000 RTC is an I2C timekeeper on the SoC's internal I2C2 bus
+ * (slave 0x70; manual 4.9), accessed through the shared HR_C7000 I2C driver
+ * (i2c_hrc7000, instance `i2c2` in hwconfig.c).  Register values are plain
+ * BINARY (not BCD): seconds/minutes are 6-bit, hours 5-bit, and the day field
+ * is a 16-bit count of days since 1970-01-01.  The core is battery-backed and
+ * keeps running across power cycles, so init only ensures the run bit is set
+ * rather than replaying the cold first-power sequence.
+ */
+
+#include "peripherals/rtc.h"
+#include "core/datetime.h"
+#include "hwconfig.h" /* i2c2 device instance + RTC_I2C_SLAVE (registers.h) */
+#include "i2c_hrc7000.h" /* i2c_init */
+
+/* RTC register offsets (manual 4.9.4). */
+enum {
+    RTC_VAL_S = 0x00,
+    RTC_VAL_M = 0x01,
+    RTC_VAL_H = 0x02,
+    RTC_VAL_D_L = 0x03,
+    RTC_VAL_D_H = 0x04,
+    RTC_LOAD_S = 0x0c,
+    RTC_LOAD_M = 0x0d,
+    RTC_LOAD_H = 0x0e,
+    RTC_LOAD_D_L = 0x0f,
+    RTC_LOAD_D_H = 0x10,
+    RTC_CCR = 0x11,
+    RTC_LOAD_VSTAT = 0x12,
+};
+
+/* Clock-control register (RTC_CCR) bits. */
+enum {
+    RTC_CCR_RUN = (1u << 1),
+    RTC_CCR_LOAD = (1u << 2),
+};
+
+/* ---- register access over the shared I2C driver -------------------- */
+
+static void rtc_reg_write(uint8_t reg, uint8_t val)
+{
+    uint8_t buf[2] = { reg, val };
+
+    i2c_acquire(&i2c2);
+    i2c_write(&i2c2, RTC_I2C_SLAVE, buf, sizeof(buf), true);
+    i2c_release(&i2c2);
+}
+
+static uint8_t rtc_reg_read(uint8_t reg)
+{
+    uint8_t val = 0;
+
+    /* Combined repeated-START read: write the register pointer (no STOP), then
+     * read one byte (STOP).  The mutex is held across both so the pointer write
+     * and the read are not interleaved by another bus user. */
+    i2c_acquire(&i2c2);
+    i2c_write(&i2c2, RTC_I2C_SLAVE, &reg, 1, false);
+    i2c_read(&i2c2, RTC_I2C_SLAVE, &val, 1, true);
+    i2c_release(&i2c2);
+
+    return val;
+}
+
+/* ---- OpenRTX peripherals/rtc.h interface --------------------------- */
+
+void rtc_init()
+{
+    uint8_t ccr;
+
+    i2c_init(&i2c2, I2C_SPEED_400kHz);
+    ccr = rtc_reg_read(RTC_CCR);
+    if ((ccr & RTC_CCR_RUN) == 0u)
+        rtc_reg_write(RTC_CCR, ccr | RTC_CCR_RUN);
+}
+
+void rtc_terminate()
+{
+    /* The RTC is battery-backed and keeps running; nothing to shut down. */
+}
+
+datetime_t rtc_getTime()
+{
+    datetime_t t = { 0 };
+    uint8_t s, m, h, dl, dh;
+    int32_t days, year;
+    uint32_t mon, mday;
+
+    s = rtc_reg_read(RTC_VAL_S);
+    m = rtc_reg_read(RTC_VAL_M);
+    h = rtc_reg_read(RTC_VAL_H);
+    dl = rtc_reg_read(RTC_VAL_D_L);
+    dh = rtc_reg_read(RTC_VAL_D_H);
+
+    t.second = (int8_t)(s & 0x3fu);
+    t.minute = (int8_t)(m & 0x3fu);
+    t.hour = (int8_t)(h & 0x1fu);
+
+    days = (int32_t)(((uint32_t)dh << 8) | (uint32_t)dl);
+    daysToCivil(days, &year, &mon, &mday);
+    t.date = (int8_t)mday;
+    t.month = (int8_t)mon;
+    t.year = (uint8_t)((year >= 2000) ? (year - 2000) : 0);
+
+    /* 1970-01-01 was a Thursday; map to 1..7 (Mon..Sun). */
+    t.day = (int8_t)((((days % 7) + 7 + 3) % 7) + 1);
+    return t;
+}
+
+void rtc_setTime(datetime_t t)
+{
+    int32_t days;
+    uint32_t day16;
+    uint8_t ccr;
+
+    days = civilToDays(2000 + (int32_t)t.year, (uint32_t)t.month,
+                       (uint32_t)t.date);
+    if (days < 0)
+        days = 0;
+    day16 = (uint32_t)days & 0xffffu;
+
+    rtc_reg_write(RTC_LOAD_VSTAT, 0u);
+    rtc_reg_write(RTC_LOAD_H, (uint8_t)((uint32_t)t.hour & 0x1fu));
+    rtc_reg_write(RTC_LOAD_M, (uint8_t)((uint32_t)t.minute & 0x3fu));
+    rtc_reg_write(RTC_LOAD_S, (uint8_t)((uint32_t)t.second & 0x3fu));
+    rtc_reg_write(RTC_LOAD_D_L, (uint8_t)(day16 & 0xffu));
+    rtc_reg_write(RTC_LOAD_D_H, (uint8_t)((day16 >> 8) & 0xffu));
+    rtc_reg_write(RTC_LOAD_VSTAT, 1u);
+
+    ccr = rtc_reg_read(RTC_CCR);
+    rtc_reg_write(RTC_CCR, ccr | RTC_CCR_LOAD | RTC_CCR_RUN);
+}
+
+void rtc_setHour(uint8_t hours, uint8_t minutes, uint8_t seconds)
+{
+    datetime_t t = rtc_getTime();
+    t.hour = (int8_t)hours;
+    t.minute = (int8_t)minutes;
+    t.second = (int8_t)seconds;
+    rtc_setTime(t);
+}
+
+void rtc_setDate(uint8_t date, uint8_t month, uint8_t year)
+{
+    datetime_t t = rtc_getTime();
+    t.date = (int8_t)date;
+    t.month = (int8_t)month;
+    t.year = year;
+    rtc_setTime(t);
+}
+
+void rtc_dstSet()
+{
+} /* no hardware DST bit; handled in higher layers */
+void rtc_dstClear()
+{
+}

--- a/platform/mcu/HR_C7000/registers.h
+++ b/platform/mcu/HR_C7000/registers.h
@@ -1,0 +1,233 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+/*
+ * HR_C7000 (Ailunce HD2) MMIO peripheral register map -- bring-up subset.
+ *
+ * Each peripheral is described as a struct laid out at its register offsets
+ * (gaps for registers this port does not use are RESERVED padding), and cast onto
+ * the peripheral base address via the accessor macros at the bottom -- the CMSIS
+ * convention. The named registers and their offsets are taken from the HR_C7000
+ * vendor user guide (system-control chapter 4, peripherals chapter 5); the wider
+ * modem / codec / RF register set is intentionally omitted from this port. Base
+ * addresses, pin-mux masks and "magic" configuration words are hardware facts
+ * recovered by on-device reverse engineering of the vendor V2.1.3 firmware; they
+ * are not guessed.
+ */
+
+#ifndef HRC7000_REGISTERS_H
+#define HRC7000_REGISTERS_H
+
+#include <stdint.h>
+
+/* -------------------------------------------------------------------------
+ *  SOCSYS -- chip system control / clock / pin-mux (base 0x11000000)
+ *  Manual 4.1 (reset), 4.2 (clock), 4.4 (system control).
+ * ------------------------------------------------------------------------- */
+typedef struct {
+    volatile uint32_t SYS_SOFT_RSTN; /* 0x00 per-block soft reset, active-low:
+                                      * [8]cpu [7]sys [6]adc_ctrl [5]adc
+                                      * [4]codec [3]audio [2]fm [1]phy [0]protocol */
+    volatile uint32_t
+        CLK_MGR_REG04; /* 0x04 PLL reconfig ctrl (b31 pll_ld, b30 clk_rdy) */
+    volatile uint32_t CLK_MGR_REG08; /* 0x08 APLL divider configuration */
+    volatile uint32_t CLK_MGR_REG0C; /* 0x0c APLL divider configuration */
+    volatile uint32_t CLK_MGR_REG10; /* 0x10 BPLL divider configuration */
+    volatile uint32_t CLK_MGR_REG14; /* 0x14 BPLL divider configuration */
+    volatile uint32_t CLK_MGR_REG18; /* 0x18 baseband clock divider coefficient */
+    volatile uint32_t CLK_MGR_REG1C; /* 0x1c FM 32K/192K divider coefficient */
+    volatile uint32_t CLK_MGR_REG20; /* 0x20 codec I2S interface clock divider */
+    volatile uint32_t CLK_MGR_REG24; /* 0x24 bus-related clock divider */
+    volatile uint32_t CLK_MGR_REG28; /* 0x28 SDIO/USB clock divider */
+    volatile uint32_t CLK_MGR_REG2C; /* 0x2c gated-clock control enable */
+    volatile uint32_t LCSFC_BAUDR;   /* 0x30 LCSFC SPI SCLK clock divider */
+    volatile uint32_t IO_DIPLEX0;    /* 0x34 PTA pad mux (i2c1/uart2/audio) */
+    volatile uint32_t IO_DIPLEX1;    /* 0x38 PTA pad mux (spi0 pins) */
+    volatile uint32_t IO_DIPLEX2;    /* 0x3c PTC pad mux */
+} SOCSYS_TypeDef;
+
+/* HD2 board PTC pad-mux values (HD2_DIPLEX2_*) live in targets/HD2/pinmap.h. */
+
+/* -------------------------------------------------------------------------
+ *  GPIO banks -- DesignWare DW_apb_gpio (one struct, three instances)
+ *  Manual 5.7, Register Tables 20-22.
+ * ------------------------------------------------------------------------- */
+typedef struct {
+    volatile uint32_t DR;      /* 0x00 output data (SWPORTA_DR) */
+    volatile uint32_t DDR;     /* 0x04 direction: 1 = output (SWPORTA_DDR) */
+    uint32_t RESERVED0[10];    /* 0x08 - 0x2c */
+    volatile uint32_t INTEN;   /* 0x30 interrupt enable */
+    volatile uint32_t INTMASK; /* 0x34 interrupt mask */
+    volatile uint32_t INTTYPE_LEVEL; /* 0x38 interrupt type (edge/level) */
+    volatile uint32_t INT_POLARITY;  /* 0x3c interrupt polarity */
+    volatile uint32_t INTSTATUS;     /* 0x40 masked interrupt status */
+    volatile uint32_t RAW_INTSTATUS; /* 0x44 raw (pre-mask) interrupt status */
+    volatile uint32_t DEBOUNCE;      /* 0x48 debounce enable */
+    volatile uint32_t PORTA_EOI;  /* 0x4c interrupt clear (end-of-interrupt) */
+    volatile uint32_t EXT_PORT;   /* 0x50 input read-back (EXT_PORTA) */
+    uint32_t RESERVED1[9];        /* 0x54 - 0x74 */
+    volatile uint32_t ALT_FUNC_B; /* 0x78 vendor per-pin alt-function-B select;
+                                   * not part of DW_apb_gpio and distinct from
+                                   * the SOCSYS pad-mux (see gpio_setAltFuncB) */
+} GPIO_TypeDef;
+
+/* HD2 board GPIOB pin bits (LED/PTT/PWR/GPS) live in targets/HD2/pinmap.h. */
+
+/* -------------------------------------------------------------------------
+ *  LCD -- HR_C7000 hardware i8080 controller (base 0x12000000, manual 5.3)
+ * ------------------------------------------------------------------------- */
+typedef struct {
+    volatile uint32_t INDEX; /* 0x00 command cycle */
+    volatile uint32_t DATA;  /* 0x04 8-bit data cycle */
+    uint32_t RESERVED0[2];   /* 0x08 - 0x0c */
+    volatile uint32_t WCFG;  /* 0x10 write strobe timing */
+} LCD_TypeDef;
+/* LCD_WCFG_DEFAULT / LCD_RESET_BIT (panel-specific) live in the ST7735S driver. */
+
+/* -------------------------------------------------------------------------
+ *  PWM block (base 0x140c0000, manual 5.8, Register Table 23). Per-channel
+ *  registers CFG/RPT/PER/FP/STATUS at 0x00/0x04/0x08/0x0c/0x10; channel stride
+ *  0x20; ch0 = LCD backlight.
+ * ------------------------------------------------------------------------- */
+typedef struct {
+    volatile uint32_t CFG;    /* 0x00 config: start/mode/soft_rst/inten */
+    volatile uint32_t RPT;    /* 0x04 ONE_SHOT repeated-period count */
+    volatile uint32_t PER;    /* 0x08 system-clock cycles per period */
+    volatile uint32_t FP;     /* 0x0c first-phase clock cycles (duty) */
+    volatile uint32_t STATUS; /* 0x10 status register */
+    volatile uint32_t RESERVED_HW[3]; /* 0x14-0x1c manual marks reserved; vendor
+                                       * V2.1.3 writes 0x300 here -- required or
+                                       * the backlight stays dark. */
+} PWM_Channel_TypeDef;
+
+#define PWM_TIMER_HZ 42000000u /* post-PLL source feeding the PWM block */
+/* PWM ch0 duty-gating: the V2.1.3 boot leaves STATUS (0x10) and the three
+ * reserved words 0x14-0x1c at 0x300.  Left at 0 they silently squash the duty
+ * cycle -> backlight LED stays dark. */
+#define PWM_CH0_GATE_ON 0x00000300u
+
+/* -------------------------------------------------------------------------
+ *  I2C2 -- DesignWare DW_apb_i2c, the RTC's dedicated internal bus.
+ *  (base 0x14080000; RTC slave address 0x70). The HR_C7000 adds a non-standard
+ *  IC_START (+0xa0) trigger that must be written to launch a transfer.
+ *  Manual 5.1, Register Tables 9-10.
+ * ------------------------------------------------------------------------- */
+typedef struct {
+    volatile uint32_t IC_CON;           /* 0x00 master cfg = 0x65 */
+    volatile uint32_t IC_TAR;           /* 0x04 target slave 7-bit address */
+    uint32_t RESERVED0[2];              /* 0x08 - 0x0c */
+    volatile uint32_t IC_DATA_CMD;      /* 0x10 tx data byte / rx command */
+    uint32_t RESERVED1[2];              /* 0x14 - 0x18 */
+    volatile uint32_t IC_FS_SCL_HCNT;   /* 0x1c */
+    volatile uint32_t IC_FS_SCL_LCNT;   /* 0x20 */
+    uint32_t RESERVED2[2];              /* 0x24 - 0x28 */
+    volatile uint32_t IC_INTR_STAT;     /* 0x2c masked interrupt status */
+    volatile uint32_t IC_INTR_MASK;     /* 0x30 */
+    volatile uint32_t IC_RAW_INTR_STAT; /* 0x34 raw interrupt status */
+    volatile uint32_t IC_RX_TL;         /* 0x38 */
+    volatile uint32_t IC_TX_TL;         /* 0x3c */
+    volatile uint32_t IC_CLR_INTR;      /* 0x40 clear all combined interrupts */
+    volatile uint32_t IC_CLR_RX_UNDER;  /* 0x44 */
+    volatile uint32_t IC_CLR_RX_OVER;   /* 0x48 */
+    volatile uint32_t IC_CLR_TX_OVER;   /* 0x4c */
+    volatile uint32_t IC_CLR_RD_REQ;    /* 0x50 */
+    volatile uint32_t IC_CLR_TX_ABRT;   /* 0x54 read clears TX_ABRT latch */
+    volatile uint32_t IC_CLR_RX_DONE;   /* 0x58 */
+    volatile uint32_t IC_CLR_ACTIVITY;  /* 0x5c */
+    volatile uint32_t IC_CLR_STOP_DET;  /* 0x60 */
+    volatile uint32_t IC_CLR_START_DET; /* 0x64 */
+    uint32_t RESERVED3;                 /* 0x68 */
+    volatile uint32_t IC_ENABLE;        /* 0x6c */
+    volatile uint32_t IC_STATUS;        /* 0x70 */
+    volatile uint32_t IC_TXFLR;         /* 0x74 tx FIFO level */
+    volatile uint32_t IC_RXFLR;         /* 0x78 rx FIFO level */
+    uint32_t RESERVED4;                 /* 0x7c */
+    volatile uint32_t IC_TX_ABRT_SRC;   /* 0x80 */
+    uint32_t RESERVED5[6];              /* 0x84 - 0x98 */
+    volatile uint32_t IC_ENABLE_STATUS; /* 0x9c bit0: IC_EN settled */
+    volatile uint32_t IC_START;         /* 0xa0 HR_C7000-specific trigger */
+} I2C_TypeDef;
+
+#define I2C_CMD_READ 0x100u        /* IC_DATA_CMD bit8: read request */
+#define I2C_CMD_STOP 0x200u        /* IC_DATA_CMD bit9: STOP after byte */
+#define I2C_STA_ACTIVITY (1u << 0) /* bus busy */
+#define I2C_STA_TFNF (1u << 1)     /* tx FIFO not full */
+#define I2C_STA_TFE (1u << 2)      /* tx FIFO empty */
+#define I2C_STA_RFNE (1u << 3)     /* rx FIFO not empty */
+#define I2C_CON_MASTER_FS 0x65u    /* master, 7-bit, fast-mode, restart-en */
+/* 400 kHz off the 42 MHz APB clock (clk/400000 = 105, split hi/lo). */
+#define I2C_SCL_HCNT 0x2cu
+#define I2C_SCL_LCNT 0x34u
+#define RTC_I2C_SLAVE 0x70u /* RTC device address (7'b1110000) */
+
+/* -------------------------------------------------------------------------
+ *  ADC -- HR_C7000 on-chip ADC (base 0x140d0000, manual 5.9, Register Table 24).
+ *  The battery pack sits on channel 2 -> DATA_CD bits[9:0].
+ * ------------------------------------------------------------------------- */
+typedef struct {
+    volatile uint32_t CTRL;       /* 0x00 */
+    volatile uint32_t INTR_DELTA; /* 0x04 interrupt error range */
+    volatile uint32_t INTR;       /* 0x08 interrupt control (bit16 INTR_EN) */
+    volatile uint32_t INTR_STA;   /* 0x0c interrupt status */
+    volatile uint32_t SCAN_TIME;  /* 0x10 scan time interval */
+    volatile uint32_t START;      /* 0x14 write 1 to start a conversion */
+    volatile uint32_t CTRL_STATE; /* 0x18 bit0 BUSY, bits[5:1] SAMP_FSM */
+    volatile uint32_t INTR_THRESHOLE; /* 0x1c interrupt initial value/threshold */
+    volatile uint32_t CTRL_STOP;      /* 0x20 */
+    volatile uint32_t CH_VLD;         /* 0x24 channel-enable bitmask (1<<ch) */
+    volatile uint32_t SEOC_TIME;      /* 0x28 */
+    volatile uint32_t P2S_EN;         /* 0x2c */
+    volatile uint32_t DATA_AB;        /* 0x30 ch0 [9:0] / ch1 [25:16] */
+    volatile uint32_t DATA_CD;        /* 0x34 ch2 (battery) / ch3 */
+    volatile uint32_t DATA_EF;        /* 0x38 ch4 / ch5 */
+    volatile uint32_t DATA_GH;        /* 0x3c ch6 / ch7 */
+} ADC_TypeDef;
+
+/* -------------------------------------------------------------------------
+ *  UART -- DesignWare 16550-compatible, 32-bit word-spaced registers. UART2
+ *  (base 0x14050000) is the GPS module port. RBR/THR/DLL alias at 0x00 and
+ *  IER/DLH alias at 0x04, selected by the LCR DLAB bit (bit 7).
+ * ------------------------------------------------------------------------- */
+typedef struct {
+    union {
+        volatile uint32_t RBR; /* 0x00 RX buffer (read) */
+        volatile uint32_t THR; /* 0x00 TX holding (write) */
+        volatile uint32_t DLL; /* 0x00 divisor latch low (LCR DLAB = 1) */
+    };
+    union {
+        volatile uint32_t IER; /* 0x04 interrupt enable */
+        volatile uint32_t DLH; /* 0x04 divisor latch high (LCR DLAB = 1) */
+    };
+    union {
+        volatile uint32_t IIR; /* 0x08 interrupt identification (read) */
+        volatile uint32_t FCR; /* 0x08 FIFO control (write) */
+    };
+    volatile uint32_t LCR;     /* 0x0c line control (bit 7 = DLAB) */
+    volatile uint32_t MCR;     /* 0x10 modem control */
+    volatile uint32_t LSR;     /* 0x14 line status (bit 0 = data ready) */
+    volatile uint32_t MSR;     /* 0x18 modem status */
+    volatile uint32_t SCR;     /* 0x1c scratch */
+} UART_TypeDef;
+
+#define UART_LCR_DLAB 0x80u   /* LCR bit 7: divisor-latch access */
+#define UART_LCR_8N1 0x03u    /* 8 data bits, no parity, 1 stop */
+#define UART_FCR_ENABLE 0x67u /* FIFO enable + RX/TX reset + trigger level */
+#define UART_LSR_DR 0x01u     /* LSR bit 0: RX data ready */
+
+/* -------------------------------------------------------------------------
+ *  Peripheral instances -- cast the base address onto the register struct.
+ * ------------------------------------------------------------------------- */
+#define SOCSYS ((SOCSYS_TypeDef *)0x11000000u)
+#define GPIOA ((GPIO_TypeDef *)0x14020000u)
+#define GPIOB ((GPIO_TypeDef *)0x14100000u)
+#define GPIOC ((GPIO_TypeDef *)0x14110000u)
+#define LCD_HW ((LCD_TypeDef *)0x12000000u)
+#define PWM_CH0 ((PWM_Channel_TypeDef *)0x140c0000u)
+#define I2C2 ((I2C_TypeDef *)0x14080000u)
+#define ADC_HW ((ADC_TypeDef *)0x140d0000u)
+#define UART2 ((UART_TypeDef *)0x14050000u) /* GPS module port */
+
+#endif                                      /* HRC7000_REGISTERS_H */

--- a/platform/targets/HD2/CMakeLists.txt
+++ b/platform/targets/HD2/CMakeLists.txt
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: Copyright 2026 OpenRTX Contributors
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# OpenRTX minimal bring-up for the Ailunce HD2 (HR_C7000 / CK803S), built on
+# the vendor Miosix kernel consumed as a dependency.  This build tree lives in
+# the OpenRTX target dir; the miosix repo carries no OpenRTX/app code.
+#
+# Scope: display + backlight + keyboard + RTC + battery + GPS + the UI.  No
+# radio / DMR / audio / M17 / NVM -- those are stubbed (hd2_stubs.c) so the
+# core + UI link.
+cmake_minimum_required(VERSION 3.21)
+
+# Kernel dependency.  miosix-kernel is normally a sibling of OpenRTX under
+# vendor/ (../../../../miosix-kernel/miosix); that relative path is the default.
+# Override it when the kernel lives elsewhere:
+#   cmake -DMIOSIX_KPATH=/path/to/miosix-kernel/miosix ...
+set(MIOSIX_KPATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../../miosix-kernel/miosix"
+    CACHE PATH "Path to the miosix kernel tree")
+set(CMAKE_TOOLCHAIN_FILE ${MIOSIX_KPATH}/cmake/Toolchains/gcc-csky.cmake)
+set(CMAKE_BUILD_TYPE "Release")
+
+project(OpenRtxHd2Min C CXX ASM)
+
+set(MIOSIX_BOARD hrc7000_hd2)
+set(MIOSIX_USER_CONFIG_PATH ${MIOSIX_KPATH}/config)
+
+add_subdirectory(${MIOSIX_KPATH} miosix EXCLUDE_FROM_ALL)
+
+# OpenRTX repo root: this dir is <root>/platform/targets/HD2, so up 3.
+set(ORTX ${CMAKE_SOURCE_DIR}/../../..)
+
+# --- Hardware-agnostic OpenRTX core (boot spine + graphics + input) ---------
+# Mirrors the proven HD2 core list.  Kept intact rather than trimmed further:
+# the boot threshold is a ~130 KB image (heavily-stripped images don't boot on
+# this SoC), and trimming these only multiplies the stub surface below.
+set(ORTX_CORE
+    ${ORTX}/openrtx/src/core/state.c
+    ${ORTX}/openrtx/src/core/threads.c
+    ${ORTX}/openrtx/src/core/battery.c
+    ${ORTX}/openrtx/src/core/graphics.c
+    ${ORTX}/openrtx/src/core/input.c
+    ${ORTX}/openrtx/src/core/utils.c
+    ${ORTX}/openrtx/src/core/queue.c
+    ${ORTX}/openrtx/src/core/chan.c
+    ${ORTX}/openrtx/src/core/gps.c
+    ${ORTX}/openrtx/src/core/cps.c
+    ${ORTX}/openrtx/src/core/crc.c
+    ${ORTX}/openrtx/src/core/datetime.c
+    ${ORTX}/openrtx/src/core/openrtx.c
+    ${ORTX}/openrtx/src/core/data_conversion.c
+    ${ORTX}/openrtx/src/core/nvmem_access.c
+    ${ORTX}/openrtx/src/core/memory_profiling.cpp
+    ${ORTX}/openrtx/src/core/audio_path.cpp
+    ${ORTX}/openrtx/src/core/audio_stream.c
+    ${ORTX}/openrtx/src/core/voicePromptUtils.c)
+# Deliberately omitted (stubbed in hd2_stubs.c): voicePrompts.c + audio_codec.c
+# + dsp.cpp (codec2's large static state trips the boot-hang the HD2 build
+# avoids), and rtx.cpp + OpMode_* (radio stack).
+
+# --- Default UI -------------------------------------------------------------
+set(ORTX_UI
+    ${ORTX}/openrtx/src/ui/default/ui.c
+    ${ORTX}/openrtx/src/ui/default/ui_main.c
+    ${ORTX}/openrtx/src/ui/default/ui_menu.c
+    ${ORTX}/openrtx/src/ui/default/ui_strings.c)
+
+# --- HD2 platform + the four minimal drivers --------------------------------
+set(ORTX_HD2
+    ${ORTX}/platform/targets/HD2/platform.c
+    ${ORTX}/platform/targets/HD2/hwconfig.c
+    ${ORTX}/platform/drivers/display/ST7735S_HD2.c
+    ${ORTX}/platform/drivers/keyboard/keyboard_HD2.c
+    ${ORTX}/platform/drivers/backlight/backlight_HD2.c
+    ${ORTX}/platform/drivers/GPIO/gpio_hrc7000.c
+    ${ORTX}/platform/mcu/HR_C7000/drivers/rtc_hd2.c
+    ${ORTX}/platform/mcu/HR_C7000/drivers/i2c_hrc7000.c
+    ${ORTX}/platform/drivers/ADC/adcHrc7000.c
+    ${ORTX}/platform/mcu/HR_C7000/drivers/delays.cpp
+    ${ORTX}/platform/drivers/GPS/gps_HD2.c
+    ${ORTX}/platform/drivers/GPS/nmea_rbuf.c)
+
+# --- Shared driver stubs for subsystems the minimal build leaves out --------
+# Codeplug + settings NVM have generic OpenRTX stubs; use them rather than
+# hand-rolled copies.  Radio / audio / stream stubs are NOT needed: the core
+# never calls those wrappers in this build, so --gc-sections drops them.
+set(ORTX_STUBS
+    ${ORTX}/platform/drivers/stubs/cps_io_stub.c
+    ${ORTX}/platform/drivers/stubs/nvmem_stub.c)
+
+# --- Vendored helper libs the core pulls in ---------------------------------
+set(ORTX_LIBS
+    ${ORTX}/lib/minmea/minmea.c
+    ${ORTX}/lib/QRCode/qrcode.c)
+
+add_executable(openrtx_hd2
+    ${ORTX}/openrtx/src/main.c
+    ${CMAKE_SOURCE_DIR}/hd2_glue.cpp
+    ${CMAKE_SOURCE_DIR}/hd2_core_stubs.c
+    ${ORTX_CORE} ${ORTX_UI} ${ORTX_HD2} ${ORTX_STUBS} ${ORTX_LIBS})
+
+target_include_directories(openrtx_hd2 PRIVATE
+    ${CMAKE_SOURCE_DIR}
+    ${ORTX}/openrtx/include
+    ${ORTX}/platform
+    ${ORTX}/platform/targets/HD2
+    ${ORTX}/platform/mcu/HR_C7000
+    ${ORTX}/lib/minmea/include
+    ${ORTX}/lib/QRCode/include
+    ${ORTX}/lib/qdec/include)
+
+target_compile_definitions(openrtx_hd2 PRIVATE
+    PLATFORM_HD2 _MIOSIX FONT_UBUNTU_REGULAR timegm=mktime
+    "GIT_VERSION=\"openrtx-hd2-min\"")
+
+miosix_link_target(openrtx_hd2)

--- a/platform/targets/HD2/hd2_core_stubs.c
+++ b/platform/targets/HD2/hd2_core_stubs.c
@@ -1,0 +1,98 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 OpenRTX Contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Core entry points the minimal HD2 bring-up cannot yet provide and for which
+ * OpenRTX has no generic driver stub.  The driver-layer gaps (codeplug NVM,
+ * settings NVM) are filled by platform/drivers/stubs/{cps_io,nvmem}_stub.c;
+ * only these two groups have no shared stub and so live here:
+ *
+ *   - vp_*  : voice prompts (real impl = core/voicePrompts.c) are left out
+ *             until the audio path is brought up.
+ *   - rtx_* : the radio task (real impl = rtx/rtx.cpp) is left out until the
+ *             baseband/RF stack is brought up.
+ *
+ * Each group is replaced by its real implementation as that subsystem lands.
+ */
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <pthread.h>
+#include "core/voicePrompts.h"
+#include "rtx/rtx.h"
+
+/* ---- Voice prompts (no audio path in the minimal bring-up) ---------------- */
+void vp_init()
+{
+}
+void vp_stop()
+{
+}
+void vp_tick()
+{
+}
+void vp_play()
+{
+}
+void vp_flush()
+{
+}
+bool vp_isPlaying()
+{
+    return false;
+}
+void vp_beep(uint16_t freq, uint16_t duration)
+{
+    (void)freq;
+    (void)duration;
+}
+void vp_beepSeries(const uint16_t *beepSeries)
+{
+    (void)beepSeries;
+}
+void vp_queueInteger(const int value)
+{
+    (void)value;
+}
+void vp_queuePrompt(const uint16_t prompt)
+{
+    (void)prompt;
+}
+void vp_queueString(const char *string, enum vpFlags flags)
+{
+    (void)string;
+    (void)flags;
+}
+void vp_queueStringTableEntry(const char *const *e)
+{
+    (void)e;
+}
+
+/* ---- rtx (no radio task in the minimal bring-up) -------------------------- */
+extern void sleepFor(unsigned int seconds, unsigned int mseconds);
+
+void rtx_init(pthread_mutex_t *m)
+{
+    (void)m;
+}
+void rtx_terminate()
+{
+}
+/* rtx_threadFunc spins `while(RUNNING) rtx_task();` -- sleep so the empty
+ * task yields the CPU to the UI/main threads instead of busy-looping. */
+void rtx_task()
+{
+    sleepFor(0, 100);
+}
+void rtx_configure(const rtxStatus_t *cfg)
+{
+    (void)cfg;
+}
+bool rtx_rxSquelchOpen()
+{
+    return false;
+}
+rssi_t rtx_getRssi()
+{
+    return (rssi_t)-127;
+}

--- a/platform/targets/HD2/hd2_glue.cpp
+++ b/platform/targets/HD2/hd2_glue.cpp
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 OpenRTX Contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Glue between OpenRTX and the vendor Miosix kernel for the HD2.  The
+ * interfaces/delays.h implementation lives in mcu/HR_C7000/drivers/delays.cpp;
+ * this file only carries the raw bring-up UART trace helper.
+ */
+
+extern "C" {
+
+// Raw UART0 trace for bring-up (UART0 @ 0x14030000, 57600 8N1 set by the bsp).
+// Bounded spin so a stuck UART can't hang a thread.
+void hd2_trace(const char *s)
+{
+    volatile unsigned int *thr = (volatile unsigned int *)0x14030000u;
+    volatile unsigned int *lsr = (volatile unsigned int *)0x14030014u;
+    while (*s) {
+        for (unsigned int g = 0; g < 200000u && (*lsr & 0x20u) == 0u; ++g) {
+        }
+        *thr = (unsigned char)*s++;
+    }
+}
+
+} // extern "C"

--- a/platform/targets/HD2/hwconfig.c
+++ b/platform/targets/HD2/hwconfig.c
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 OpenRTX Contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Definitions of the const driver-config structs + hardware descriptor
+ * declared in hwconfig.h.
+ */
+
+#include "hwconfig.h"
+#include "interfaces/platform.h" /* hwInfo_t */
+#include "drivers/ADC/adcHrc7000.h"
+#include "drivers/i2c_hrc7000.h"
+#include <pthread.h>
+
+/* On-chip ADC: battery on ADC_VBAT_CH via a 1:3 divider; 3.3 V reference, 10-bit
+ * converter.  The mutex serialises access -- it is taken/released by the generic
+ * adc_getRawSample() wrapper (peripherals/adc.h), so the driver's sample() need
+ * not lock. */
+static pthread_mutex_t adc1Mutex;
+ADC_HRC7000_DEVICE_DEFINE(adc1, &adc1Mutex, ADC_COUNTS_TO_UV(3300000, 10))
+
+/* Internal I2C2 DesignWare master (base 0x14080000) -- the RTC's dedicated bus.
+ * The mutex is taken via i2c_acquire()/i2c_release() by the RTC driver. */
+static pthread_mutex_t i2c2Mutex = PTHREAD_MUTEX_INITIALIZER;
+I2C_HRC7000_DEVICE_DEFINE(i2c2, I2C2, &i2c2Mutex)
+
+const hwInfo_t hwInfo = {
+    .name = "HD2",
+    .hw_version = 0,
+    .flags = 0,
+    .uhf_band = 1,
+    .vhf_band = 1,
+    .uhf_maxFreq = 480,
+    .uhf_minFreq = 400,
+    .vhf_maxFreq = 174,
+    .vhf_minFreq = 136,
+};

--- a/platform/targets/HD2/hwconfig.h
+++ b/platform/targets/HD2/hwconfig.h
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2020-2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */
+
+#ifndef HWCONFIG_H
+#define HWCONFIG_H
+
+#include "registers.h"
+#include "peripherals/adc.h"
+#include "peripherals/i2c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Screen: 160x128 ST7735S TFT, RGB565, HW i8080 bus */
+#define CONFIG_SCREEN_WIDTH 160
+#define CONFIG_SCREEN_HEIGHT 128
+#define CONFIG_PIX_FMT_RGB565
+
+/* LCD backlight is a PWM-dimmed LED */
+#define CONFIG_SCREEN_BRIGHTNESS
+
+/* On-SoC real-time clock (32.768 kHz xtal, coin-cell backed) */
+#define CONFIG_RTC
+
+/* Battery: 2-cell Li-Ion */
+#define CONFIG_BAT_LIION
+#define CONFIG_BAT_NCELLS 2
+
+/* GPS: module on UART2, polled; NMEA ring-buffer size */
+#define CONFIG_GPS
+#define CONFIG_NMEA_RBUF_SIZE 512
+
+/* On-chip ADC channels (HR_C7000 ADC block). */
+enum AdcChannels {
+    ADC_VBAT_CH = 2, /* battery pack, read through a 1:3 divider */
+};
+
+/* Board device instances (defined in hwconfig.c).  hwInfo lives in hwconfig.c
+ * too; platform.c externs it locally to avoid a hwconfig.h <-> platform.h
+ * include cycle (interfaces/platform.h already includes this file). */
+extern const struct Adc adc1;
+extern const struct i2cDevice i2c2; /* internal RTC bus */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HWCONFIG_H */

--- a/platform/targets/HD2/pinmap.h
+++ b/platform/targets/HD2/pinmap.h
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Ailunce HD2 board pin map: each GPIO is given a unique functional label
+ * (port, pin) so drivers call e.g. gpio_readPin(PTT_SW) instead of a bare
+ * gpio_readPin(GPIOB, 11).  Split out of the HR_C7000 SoC register map
+ * (mcu/HR_C7000/registers.h) so the SoC header stays board-agnostic.
+ */
+#ifndef HD2_PINMAP_H
+#define HD2_PINMAP_H
+
+#include "registers.h"
+
+/*
+ * PTC pad-mux values (SOCSYS IO_DIPLEX2, manual 4.4.4.6 -- upper bits are
+ * write-only, so always write the whole-register constant, never
+ * read-modify-write):
+ *   PTC_GPIO: every PTC pad in GPIO mode (keypad matrix scan).
+ *   LCD_I80:  bits 3..18 = 0 -> the HW i8080 controller @0x12000000 owns
+ *             PTC3-6 (CS/RS/WR/RD) and PTC7-14 (DB0-7); the rest stays GPIO
+ *             (PTC2 = panel reset, ADC/DAC pads).
+ * The keypad matrix shares the LCD data pins (rows PTC7-10, cols PTC11-14),
+ * so a scan momentarily swaps the mux GPIO<->I80 (see keyboard_HD2.c).
+ */
+#define HD2_DIPLEX2_PTC_GPIO 0x3ffffffbu
+#define HD2_DIPLEX2_LCD_I80 0x3ff80003u
+
+/* Discrete GPIO signals (port, pin) -- live-verified against V2.1.3. */
+#define GREEN_LED GPIOB, 0 /* signalling LED, active-high */
+#define RED_LED GPIOB, 1   /* signalling LED, active-high */
+#define EMER_SW GPIOB, 7   /* emergency side key, active-low */
+#define SK1_SW GPIOB, 9    /* side key 1, active-low */
+#define PTT_SW GPIOB, 11   /* PTT button, active-low */
+#define PWR_SW GPIOB, 12   /* volume/power knob: LOW = on */
+#define PWR_HOLD GPIOB, 13 /* power self-latch: HIGH = hold */
+#define GPS_PWR GPIOB, 15  /* GPS module power: HIGH = on */
+#define ROT_A GPIOA, 0     /* rotary encoder quadrature A */
+#define ROT_B GPIOA, 1     /* rotary encoder quadrature B */
+#define LCD_RST GPIOC, 2   /* ST7735S panel reset */
+
+/*
+ * 4x4 keypad matrix on GPIOC: rows on PTC7-10 (inputs), cols on PTC11-14
+ * (driven).  KBD_ROW(n)/KBD_COL(n) expand to the (port, pin) pair for the
+ * n-th row/column so the scan loop can label each line.
+ */
+#define KBD_ROW_SHIFT 7u
+#define KBD_COL_SHIFT 11u
+#define KBD_ROW_COUNT 4u
+#define KBD_COL_COUNT 4u
+#define KBD_ROW(n) GPIOC, (KBD_ROW_SHIFT + (n))
+#define KBD_COL(n) GPIOC, (KBD_COL_SHIFT + (n))
+
+#endif /* HD2_PINMAP_H */

--- a/platform/targets/HD2/platform.c
+++ b/platform/targets/HD2/platform.c
@@ -1,0 +1,149 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 OpenRTX Contributors
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * Ailunce HD2 platform layer -- minimal bring-up (display / backlight /
+ * keyboard / RTC / power).  The Miosix bsp already brings up clocks, the
+ * watchdog-off, the UART0 console, the LEDs and the PTB13 power self-latch,
+ * so this file only owns the OpenRTX-facing HAL and the power/PTT sense.
+ */
+
+#include "interfaces/platform.h"
+#include "peripherals/gpio.h"
+#include "peripherals/rtc.h"
+#include "drivers/ADC/adcHrc7000.h"
+#include "drivers/GPS/gps_HD2.h"
+#include "drivers/backlight/backlight.h"
+#include "hwconfig.h"
+#include "pinmap.h"
+
+/* The on-chip ADC instance (adc1), its mutex, and the hwInfo descriptor live in
+ * hwconfig.c; ADC_VBAT_CH is in hwconfig.h (enum AdcChannels).  hwInfo is
+ * extern'd here rather than in hwconfig.h to avoid a hwconfig.h <-> platform.h
+ * include cycle. */
+extern const hwInfo_t hwInfo;
+
+void platform_init()
+{
+    /* Establish the V2.1.3 SoC pad-mux + GPIO baseline for PTA/PTB.  The Miosix
+     * kernel already brought up the PLL, timers and UART0; here we only own the
+     * pad mux / GPIO directions the vendor firmware sets.  (Clocks are NOT
+     * re-touched under Miosix -- re-running the PLL init hangs the kernel
+     * timer.)  These are whole-register vendor snapshot values; the upper DIPLEX
+     * bits are write-only, so never read-modify-write them.  The PTC/LCD pad-mux
+     * + bus directions are owned by the display driver (display_init). */
+    SOCSYS->IO_DIPLEX0 = 0x00000060u; /* PTA: vendor pad-mux baseline */
+    SOCSYS->IO_DIPLEX1 = 0x00000007u; /* PTA: SPI0 pads (vendor baseline) */
+
+    /* PTA GPIO direction (DDR) + output levels (DR): the V2.1.3 vendor boot
+     * snapshot.  Apart from the rotary encoder (PTA0/1, inputs), these pads'
+     * roles aren't reverse-engineered; kept verbatim as the known-good state. */
+    GPIOA->DDR = 0x003401e0u;
+    GPIOA->DR |= 0x001401e0u;
+
+    GPIOB->DDR = 0x3d7ae51fu; /* incl. knob/PTT sense as input */
+    GPIOB->DR |= 0x00506414u; /* preserves the PTB13 power latch */
+
+    adcHrc7000_init(&adc1);   /* on-chip ADC (battery on ADC_VBAT_CH) */
+    rtc_init();
+}
+
+void platform_terminate()
+{
+    backlight_terminate();
+    rtc_terminate();
+
+    /* The power self-latch drop + SOCSYS system soft-reset is done atomically
+     * (IRQs off) by the miosix bsp shutdown() when main() returns -- doing the
+     * latch-drop here first would risk a partial brown-out before the reset. */
+}
+
+const hwInfo_t *platform_getHwInfo()
+{
+    return &hwInfo;
+}
+
+bool platform_pwrButtonStatus()
+{
+    return gpio_readPin(PWR_SW) == 0; /* knob LOW = on */
+}
+
+bool platform_getPttStatus()
+{
+    return gpio_readPin(PTT_SW) == 0; /* active-low */
+}
+
+void platform_ledOn(led_t led)
+{
+    switch (led) {
+        case GREEN:
+            gpio_setPin(GREEN_LED);
+            break;
+        case RED:
+            gpio_setPin(RED_LED);
+            break;
+        default:
+            break;
+    }
+}
+
+void platform_ledOff(led_t led)
+{
+    switch (led) {
+        case GREEN:
+            gpio_clearPin(GREEN_LED);
+            break;
+        case RED:
+            gpio_clearPin(RED_LED);
+            break;
+        default:
+            break;
+    }
+}
+
+/* --- Battery voltage (on-chip ADC channel 2) ----------------------------- */
+uint16_t platform_getVbat()
+{
+    /* adc_getVoltage returns the pin voltage in uV; the pack is behind a 1:3
+     * divider, so multiply by 3 and convert uV -> mV.  The state update task
+     * low-pass filters this, so no averaging is done here. */
+    return (uint16_t)((adc_getVoltage(&adc1, ADC_VBAT_CH) * 3u) / 1000u);
+}
+
+/* --- Other analog/audio sensing not wired in the minimal bring-up --------- */
+uint8_t platform_getMicLevel()
+{
+    return 0;
+}
+uint8_t platform_getVolumeLevel()
+{
+    return 0;
+}
+int8_t platform_getChSelector()
+{
+    return 0;
+}
+void platform_beepStart(uint16_t freq)
+{
+    (void)freq;
+}
+void platform_beepStop()
+{
+}
+
+/* --- RTC ----------------------------------------------------------------- */
+datetime_t platform_getCurrentTime()
+{
+    return rtc_getTime();
+}
+
+void platform_setTime(datetime_t t)
+{
+    rtc_setTime(t);
+}
+
+/* --- GPS (UART2, polled) ------------------------------------------------- */
+const struct gpsDevice *platform_initGps()
+{
+    return gps_HD2_init();
+}


### PR DESCRIPTION
First on-hardware bring-up of the Ailunce HD2 (HR_C7000 / CK803S) target on the external miosix kernel (board hrc7000_hd2). Boots the stock OpenRTX UI with the basics working, live-verified:

  - display   ST7735S 160x128 RGB565 over the HW i8080 controller @0x12000000
  - backlight PWM ch0 @0x140c0000 (duty clamped below period: duty==period
              wraps to LED-off on this comparator, so 100% mapped to dark)
  - keyboard  4x4 matrix on the shared LCD pins + side keys + rotary knob
  - RTC       DesignWare I2C2 @0x14080000 slave 0x70; the master is enabled
              ONCE and left enabled (toggling IC_ENABLE per transfer corrupted
              the FIFO -> garbage read-back)
  - battery   on-chip ADC ch2 -> platform_getVbat (Li-ion 2S)
  - GPS       polled UART2 (DesignWare 16550 @0x14050000, 9600 8N1) -> NMEA
              ring buffer -> CONFIG_GPS; driven by gps_task(), no ISR

Radio / DMR / audio / M17 are not yet brought up. The driver-layer gaps link through OpenRTX's shared stubs (`platform/drivers/stubs/{cps_io,nvmem}_stub.c`); the two core entry points that have no shared stub — `vp_*` (voice prompts) and `rtx_*` (radio task) — are no-ops in `hd2_core_stubs.c`, each replaced by its real implementation as that subsystem lands. Build tree: `platform/targets/HD2` links the external miosix (`MIOSIX_KPATH`), toolchain `csky-miosix-elf`.

## Review feedback addressed

Reworked per @silseva's review of the original single commit:

  - **Split into 5 logical commits**: HR_C7000 MCU support → HD2 platform + build → display + backlight → keyboard → GPS.
  - **`mcu/CSKY_V2` → `mcu/HR_C7000`** — C-SKY V2 is the CPU architecture; HR_C7000 is the MCU, so the SoC support layer is named for the SoC.
  - **`hd2_regs.h` → `platform/mcu/HR_C7000/registers.h`**, rewritten as CMSIS-style peripheral structs cast onto the MMIO bases (SOCSYS / GPIO / LCD i8080 / PWM / I2C2 / ADC) instead of a flat block of `#define` addresses. Register names and offsets are taken from the HR_C7000 user guide.
  - **New `gpio_hrc7000` driver** under `platform/drivers/GPIO/` (native `gpio_setMode`/`setPin`/`clearPin`/`readPin` over the DW_apb_gpio banks), used in place of ad-hoc GPIO register writes. Pin-function muxing stays with the SOCSYS pad-mux, as this SoC has no per-GPIO alternate-function register.
  - **`hd2_stubs.c` removed** in favour of the shared `platform/drivers/stubs/` drivers; only the `vp_*` / `rtx_*` core entry points (which have no shared stub) remain, in `hd2_core_stubs.c`.
