### PR TITLE
Disable auto-closing of prs and issues using 'In progress' label

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -16,5 +16,6 @@ jobs:
           close-issue-label: Stale-Closed
           close-pr-label: Stale-Closed
           exempt-issue-labels: bug,issue,In progress
+          exempt-pr-labels: In progress
           days-before-stale: 60
           days-before-close: 15

--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -15,6 +15,6 @@ jobs:
           close-pr-message: 'This PR was closed due to continued inactivity.'
           close-issue-label: Stale-Closed
           close-pr-label: Stale-Closed
-          exempt-issue-labels: bug,issue,'In progress'
+          exempt-issue-labels: bug,issue,In progress
           days-before-stale: 60
           days-before-close: 15


### PR DESCRIPTION
In the dev office hours today, Silvano and Marco discussed the github stale issue bot being a bit obnoxious. This PR adds the ability to label a PR with 'In progress', which mirrors what you can use for issues, in order for the bot to skip over the PR from getting marked stale.

After this, in order to mark any issues or PRs as expected to be long running and not wanting the github bot to nudge, just add the label 'In progress'.