### PR TITLE
HD2: analog-FM radio bring-up (AT1846S + rtx/OpMode_FM)

### DIFF
--- a/openrtx/include/interfaces/radio.h
+++ b/openrtx/include/interfaces/radio.h
@@ -58,6 +58,19 @@ void radio_setOpmode(const enum opmode mode);
 bool radio_checkRxDigitalSquelch();
 
 /**
+ * Query a hardware RF-squelch decision, for targets whose transceiver has an
+ * on-chip carrier/squelch comparator (with its own hysteresis) that is steadier
+ * than thresholding the raw RSSI.
+ *
+ * @param open: written with the hardware squelch state (true = open) when this
+ * function returns true.
+ * @return true if the target provides a hardware RF-squelch decision (written
+ * to *open); false if it does not, in which case the caller falls back to
+ * thresholding radio_getRssi(). The default implementation returns false.
+ */
+bool radio_checkRxRfSquelch(bool *open);
+
+/**
  * Enable AF output towards the speakers.
  */
 void radio_enableAfOutput();

--- a/openrtx/src/rtx/OpMode_FM.cpp
+++ b/openrtx/src/rtx/OpMode_FM.cpp
@@ -14,6 +14,18 @@
 #include "drivers/baseband/AT1846S.h"
 #endif
 
+/*
+ * Weak default for the hardware RF-squelch hook (radio.h).  Targets whose
+ * transceiver exposes an on-chip carrier/squelch comparator override this with
+ * a strong definition to report that decision; the default reports "no hardware
+ * squelch", so update() falls back to thresholding radio_getRssi().
+ */
+extern "C" __attribute__((weak)) bool radio_checkRxRfSquelch(bool *open)
+{
+    (void) open;
+    return false;
+}
+
 /**
  * \internal
  * On MD-UV3x0 radios the volume knob does not regulate the amplitude of the
@@ -78,15 +90,25 @@ void OpMode_FM::update(rtxStatus_t *const status, const bool newCfg)
     // RX logic
     if(status->opStatus == RX)
     {
-        // RF squelch mechanism
-        // This turns squelch (0 to 15) into RSSI (-127.0dbm to -61dbm)
-        rssi_t squelch = -127 + (status->sqlLevel * 66) / 15;
-        rssi_t rssi    = rtx_getRssi();
+        // RF squelch mechanism.  Prefer the target's hardware carrier/squelch
+        // comparator if it has one (steadier than thresholding the RSSI);
+        // otherwise turn the squelch level (0 to 15) into an RSSI threshold.
+        bool hwSqlOpen;
+        if(radio_checkRxRfSquelch(&hwSqlOpen))
+        {
+            rfSqlOpen = hwSqlOpen;
+        }
+        else
+        {
+            // This turns squelch (0 to 15) into RSSI (-127.0dbm to -61dbm)
+            rssi_t squelch = -127 + (status->sqlLevel * 66) / 15;
+            rssi_t rssi    = rtx_getRssi();
 
-        // Provide a bit of hysteresis, only change state if the RSSI has
-        // moved more than 1dBm on either side of the current squelch setting.
-        if((rfSqlOpen == false) && (rssi > (squelch + 1))) rfSqlOpen = true;
-        if((rfSqlOpen == true)  && (rssi < (squelch - 1))) rfSqlOpen = false;
+            // Provide a bit of hysteresis, only change state if the RSSI has
+            // moved more than 1dBm on either side of the current squelch.
+            if((rfSqlOpen == false) && (rssi > (squelch + 1))) rfSqlOpen = true;
+            if((rfSqlOpen == true)  && (rssi < (squelch - 1))) rfSqlOpen = false;
+        }
 
         // Local flags for current RF and tone squelch status
         bool rfSql   = ((status->rxToneEn == 0) && (rfSqlOpen == true));

--- a/platform/drivers/GPIO/gpio_hrc7000.h
+++ b/platform/drivers/GPIO/gpio_hrc7000.h
@@ -37,6 +37,28 @@ extern "C" {
  */
 void gpio_setMode(const void *port, const uint8_t pin, const uint16_t mode);
 
+/*
+ * The DW_apb_gpio has no atomic bit-set/clear register, so setPin/clearPin are
+ * read-modify-write on the shared port DR.  In the threaded build a port (esp.
+ * GPIOB: LEDs + PTT + power-hold + the radio/audio pins) is poked from several
+ * threads, and a plain |=/&= can lose an update if a context switch lands
+ * between the load and the store -- worst case the lost bit is PTB13 power-hold.
+ * Single core, so masking interrupts around the RMW makes it atomic.  Uses the
+ * CK803S PSR (cr<0,0>) save + `psrclr ie` idiom (same as targets/HD2/main.c);
+ * restoring the saved PSR is nesting-safe.
+ */
+static inline uint32_t gpio_irqSave(void)
+{
+    uint32_t psr;
+    __asm__ volatile("mfcr %0, cr<0, 0>\n\tpsrclr ie" : "=r"(psr) : : "memory");
+    return psr;
+}
+
+static inline void gpio_irqRestore(uint32_t psr)
+{
+    __asm__ volatile("mtcr %0, cr<0, 0>" : : "r"(psr) : "memory");
+}
+
 /**
  * Set gpio pin to high logic level.
  *
@@ -45,7 +67,9 @@ void gpio_setMode(const void *port, const uint8_t pin, const uint16_t mode);
  */
 static inline void gpio_setPin(const void *port, const uint8_t pin)
 {
+    uint32_t psr = gpio_irqSave();
     ((GPIO_TypeDef *)port)->DR |= (1u << pin);
+    gpio_irqRestore(psr);
 }
 
 /**
@@ -56,7 +80,9 @@ static inline void gpio_setPin(const void *port, const uint8_t pin)
  */
 static inline void gpio_clearPin(const void *port, const uint8_t pin)
 {
+    uint32_t psr = gpio_irqSave();
     ((GPIO_TypeDef *)port)->DR &= ~(1u << pin);
+    gpio_irqRestore(psr);
 }
 
 /**

--- a/platform/drivers/audio/audio_HD2.c
+++ b/platform/drivers/audio/audio_HD2.c
@@ -1,0 +1,286 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * OpenRTX audio.h routing driver for the Ailunce HD2 (HR_C7000).
+ *
+ * Implements the standard OpenRTX audio path matrix (sources {MIC,RTX,MCU} ->
+ * sinks {SPK,RTX,MCU}), modeled on platform/drivers/audio/audio_GDx.c.  It is
+ * the single owner of the HD2's *board-level* audio routing: the GPIOB
+ * speaker-amp (PTB4) + gain (PTB17) + RX-audio route (PTB10) lines that
+ * radio_HD2.cpp deliberately left "to the audio agent", plus the codec /
+ * socsys audio-gate bring-up.
+ *
+ * Division of labour (one source of truth for the HW-verified register
+ * values):
+ *   - This file OWNS the HR_C7000 codec bring-up (codec_bringup(), the
+ *     byte-register CB() sequence captured LIVE from a vendor unit playing FM).
+ *     It runs at platform_init time from audio_init(), like every other OpenRTX
+ *     target, and is idempotent (a static latch makes repeat calls free).
+ *   - hd2_audio_out_warm() sets the codec audio-OUTPUT stage (LINEOUT_CTRL/
+ *     AUDIO_CONTROL/AUDIO_BUFFER_CLR) for MCU-PCM playback (beep path).
+ *   - The AT1846S RX-audio chip-side mute (reg 0x30 bit7) is released via the
+ *     radio.h hook radio_enableAfOutput()/disableAfOutput().
+ *   - This file also owns the board-level GPIO twiddles.
+ *
+ * NOTE (FM bring-up build): there is NO MCU->codec-DAC PCM playback path in
+ * this build (outputStream_HD2.cpp is not linked), so the SINK_SPK output
+ * device carries a NULL driver -- the endpoint enum is kept, but no PCM stream
+ * driver is wired.  The analog FM-RX path (SOURCE_RTX -> SINK_SPK) is pure GPIO
+ * and is fully preserved.
+ *
+ * TX (MIC->RTX) is intentionally not keyed here.
+ */
+
+#include "interfaces/audio.h"
+#include "interfaces/radio.h"
+#include "interfaces/delays.h"
+#include "drivers/GPIO/gpio_hrc7000.h"
+#include "pinmap.h" /* -> registers.h (SOCSYS, CODEC_BYTE) */
+
+/*
+ * HR_C7000 PCM/audio-codec block (byte-addressed MMIO @ 0x16000900, verified
+ * alive + readable on hardware).  Port of boot_init_modem_audio_path
+ * (0x0305e62c) + the analog-FM tail of boot_init_audio_route (0x0305e7d8).
+ * MUST use byte writes -- the block ignores partial word writes.
+ *
+ * CODEC_BYTE(off) comes from registers.h (byte-addressed PCM block); keep the
+ * short local CB() name this driver uses.
+ */
+#define CB(off) CODEC_BYTE(off)
+
+/* Codec DAC output gain (GCR_DACL @ codec 0xdf): vendor sources the low 6 bits
+ * (godl) from codeplug calibration; our FM build has no codeplug, so use the
+ * vendor's known-good value (= g_tune_data 0x34 | 0x80, from a vendor unit
+ * playing FM) so the codec DAC isn't mis-gained. */
+#define CODEC_DACL_GAIN 0xb4u
+
+static bool g_codec_inited = false;
+
+/*
+ * HR_C7000 codec bring-up (verbatim vendor sequence).  Pulses the PCM block
+ * reset then clears the codec soft-reset (SOCSYS->SYS_SOFT_RSTN bit4 once; the
+ * bit is auto-releasing, see radio_HD2.cpp's SYS_SOFT_RSTN note), waits on the
+ * LINEOUT_CTRL[31] standby handshake, then sets the DAC gain + lineout.  Runs
+ * once at platform_init time from audio_init(); idempotent.
+ *
+ * Ownership contract: audio_init() (this file) owns the codec/audio-if reset
+ * bits (3,4); the modem FM boot (radio_HD2.cpp hd2_modem_fm_boot_init) PRESERVES
+ * bits 3,4 via RMW so it never disturbs the codec state set up here.
+ */
+static void codec_bringup(void)
+{
+    if (g_codec_inited)
+        return;
+
+    /* PCM block reset pulse + codec soft-reset (matches vendor exactly). */
+    CB(0xd2) |= 0x03;
+    SOCSYS->SYS_SOFT_RSTN &= 0xffffffefu; /* clear bit4 = codec reset */
+    delayMs(2);
+    CB(0xd2) &= ~0x01;
+    delayMs(100);
+    CB(0xd2) &= ~0x02;
+    CB(0xd3) = 0x40;
+    CB(0xcb) = 0x00;
+    CB(0xcc) |= 0x40;
+    CB(0xc9) = 0xc0;
+    CB(0xcf) &= ~0x10;
+    delayMs(100);
+    CB(0xcf) &= ~0x80;
+    CB(0xc8) = 0xc0;
+    CB(0xcd) &= ~0x10;
+
+    /* Wait for the PCM handshake (socsys 0x88 bit31 clear), bounded. */
+    for (uint32_t g = 0; g < 200u; ++g) {
+        if ((SOCSYS->LINEOUT_CTRL & 0x80000000u) == 0u)
+            break;
+        delayMs(10);
+    }
+
+    CB(0xcd) &= ~0x80;
+    delayMs(100);
+    CB(0xdf) = CODEC_DACL_GAIN;
+    CB(0xe5) = 0x8b;
+    SOCSYS->LINEOUT_CTRL = 1;
+
+    /* boot_init_audio_route analog tail (same block). */
+    CB(0xc8) = 0xc0;
+    CB(0xcd) = 0x20;
+    CB(0xe5) = 0x8b;
+    CB(0xdf) = CODEC_DACL_GAIN;
+    SOCSYS->AUDIO_BUFFER_CLR |= 0x02; /* _hrc7000_pcm_mode |= 2 */
+
+    g_codec_inited = true;
+}
+
+/*
+ * Warm up the HR_C7000 codec audio-OUTPUT stage ONCE for MCU-PCM playback: make
+ * sure the codec is up, then open the socsys audio gate (LINEOUT/AUDIO_CONTROL/
+ * AUDIO_BUFFER_CLR).  The PWM-beep mixes THROUGH the codec (DAC -> lineout ->
+ * speaker), so the codec must be initialised before a beep is audible.  Called
+ * lazily from the beep path.  GPIOB.4/.10 (amp + route) are left to the caller
+ * so they re-assert per beep.
+ */
+void hd2_audio_out_warm(void)
+{
+    static bool warmed = false;
+    if (warmed)
+        return;
+    codec_bringup();
+    SOCSYS->AUDIO_CONTROL = 0x00000002u;
+    SOCSYS->AUDIO_BUFFER_CLR = 0x00000000u;
+    SOCSYS->LINEOUT_CTRL =
+        0x00000003u; /* both lineouts; speaker is on LINE2OUT */
+    warmed = true;
+}
+
+#define PATH(x, y) (((x) << 4) | (y))
+
+/*
+ * Path compatibility matrix -- can two paths be open simultaneously?
+ * Indexed by (source * 3 + sink) for each of the two paths.
+ *
+ * Row/col order: MIC-SPK MIC-RTX MIC-MCU RTX-SPK RTX-RTX RTX-MCU MCU-SPK MCU-RTX MCU-MCU
+ */
+static const uint8_t pathCompatibilityMatrix[9][9] = {
+    //         M-S M-R M-M R-S R-R R-M C-S C-R C-M
+    /* MIC-SPK */ { 0, 0, 0, 0, 1, 1, 0, 1, 1 },
+    /* MIC-RTX */ { 0, 0, 0, 1, 0, 1, 1, 0, 1 },
+    /* MIC-MCU */ { 0, 0, 0, 1, 1, 0, 1, 1, 0 },
+    /* RTX-SPK */ { 0, 1, 1, 0, 0, 0, 0, 1, 1 },
+    /* RTX-RTX */ { 1, 0, 1, 0, 0, 0, 1, 0, 1 },
+    /* RTX-MCU */ { 1, 1, 0, 0, 0, 0, 1, 1, 0 },
+    /* MCU-SPK */ { 0, 1, 1, 0, 1, 1, 0, 0, 0 },
+    /* MCU-RTX */ { 1, 0, 1, 1, 0, 1, 0, 0, 0 },
+    /* MCU-MCU */ { 1, 1, 0, 1, 1, 0, 0, 0, 0 }
+};
+
+/* No MCU->codec-DAC PCM stream driver in this FM build (outputStream_HD2.cpp
+ * is not linked): SINK_SPK carries a NULL driver.  The endpoint enum is kept so
+ * the audio_path core still resolves the sink. */
+const struct audioDevice outputDevices[] = {
+    { NULL, 0, 0, SINK_MCU },
+    { NULL, 0, 0, SINK_RTX },
+    { NULL, 0, 0, SINK_SPK },
+};
+
+const struct audioDevice inputDevices[] = {
+    { NULL, 0, 0, SINK_MCU },
+    { NULL, 0, 0, SINK_RTX },
+    { NULL, 0, 0, SINK_SPK },
+};
+
+/* --- board-level helpers ------------------------------------------------ */
+
+static inline void spkr_amp_mute(void)
+{
+    gpio_setPin(GPIOB, SPKR_AMP_PIN);    /* PTB4  HIGH = muted    */
+    gpio_clearPin(GPIOB, SPKR_GAIN_PIN); /* PTB17 LOW  = low gain */
+}
+
+static inline void spkr_amp_unmute(void)
+{
+    gpio_clearPin(GPIOB, SPKR_AMP_PIN); /* PTB4  LOW  = on       */
+    gpio_setPin(GPIOB, SPKR_GAIN_PIN);  /* PTB17 HIGH = full gain
+                                            * (without it ALL speaker
+                                            * audio is barely audible
+                                            * -- see pinmap.h) */
+}
+
+static inline void rx_route_on(void)
+{
+    gpio_clearPin(GPIOB, AUDIO_ROUTE_PIN);
+} /* PTB10 LOW = routed */
+
+static inline void rx_route_off(void)
+{
+    gpio_setPin(GPIOB, AUDIO_ROUTE_PIN);
+} /* PTB10 HIGH = un-routed (close the route gate) */
+
+void audio_init()
+{
+    /* Drive the amp + gain + route lines as outputs; start with the speaker
+     * muted (PTB4 HIGH, PTB17 LOW), matching the vendor's tuning state. */
+    gpio_setMode(GPIOB, SPKR_AMP_PIN, OUTPUT);
+    gpio_setMode(GPIOB, SPKR_GAIN_PIN, OUTPUT);
+    gpio_setMode(GPIOB, AUDIO_ROUTE_PIN, OUTPUT);
+    spkr_amp_mute();
+    rx_route_off(); /* start with the RX-audio route closed (PTB10 HIGH) */
+
+    /* Bring the HR_C7000 codec up at platform_init, like every other target. */
+    codec_bringup();
+}
+
+void audio_terminate()
+{
+    spkr_amp_mute();
+}
+
+void audio_connect(const enum AudioSource source, const enum AudioSink sink)
+{
+    switch (PATH(source, sink)) {
+        case PATH(SOURCE_RTX, SINK_SPK):
+            /* FM RX audio -> speaker.  PURE-GPIO gate (must be trivial: this
+             * fires on every squelch crossing).  The heavy AT1846S AF-DSP
+             * config + chip-side unmute already ran once in radio_enableRx;
+             * here we only route the analog AF (PTB10) and unmute the speaker
+             * amp (PTB4). */
+            rx_route_on();
+            spkr_amp_unmute();
+            break;
+
+        case PATH(SOURCE_MCU, SINK_SPK):
+            /* Beep / voice-prompt playback from the MCU (mixes through the
+             * codec DAC -> lineout -> speaker, so the codec must be warm). */
+            hd2_audio_out_warm();
+            radio_disableAfOutput(); /* mute the live analog FM-RX audio */
+            rx_route_on();
+            spkr_amp_unmute();
+            break;
+
+        case PATH(SOURCE_MIC, SINK_RTX):
+            /* TX (mic -> transceiver).  Keying is owned by radio_enableTx;
+             * left as an explicit no-op here. */
+            break;
+
+        default:
+            break;
+    }
+}
+
+void audio_disconnect(const enum AudioSource source, const enum AudioSink sink)
+{
+    switch (PATH(source, sink)) {
+        case PATH(SOURCE_RTX, SINK_SPK):
+            /* Squelch gate: mute the amp AND close the RX-audio route (PTB10).
+             * The route is opened on connect but was never closed, so it latched
+             * open on the first RX and left the AT1846S demod noise floor a
+             * permanent path to the amp (a faint squeal that appeared on the
+             * first audio event and persisted).  The AT1846S AF config +
+             * chip-side unmute stay in place so re-open is still a GPIO toggle. */
+            spkr_amp_mute();
+            rx_route_off();
+            break;
+
+        case PATH(SOURCE_MCU, SINK_SPK):
+            spkr_amp_mute();
+            rx_route_off();         /* close the RX-audio route (PTB10) */
+            radio_enableAfOutput(); /* restore the FM-RX AF output */
+            break;
+
+        default:
+            break;
+    }
+}
+
+bool audio_checkPathCompatibility(const enum AudioSource p1Source,
+                                  const enum AudioSink p1Sink,
+                                  const enum AudioSource p2Source,
+                                  const enum AudioSink p2Sink)
+{
+    uint8_t p1Index = (p1Source * 3) + p1Sink;
+    uint8_t p2Index = (p2Source * 3) + p2Sink;
+
+    return pathCompatibilityMatrix[p1Index][p2Index] == 1;
+}

--- a/platform/drivers/baseband/AT1846S.h
+++ b/platform/drivers/baseband/AT1846S.h
@@ -85,6 +85,12 @@ public:
      *
      * @param freq: VCO frequency.
      */
+#if defined(PLATFORM_HD2)
+    /* The HD2's AT1846SD needs a vendor-specific tune sequence (band-select
+     * register 0x05 + a reg-0x30 0x4006/0x4046 double-write); it is defined
+     * out-of-line in AT1846S_HD2.cpp. */
+    void setFrequency(const freq_t freq);
+#else
     void setFrequency(const freq_t freq)
     {
         // AT1846S datasheet specifies a frequency step of 1/16th of kHz per bit.
@@ -101,6 +107,7 @@ public:
 
         reloadConfig();
     }
+#endif
 
     /**
      * Set the transmission and reception bandwidth.
@@ -345,6 +352,21 @@ public:
         maskSetRegister(0x30, 0x0080, 0x0000);
     }
 
+    /**
+     * Write one register via I2C interface.
+     *
+     * @param reg: address of the register to be written.
+     * @param value: value to be written to the register.
+     */
+    void i2c_writeReg16(const uint8_t reg, const uint16_t value);
+
+    /**
+     * Read one register via I2C interface.
+     *
+     * @param reg: address of the register to be read.
+     */
+    uint16_t i2c_readReg16(const uint8_t reg);
+
 private:
 
     /**
@@ -389,21 +411,6 @@ private:
      * Initialise the I2C interface.
      */
     void i2c_init();
-
-    /**
-     * Write one register via I2C interface.
-     *
-     * @param reg: address of the register to be written.
-     * @param value: value to be written to the register.
-     */
-    void i2c_writeReg16(const uint8_t reg, const uint16_t value);
-
-    /**
-     * Read one register via I2C interface.
-     *
-     * @param reg: address of the register to be read.
-     */
-    uint16_t i2c_readReg16(const uint8_t reg);
 
     /**
      * This function returns the value to be written into the AT1846S CTCSS

--- a/platform/drivers/baseband/AT1846S_HD2.cpp
+++ b/platform/drivers/baseband/AT1846S_HD2.cpp
@@ -1,0 +1,332 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * AT1846S driver for the HD2 (HD-GPS-HD2PA-C7000).  Ported verbatim
+ * from the vendor V2.1.3 firmware (src/firmware/at1846s/at1846s.c) --
+ * register sequences are preserved bit-exact; only decimal-vs-hex
+ * literals were normalised.  See docs/superpowers/plans/
+ * 2026-05-29-at1846s-hd2-openrtx-port.md for the full port plan.
+ *
+ * Vendor source addresses (V2.1.3 app image @ 0x0300d000):
+ *   - at1846s_chip_init        @ 0x03058bd4
+ *   - at1846s_load_audio_bank  @ 0x03058b28
+ *   - at1846s_set_freq         @ 0x03058e24
+ *   - at1846s_reg_write/read   @ 0x03058b60
+ */
+
+#include "interfaces/delays.h"
+#include "hwconfig.h"            /* i2c1 device instance (radio bus) */
+#include "drivers/i2c_hrc7000.h" /* i2c_init */
+#include "drivers/baseband/AT1846S.h"
+
+/*
+ * AT1846S audio / channel-filter "bank" tables, extracted live from the
+ * V2.1.3 image:
+ *
+ *   - regList    : 23 register indices @ SAHB SRAM 0x18000a30..0x18000a47
+ *   - bankValues : 2 x 23 u16 entries  @ flash 0x0307dee0
+ *                  bank 0 = DMR / 12.5 kHz path
+ *                  bank 1 = FM  / 25   kHz path
+ *
+ * Reg 0x7F is the AT1846S page-select register: writing 0x0001 paged in,
+ * 0x0000 paged out -- the table's first and last entries do the wrapping
+ * so the middle entries (0x06..0x12) hit page-1 AGC registers.
+ */
+static constexpr uint8_t bankRegList[23] = { 0x15, 0x32, 0x3A, 0x3C, 0x3F, 0x48,
+                                             0x60, 0x62, 0x65, 0x66, 0x7F, 0x06,
+                                             0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C,
+                                             0x0D, 0x0E, 0x0F, 0x12, 0x7F };
+
+/*
+ * Vendor at1846s_load_audio_bank @0x03058b28 indexes table @0x0307dee0: param 0 =
+ * BANK0 (the 0x1100/0x4495/0x00c3.../0xeb2e set) and the vendor's ANALOG-FM
+ * path (rf_apply_channel_to_pll @0x03059090 FM-voice case, at1846s_set_freq_alt
+ * @0x03058d68) calls load_audio_bank(0).  So index 0 is the FM audio-DSP bank
+ * and index 1 is the DMR bank -- NOT the other way round.  ELF-verified bytes.
+ */
+static constexpr uint16_t bankValues[2][23] = {
+    /* bank 0 -- FM (analog / broadcast); vendor load_audio_bank(0) */
+    { 0x1100, 0x4495, 0x00C3, 0x0407, 0x28D0, 0x20BE, 0x1BB7, 0x1425,
+      0x2494, 0xEB2E, 0x0001, 0x0014, 0x020C, 0x0214, 0x030C, 0x0314,
+      0x0324, 0x0344, 0x1344, 0x1B44, 0x3F44, 0xE0EB, 0x0000 },
+    /* bank 1 -- DMR; vendor load_audio_bank(1) */
+    { 0x1F00, 0x7564, 0x04C3, 0x1930, 0x29D2, 0x203E, 0x101E, 0x3767,
+      0x248A, 0xFFAE, 0x0001, 0x0024, 0x0214, 0x0224, 0x0314, 0x0324,
+      0x0344, 0x0384, 0x1384, 0x1B84, 0x3F84, 0xE0EB, 0x0000 }
+};
+
+/*
+ * Band-select classifier constants, extracted live from V2.1.3 image:
+ *
+ *   FREQ_BAND_MODULUS @ 0x03058ec4 = 11 375 000  (~11.375 MHz VCO subband)
+ *   FREQ_BAND_THRESH  @ 0x03058ec8 = 11 374 498
+ *   FREQ_BAND_SPECIAL @ 0x03058ecc =    455 000 000  (455 MHz -> 0x8643)
+ *
+ * Vendor at1846s_set_freq @ 0x03058e24 computes:
+ *   if (THRESH < ((freq % MODULUS) - 0xFB))     reg5 = 0x8763
+ *   elif (freq == SPECIAL)                      reg5 = 0x8643
+ *   else                                        reg5 = 0x8543
+ *
+ * The (modulo - 0xFB) form, with unsigned underflow when (freq % MOD)
+ * is below 0xFB (251 Hz), is intentional and selects the 0x8763 band
+ * within 251 Hz on either side of any 11.375 MHz boundary.
+ */
+static constexpr uint32_t FREQ_BAND_MODULUS = 11375000u;
+static constexpr uint32_t FREQ_BAND_THRESH = 11374498u;
+static constexpr uint32_t FREQ_BAND_SPECIAL = 455000000u;
+static constexpr uint16_t FREQ_BAND_GUARD = 0x00FBu;
+
+void AT1846S::init()
+{
+    /* Verbatim port of at1846s_chip_init @ 0x03058bd4.  Do NOT reorder
+     * or fold these writes -- the 0x40A4 -> 0x40A6 -> 0x4006 sequence
+     * with 100 ms gaps is a VCO calibration dance that has to run as-is.
+     *
+     * Register-meaning annotations come from the sibling
+     * OpenRTX drivers for the SAME chip (AT1846S_GDx.cpp / _UV3x0.cpp,
+     * both with working FM audio); "GDx:" notes the GD77 value where it
+     * differs from the vendor-HD2 value used here.
+     *
+     * Registers the GD77 init programs that this vendor init NEVER
+     * touches:
+     *   0x09=0x03AC, 0x24=0x0001, 0x3F (RSSI 3 threshold),
+     *   0x48/0x60 (noise 1/2 thresholds), 0x49 (RSSI SQL thresholds),
+     *   0x4E=0x0082->0x2082 (soft-mute ctrl), 0x62 (mod-detect thresh).
+     *
+     * The 0x09/0x24/0x4E (pre-cal) and 0x49/0x60/0x48
+     * (post-cal) gaps are filled below as explicit "GDx supplement"
+     * blocks APPENDED to the vendor sequence -- no vendor write was
+     * replaced.  The GDx PGA/mixer overrides (0x0A=0x7BA0 / 0x59=0x09D2)
+     * are deliberately NOT applied here. */
+
+    /* Bring up the radio-bus I2C1 controller.  The PTA7/PTA8 pads are muxed to
+     * I2C1 by platform_init's IO_DIPLEX0 baseline (0x60, the SCL/SDA select bits
+     * are clear), which runs before this singleton is first constructed. */
+    i2c_init();
+
+    i2c_writeReg16(0x30, 0x0001); // Soft reset
+    delayMs(200);
+    i2c_writeReg16(0x30, 0x0004); // Chip enable
+
+    i2c_writeReg16(0x04, 0x0FD0); // 26 MHz crystal frequency (same as GDx)
+    i2c_writeReg16(0x0A,
+                   0x4C20); // PGA gain (GDx: 0x7BA0); decimal '10' in source
+    i2c_writeReg16(0x0F, 0x8A24); // HD2-specific VCO/PLL fine-tune
+    i2c_writeReg16(0x1F,
+                   0x1001); // GPIO config (GDx: 0x1000 = gpio6 squelch out)
+    i2c_writeReg16(0x31, 0x0031); // (same as GDx)
+    i2c_writeReg16(0x33, 0x44A5); // AGC number (GDx: 0x45F5 from the start)
+    i2c_writeReg16(0x34, 0x2B87); // RX digital gain (GDx: 0x2B89)
+    i2c_writeReg16(0x41, 0x470F); // TX digital gain (same as GDx)
+    i2c_writeReg16(0x42, 0x1036); // (same as GDx)
+    i2c_writeReg16(0x43, 0x00BB); // (same as GDx)
+    i2c_writeReg16(
+        0x44, 0x07F7); // TX/RX gain; HD2 runtime uses low byte as RX volume
+    i2c_writeReg16(0x3A,
+                   0x00C3); // Mod-detect / AF-source select; GDx-FM=0x44C3,
+    //   vendor-HD2-FM-RX runtime=0x80E1, tone mux=[14:12]
+    i2c_writeReg16(0x59, 0x0B90); // Mixer gain (GDx: 0x09D2)
+    i2c_writeReg16(0x47, 0x7F2F); // Soft mute (same as GDx)
+    i2c_writeReg16(0x4F, 0x2C62); // (same as GDx)
+    i2c_writeReg16(0x53, 0x0094); // (same as GDx)
+    i2c_writeReg16(0x54,
+                   0x2A18); // (GDx: 0x2A3C; vendor FM-RX runtime also 0x2A3C)
+    i2c_writeReg16(0x55, 0x0081); // (same as GDx)
+    i2c_writeReg16(0x56, 0x0B22); // (GDx: 0x0B02)
+    i2c_writeReg16(0x57, 0x1C00); // Bypass RSSI low-pass (same as GDx)
+    i2c_writeReg16(0x58, 0x8405); // Filter/emphasis ctrl (GDx: 0xBCCD)
+    i2c_writeReg16(0x5A, 0x0ADD); // SQ detection time (GDx: 0x4935)
+    i2c_writeReg16(
+        0x63,
+        0x3FFF); // Mod-detect thresh (GDx: 0x16AD); decimal '99' in source
+    i2c_writeReg16(0x79, 0xD932); // HD2-specific VCO/PLL fine-tune
+    i2c_writeReg16(0x68, 0x05E5); // HD2-specific VCO/PLL fine-tune
+    i2c_writeReg16(0x6B, 0x02FE); // HD2-specific VCO/PLL fine-tune
+    i2c_writeReg16(0x71, 0x0F1C); // HD2-specific VCO/PLL fine-tune
+    i2c_writeReg16(0x73, 0x0A3E); // HD2-specific VCO/PLL fine-tune
+    i2c_writeReg16(0x74, 0x090E); // HD2-specific VCO/PLL fine-tune
+    i2c_writeReg16(0x75, 0x0833); // HD2-specific VCO/PLL fine-tune
+    i2c_writeReg16(0x76, 0x0806); // HD2-specific VCO/PLL fine-tune
+
+    /* --- GDx supplement (pre-cal) ----------------------------------------
+     * Registers the working GD77 driver (AT1846S_GDx.cpp init(), same chip,
+     * working FM audio) programs BEFORE its calibration that the vendor HD2
+     * init never touches.  Appended after the vendor pre-cal block; no
+     * vendor value above is replaced. */
+    i2c_writeReg16(
+        0x09,
+        0x03AC); // GDx supplement: undocumented bias/regulator setup (vendor never writes it)
+    i2c_writeReg16(
+        0x24,
+        0x0001); // GDx supplement: PLL/synth enable (vendor never writes it)
+    i2c_writeReg16(
+        0x4E,
+        0x2082); // GDx supplement: soft-mute control, GDx final value (vendor never
+                 //   writes it at init; the vendor FM-RX path later rewrites
+    //   0x4E=0x6002 at channel config -- that stays.  This is just a
+    //   sane init value, matching GDx's 0x0082 -> 0x2082 staging.)
+
+    /* VCO calibration -- delays are bit-exact with vendor. */
+    i2c_writeReg16(0x30, 0x40A4);
+    delayMs(100);
+    i2c_writeReg16(0x30, 0x40A6); // Start calibration
+    delayMs(100);
+    i2c_writeReg16(0x30, 0x4006); // Stop calibration
+    delayMs(200);
+
+    /* Post-calibration tweaks.  (GDx post-cal additionally re-stages PGA
+     * 0x0A, mixer 0x59, TX gain 0x41/0x44 steps, noise/RSSI/SQL thresholds
+     * 0x48/0x60/0x3F/0x49 -- the vendor HD2 init does none of that.) */
+    i2c_writeReg16(0x58, 0xBCFD); // Filter/emphasis ctrl (GDx post-cal: 0xBCED)
+    i2c_writeReg16(
+        0x40,
+        0x0031); // AF-DSP ctrl (runtime: 0x0030 listen / 0x0011 scan-mute)
+    i2c_writeReg16(0x33, 0x45F5); // AGC number (now matches GDx)
+
+    /* --- GDx supplement (post-cal) ---------------------------------------
+     * GDx post-calibration writes the vendor HD2 init never does.  Appended
+     * after the vendor post-cal tweaks; no vendor value above is replaced.
+     * (The GDx 0x0A/0x59 PGA/mixer overrides are NOT applied here.) */
+    i2c_writeReg16(
+        0x49,
+        0x0C96); // GDx supplement: RSSI SQL thresholds (open/close) (vendor never writes it)
+    i2c_writeReg16(
+        0x60,
+        0x1A32); // GDx supplement: noise-2 threshold (vendor never writes it)
+    i2c_writeReg16(
+        0x48,
+        0x1A32); // GDx supplement: noise-1 threshold (vendor never writes it at init;
+                 //   the per-bandwidth bank load overwrites 0x48 later -- fine)
+}
+
+void AT1846S::setBandwidth(const AT1846S_BW band)
+{
+    /*
+     * Vendor at1846s_load_audio_bank @ 0x03058b28: walks a 23-entry
+     * reg list and writes corresponding values from bank0 (12.5 kHz /
+     * DMR) or bank1 (25 kHz / FM).  Reg 0x7F appears twice in the list
+     * to page registers 0x06..0x12 in and back out (AT1846S page model).
+     */
+    /* Our bankValues ARE the vendor's at1846s_load_audio_bank
+     * table (reg-list + bank0/bank1 byte-identical to ELF @0x0307dee0).  FM path loads
+     * BANK 0, DMR loads BANK 1.  The vendor does
+     * NOT set reg 0x30 bits[12:13] for bandwidth (FM=0x4xxx, DMR=0x7xxx) -- so no
+     * maskSet(0x30,...) here. */
+    const uint8_t bank = (band == AT1846S_BW::_25) ? 0 : 1;
+    for (uint32_t i = 0; i < 23; ++i)
+        i2c_writeReg16(bankRegList[i], bankValues[bank][i]);
+
+    reloadConfig();
+}
+
+void AT1846S::setOpMode(const AT1846S_OpMode mode)
+{
+    /*
+     * On the HD2, the vendor firmware ties op-mode (DMR vs FM) to the
+     * audio-bank selection rather than treating it as a separate axis
+     * -- bank 0 programs the FM audio-DSP chain, bank 1 the DMR one.
+     * FM uses the _25 path -> bank 0; DMR uses
+     * the _12P5 path -> bank 1.
+     *
+     * NOTE: full DMR support also needs reg 0x33/0x40-0x44/0x58/0x57
+     * tweaks that the vendor handles in the radio layer (out of scope
+     * for this port).  For now this is a thin convenience over
+     * setBandwidth() so the OpenRTX core's setOpMode() call has a home.
+     */
+    setBandwidth((mode == AT1846S_OpMode::DMR) ? AT1846S_BW::_12P5 :
+                                                 AT1846S_BW::_25);
+}
+
+void AT1846S::setFrequency(const freq_t freq)
+{
+    /*
+     * Verbatim port of at1846s_set_freq @ 0x03058e24.  See the constant
+     * block above for the band-select classifier rationale.
+     */
+    const uint32_t f = static_cast<uint32_t>(freq);
+    const uint32_t modRem = (f % FREQ_BAND_MODULUS);
+
+    uint16_t reg5;
+    if (FREQ_BAND_THRESH < (modRem - FREQ_BAND_GUARD)) {
+        reg5 = 0x8763u;
+    } else if (f == FREQ_BAND_SPECIAL) {
+        reg5 = 0x8643u;
+    } else {
+        reg5 = 0x8543u;
+    }
+    i2c_writeReg16(0x05, reg5);
+
+    /* PLL divider: vendor computes (freq * 4) / 250 == (freq * 16) / 1000,
+     * matching AT1846S datasheet's 1/16-kHz-per-bit step.  Use 64-bit
+     * intermediate to avoid the 32-bit overflow at freq > ~268 MHz. */
+    const uint64_t val = ((uint64_t)f * 16ULL) / 1000ULL;
+    i2c_writeReg16(0x29, static_cast<uint16_t>((val >> 16) & 0xFFFFu));
+    i2c_writeReg16(0x2A, static_cast<uint16_t>(val & 0xFFFFu));
+
+    /*
+     * Vendor at1846s_set_freq tail reloads reg 0x30 with one of two
+     * patterns:
+     *
+     *   chan & 0x40 == 0 && (chan+0xa9) & 0xc0 != 0   -> 0x7006, 0x7046
+     *   otherwise                                     -> 0x4006, 0x4046
+     *
+     * The chan_struct flag selecting between them lives in the radio
+     * layer (out of scope here).  Default to the 0x4006/0x4046 path,
+     * which is what the analog FM bring-up needs.
+     *
+     * HD2 has at1846s_set_freq_alt @ 0x03058d68 (uses 0x4026/0x7026 and
+     * also reloads the audio bank); TODO when the channel layer lands.
+     */
+    i2c_writeReg16(0x30, 0x4006);
+    i2c_writeReg16(0x30, 0x4046);
+}
+
+/*
+ * setFuncMode is NOT overridden here: the HD2's reg-0x30 bits 5/6 (RX/TX
+ * enable) match the base AT1846S behaviour exactly, so the shared inline in
+ * AT1846S.h is used unchanged.  (If a later live trace shows reg 0x30 needs
+ * the 0x4006/0x4046 double-write here too, add an override -- see plan §8 Q4.)
+ */
+
+/*
+ * I2C transport layer.  The AT1846S sits on the HR_C7000 hardware DesignWare
+ * I2C1 controller (base 0x14070000), driven by
+ * the shared HR_C7000 I2C driver (i2c_hrc7000, instance i2c1; pins PTA7/PTA8).
+ * Same wire-protocol shape as AT1846S_GDx.cpp.
+ */
+
+static constexpr uint8_t devAddr = 0x71; /* AT1846S 7-bit address on I2C1 */
+
+void AT1846S::i2c_init()
+{
+    /* Scope-qualified: this method shares its name with the free i2c_init(). */
+    ::i2c_init(&i2c1, I2C_SPEED_400kHz);
+}
+
+void AT1846S::i2c_writeReg16(uint8_t reg, uint16_t value)
+{
+    /* AT1846S register payload is big-endian (MSB first on the wire). */
+    uint8_t buf[3];
+    buf[0] = reg;
+    buf[1] = (value >> 8) & 0xFF;
+    buf[2] = value & 0xFF;
+
+    i2c_acquire(&i2c1);
+    i2c_write(&i2c1, devAddr, buf, 3, true);
+    i2c_release(&i2c1);
+}
+
+uint16_t AT1846S::i2c_readReg16(uint8_t reg)
+{
+    uint16_t value = 0;
+
+    i2c_acquire(&i2c1);
+    i2c_write(&i2c1, devAddr, &reg, 1, false);
+    i2c_read(&i2c1, devAddr, &value, 2, true);
+    i2c_release(&i2c1);
+
+    /* AT1846S sends register data in big-endian on the wire. */
+    return __builtin_bswap16(value);
+}

--- a/platform/drivers/baseband/radio_HD2.cpp
+++ b/platform/drivers/baseband/radio_HD2.cpp
@@ -1,0 +1,558 @@
+/*
+ * SPDX-FileCopyrightText: Copyright 2026 OpenRTX Contributors
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *
+ * OpenRTX radio.h driver for the Ailunce HD2 (HR_C7000 / CSKY V2 ck803s).
+ *
+ * SCOPE: analog-FM RX control path + FM voice TX (2026-06-11).
+ *   - tune (radio_setVcoFrequency-equivalent via radio_enableRx)
+ *   - RSSI read (AT1846S reg 0x1B)
+ *   - CTCSS/DCS digital squelch (AT1846S reg 0x3A/0x1C)
+ *   - opmode / opstatus bookkeeping
+ *
+ * The RF squelch decision lives in the OpenRTX core (OpMode_FM); this driver
+ * surfaces the AT1846S hardware carrier/squelch comparator through the
+ * radio_checkRxRfSquelch() hook (steadier than an RSSI threshold), plus a
+ * calibrated RSSI and the tone-squelch flag.
+ *
+ * Modeled on platform/drivers/baseband/radio_GDx.cpp (the other
+ * AT1846S-direct OpenRTX target).  This FM-only bring-up build strips the DMR
+ * modem path (HR_C7000 Layer-2) and the diagnostic/loader helper surface; only
+ * the FM RX + FM voice-TX entry points remain.
+ *
+ * Vendor V2.1.3 references (app image @ 0x0300d000):
+ *   - at1846s_rx_path_open   @ 0x030405a0 : reg0x30 |= 0x20 ; gpio_out_set(0x24)
+ *   - at1846s_rx_path_close  @ 0x03040564 : reg0x30 &= ~0x20 ; spkr unmute
+ *   - rx_squelch_monitor_tick@ 0x03040a6c : reads reg 0x1C bit0 = carrier/sql
+ *   - FUN_03040994           @ 0x03040994 : reads reg 0x1B, (v & 0x7FFF) >> 8 = RSSI
+ *   - at1846s_set_freq       @ 0x03058e24 : ported in AT1846S_HD2.cpp
+ */
+
+#include "interfaces/radio.h"
+#include "interfaces/delays.h"
+#include "drivers/baseband/AT1846S.h"
+#include "hwconfig.h" /* i2c1 device instance (radio bus) */
+#include "pinmap.h"   /* BAND_SEL_PIN / MIC_PATH_PIN board pin labels */
+#include "drivers/GPIO/gpio_hrc7000.h"
+#include "radioUtils.h"
+
+// Exact-value AT1846S writes for the TX key/dekey sequence (this file, below);
+// TX was brought up and verified with these exact words -- keep them
+// bit-identical rather than routing through the AT1846S class setters.
+extern "C" void hd2_at1846s_write(uint8_t reg, uint16_t val);
+extern "C" uint16_t hd2_at1846s_read(uint8_t reg);
+
+// AT1846S RX-audio (AF-DSP) listen config -- proven path lives in this file
+// (below).  Applied once per RX entry.
+extern "C" void hd2_at1846s_rx_audio_config(void);
+
+// ONE-TIME modem RX + baseband-IF-ADC + codec bring-up (this file, below).
+// Called once from radio_init (before any RX); does the SYS_SOFT_RSTN modem
+// reset (narrowed to spare the CPU ADC) + codec + modem FM gate config.
+extern "C" void hd2_modem_fm_boot_init(void);
+
+static const rtxStatus_t *config;  // Radio configuration pointer
+static enum opstatus radioStatus;  // Current operating status
+static Band currRxBand = BND_NONE; // Current RX band
+
+/*
+ * APC TX-power level (CPU DAC channel B, 12-bit; vendor ramps this on
+ * every TX entry from a per-band power cal table we don't parse yet).
+ * Conservative default: quarter scale.
+ */
+static volatile uint16_t apcLevel = 0x400;
+
+/*
+ * Map the current codeplug TX power (mW) to the two hardware drive controls:
+ * APC DAC level (ch B) and AT1846S reg 0x0a padrv field.  Four discrete levels
+ * matching the UI (Extra Low / Low / Medium / High).  Values are conservative --
+ * even "High" sits well below the DAC ceiling (the PA runs hot near full drive).
+ */
+extern "C" void hd2_txpower_levels(uint16_t *apc, uint16_t *padrv)
+{
+    const uint32_t p = (config != nullptr) ? config->txPower : 1000u;
+    if (p <= 100u) {
+        *apc = 0x060u;
+        *padrv = 0x08u;
+    } /* Extra Low */
+    else if (p <= 1000u) {
+        *apc = 0x100u;
+        *padrv = 0x08u;
+    } /* Low       */
+    else if (p <= 2500u) {
+        *apc = 0x200u;
+        *padrv = 0x0Fu;
+    } /* Medium    */
+    else {
+        *apc = 0x400u;
+        *padrv = 0x0Fu;
+    } /* High      */
+}
+
+static AT1846S &at1846s = AT1846S::instance(); // AT1846S driver (singleton)
+
+void radio_init(const rtxStatus_t *rtxState)
+{
+    config = rtxState;
+    radioStatus = OFF;
+
+    /*
+     * Bring up the AT1846S.  init() runs the full vendor V2.1.3
+     * chip-init + VCO calibration dance and leaves the chip configured
+     * for the FM (25 kHz) audio bank with RX and TX both off.
+     *
+     * The I2C transport (I2C1, SCL=PTA7 / SDA=PTA8, slave 0x71) is brought up
+     * by the AT1846S constructor via i2c_init(&i2c1); no extra wiring is
+     * needed here.
+     */
+    at1846s.init();
+
+    // ONE-TIME HR_C7000 modem RX + baseband-IF-ADC + codec bring-up, here at init
+    // (before any RX, on the rtx thread at startup).  This is the ONLY place the
+    // modem SYS_SOFT_RSTN reset + modem FM gate config happen -- doing them per RX
+    // entry (radio_enableRx) hung the bus.  The reset is narrowed to
+    // spare the CPU/volume ADC the UI is already using.
+    hd2_modem_fm_boot_init();
+
+    // Keep AF output muted until the core opens the squelch.
+    radio_disableAfOutput();
+}
+
+void radio_terminate()
+{
+    radioStatus = OFF;
+    radio_disableRtx();
+}
+
+void radio_setOpmode(const enum opmode mode)
+{
+    switch (mode) {
+        case OPMODE_FM:
+            at1846s.setOpMode(AT1846S_OpMode::FM);
+            break;
+
+        default:
+            /* DMR / M17 / broadcast-FM are out of scope for this FM-only
+             * build; leave the transceiver as-is. */
+            break;
+    }
+}
+
+bool radio_checkRxDigitalSquelch()
+{
+    // CTCSS tone detection via AT1846S reg 0x3A/0x1C.  The upstream rtxStatus_t
+    // carries only a CTC/DCS tone value (rxTone), not a tone TYPE field, so this
+    // FM build follows radio_GDx.cpp and treats the sub-audio squelch as CTCSS.
+    return at1846s.rxCtcssDetected();
+}
+
+void radio_enableAfOutput()
+{
+    /*
+     * Unmute the AT1846S RX audio output (reg 0x30 bit 7).  The actual speaker
+     * amp / audio routing on the HD2 is a board-level concern owned by
+     * audio_HD2.c (PTB4/PTB10/PTB17); here we only release the chip-side mute.
+     */
+    at1846s.unmuteRxOutput();
+}
+
+void radio_disableAfOutput()
+{
+    at1846s.muteRxOutput();
+}
+
+void radio_enableRx()
+{
+    if (currRxBand == BND_NONE)
+        return;
+
+    // Tune the AT1846S VCO to the RX frequency and enable the RX path.
+    at1846s.setFrequency(config->rxFrequency);
+    at1846s.setFuncMode(AT1846S_FuncMode::RX);
+
+    // Enable RX-side CTCSS detection if the channel requests it (CTCSS only --
+    // the upstream config has no tone-type field; see radio_GDx.cpp).
+    if (config->rxToneEn)
+        at1846s.enableRxCtcss(config->rxTone);
+
+    // Apply the AT1846S RX-audio (AF-DSP) config ONCE here -- the heavy I2C
+    // burst belongs at RX entry, not on every squelch crossing.  Then release
+    // the chip-side AF mute (reg 0x30 bit7) so the board speaker-amp (PTB4),
+    // toggled by the audio matrix, is the only per-squelch gate.
+    hd2_at1846s_rx_audio_config();
+    at1846s.unmuteRxOutput();
+
+    // The HR_C7000 modem RX + codec FM bring-up is done ONCE in radio_init
+    // (hd2_modem_fm_boot_init), NOT here -- per-RX-entry modem writes/resets hung
+    // the bus.  radio_enableRx is AT1846S-only: tune + AF-DSP config
+    // + chip unmute; the board speaker-amp (PTB4) is the per-squelch gate.
+
+    radioStatus = RX;
+}
+
+/* ---------------------------------------------------------------------- *
+ *  Canonical analog-FM TX key / unkey -- the SINGLE register recipe.
+ *
+ *  Does NOT select the modulator source: the OpMode path leaves the FM engine
+ *  on the mic ADC (mic -> codec ADC -> C7000 FM modulator -> MOD1/MOD2 ->
+ *  AT1846S varactors).  `narrow` picks the reg-0x59 deviation bank (true =
+ *  12.5 kHz).  Do NOT touch SIG_CENTER/RF_MOD_BIAS -- the boot cal modulates
+ *  cleanest (mid-scale guesses audibly degraded the audio).
+ * ---------------------------------------------------------------------- */
+extern "C" void hd2_fm_tx_key(uint32_t txFreq, bool narrow, uint8_t txToneEn,
+                              uint16_t txTone)
+{
+    // Tune the VCO to the TX frequency -- RAW (2026-06-18).  Residual synth
+    // error becomes a proper per-band/per-radio CALIBRATION (shared FM + DMR)
+    // once nvm_readCalibData has an HD2 backend -- not a magic constant here.
+    at1846s.setFrequency(txFreq);
+
+    // Arm the C7000 FM-TX engine.  SYS_INTERP_MASK must hold the vendor FM value:
+    // with the boot 0x7f mask the engine wedges on its first unserviced
+    // FM_TX_INTERP and the carrier stays dead-quiet.  Masking (bit16) or acking
+    // 0x3b0 works; we mask (no service thread).
+    SOCSYS->SYS_INTERP_MASK = SYS_INTERP_MASK_FM_VENDOR;
+    SOCSYS->WORK_MODE |= WORK_MODE_FM_MOD;
+    SOCSYS->FM_PTT = 1u;
+
+    // Band-select switch (PTB19, from the vendor spkr/mic_path_set_by_freq: high
+    // band -> set, low band -> clear).  Steers the RF path / PA chain.
+    if (txFreq >= 300000000u)
+        gpio_setPin(GPIOB, BAND_SEL_PIN);
+    else
+        gpio_clearPin(GPIOB, BAND_SEL_PIN);
+
+    // TX power level -> APC DAC drive (ch B) + AT1846S reg 0x0a padrv.
+    uint16_t apc, padrv;
+    hd2_txpower_levels(&apc, &padrv); // map current txPower -> APC + padrv
+    apcLevel = apc; // stash into the file-scope volatile before driving the DAC
+
+    DAC_HW->PD_MODE_EN &= ~0x2u; // ch B low-power mode off
+    DAC_HW->PD_CTRL &= ~0x2u;    // ch B power up
+    DAC_HW->DATA_B = apcLevel;
+
+    // Vendor TX parity: mic-path gate PTB3 high (vendor mic_path_set_by_freq).
+    gpio_setPin(GPIOB, MIC_PATH_PIN);
+
+    hd2_at1846s_write(0x0a, (uint16_t)((padrv << 11) | 0x0420u));
+
+    // TX FM deviation (reg 0x59 -- shared with the RX mixer gain, restored in
+    // hd2_fm_tx_unkey).  Pick by bandwidth and whether a sub-audio tone is
+    // active (the low 6 bits set the CTCSS/DCS deviation).
+    {
+        uint16_t dev59;
+        if (narrow)
+            dev59 = txToneEn ? 0x0B11u : 0x0C90u;
+        else
+            dev59 = txToneEn ? 0x0C62u : 0x0C50u;
+        hd2_at1846s_write(0x59, dev59);
+    }
+
+    // AT1846S: TX-side AF-DSP ctrl, then key the carrier (exact words from the
+    // verified bring-up), then the vendor tx_pa_enable (reg 0x30 |= 0x80 -- the
+    // datasheet calls bit7 "mute", but the vendor sets it on every key-up and
+    // clears it on every dekey: it is the PA-stage gate in TX context).
+    hd2_at1846s_write(0x40, 0x0030u);
+    hd2_at1846s_write(0x30, 0x4006u);
+    hd2_at1846s_write(0x30, 0x4046u); // tx_on
+    hd2_at1846s_write(0x30, 0x40c6u); // + bit7: PA on (vendor tx_pa_enable)
+
+    // Sub-audio encode: the AT1846S sums its own CTCSS generator into the TX
+    // modulation; disableCtcss() in radio_disableRtx() clears it.  CTCSS only --
+    // the upstream config carries no tone-type/tail-elim fields (see the port
+    // notes); DCS-TX + reverse-burst tail elimination from the vendor path are
+    // not wired in this build.
+    if (txToneEn)
+        at1846s.enableTxCtcss(txTone);
+}
+
+extern "C" void hd2_fm_tx_unkey(void)
+{
+    DAC_HW->DATA_B = 0u;                // APC drive to zero first
+    hd2_at1846s_write(0x30, 0x4046u);   // PA off (bit7 clear) first...
+    hd2_at1846s_write(0x30, 0x4006u);   // ...then tx_on off (dekey)
+    hd2_at1846s_write(0x0a, 0x4c20u);   // restore padrv to chip-init default
+    DAC_HW->PD_CTRL |= 0x2u;            // APC DAC ch B power down
+    gpio_clearPin(GPIOB, MIC_PATH_PIN); // mic gate off
+    SOCSYS->FM_PTT = 0u;
+    SOCSYS->WORK_MODE &= ~WORK_MODE_FM_MOD;
+    hd2_at1846s_write(0x40, 0x0031u); // RX-side AF-DSP ctrl value
+    hd2_at1846s_write(0x59,
+                      0x0b90u); // restore RX mixer gain (TX set 0x59 deviation)
+}
+
+void radio_enableTx()
+{
+    /*
+     * FM voice TX -- HW-verified 2026-06-11 (voice received on a second
+     * radio; brought up via diag op 'Y').
+     *
+     * Architecture: mic -> codec ADC -> C7000 FM modulator engine ->
+     * MOD1/MOD2 pins (two-point modulation) -> AT1846S varactors.  The
+     * AT1846S only keys the carrier (its FM bank parks voice_sel=000);
+     * the mic feed into the engine is pure hardware -- no CPU sample
+     * pumping.  Do NOT touch SIG_CENTER/RF_MOD_BIAS: the boot/reset cal
+     * modulates cleanest.
+     */
+    if (config->txDisable == 1)
+        return;
+
+    // FM voice TX only (DMR / M17 out of scope for this build).
+    if (config->opMode != OPMODE_FM)
+        return;
+
+    // AT1846S hardware band sanity (134-174 / 400-527 MHz).
+    if (getBandFromFrequency(config->txFrequency) == BND_NONE)
+        return;
+
+    // Key the analog-FM TX path via the shared canonical recipe (the SINGLE
+    // register sequence -- see hd2_fm_tx_key).
+    hd2_fm_tx_key(config->txFrequency, config->bandwidth == BW_12_5,
+                  config->txToneEn, config->txTone);
+
+    radioStatus = TX;
+}
+
+void radio_disableRtx()
+{
+    /*
+     * TX teardown first (no-op when not transmitting): dekey the AT1846S
+     * carrier, then stop the C7000 FM-TX engine and drop back to the
+     * RX-side work_mode.  Order mirrors the verified bring-up: carrier
+     * off before the modulator so we don't radiate an unmodulated blip.
+     */
+    if (radioStatus == TX)
+        hd2_fm_tx_unkey(); // shared canonical FM-TX teardown
+
+    // Drop both RX and TX on the chip side and silence any tone output.
+    at1846s.disableTone();
+    at1846s.disableCtcss();
+    at1846s.setFuncMode(AT1846S_FuncMode::OFF);
+    radioStatus = OFF;
+}
+
+void radio_updateConfiguration()
+{
+    currRxBand = getBandFromFrequency(config->rxFrequency);
+
+    if (currRxBand == BND_NONE)
+        return;
+
+    /*
+     * Analog-FM bandwidth select.  No flash calibration backend yet, so the
+     * per-band noise/RSSI/squelch threshold tuning that GDx pulls from calData
+     * is left at the AT1846S init defaults.
+     */
+    if (config->opMode == OPMODE_FM) {
+        switch (config->bandwidth) {
+            case BW_12_5:
+                at1846s.setBandwidth(AT1846S_BW::_12P5);
+                break;
+
+            case BW_25:
+                at1846s.setBandwidth(AT1846S_BW::_25);
+                break;
+
+            default:
+                break;
+        }
+
+        /*
+         * Squelch is handled in software by OpMode_FM (RSSI threshold on
+         * radio_getRssi()); the AT1846S internal RSSI squelch (reg 0x49) is
+         * left at its init default rather than driven from config->sqlLevel.
+         */
+    }
+
+    /*
+     * Re-apply the VCO frequency / RX path if we are already receiving, so a
+     * config change (e.g. a new RX frequency) takes effect without the core
+     * having to cycle the op-status.  Mirrors radio_GDx.cpp.
+     */
+    if (radioStatus == RX)
+        radio_enableRx();
+}
+
+rssi_t radio_getRssi()
+{
+    /*
+     * AT1846S reg 0x1B upper byte holds the RSSI level; the generic driver maps
+     * it to dBm as (-137 + (reg >> 8)).
+     *
+     * Peak-hold (instant rise, slow fall ~2 dB/call @ ~33 Hz): with NO carrier
+     * the chip refreshes reg-0x1B rssi_db only periodically and reads near-zero
+     * between updates (HW 2026-06-14), so a plain read flickers the S-meter to
+     * 0.  Peak-hold latches the periodic true value and ignores the stale dips,
+     * while a real signal drop still falls.
+     */
+    static rssi_t held = -127;
+
+    rssi_t raw = static_cast<rssi_t>(at1846s.readRSSI());
+    if (raw >= held)
+        held = raw;
+    else if ((held - raw) > 2)
+        held = static_cast<rssi_t>(held - 2);
+    else
+        held = raw;
+
+    return held;
+}
+
+enum opstatus radio_getStatus()
+{
+    return radioStatus;
+}
+
+/* ============================================================== *
+ *  AT1846S live register access + analog-FM audio/modem bring-up *
+ * ============================================================== */
+/*
+ * RX audio volume (AT1846S reg 0x44 low byte; reg = 0x900 | vol).  Vendor
+ * sources this from the codeplug tune data; our FM bring-up has no volume
+ * setting, so it defaults near-max. */
+static const uint16_t g_fm_volume = 0x3fu;
+
+/*
+ * AT1846S RX-audio (AF-DSP) config -- the chip-side half of the proven listen
+ * sequence, WITHOUT the codec/socsys gate and WITHOUT any board GPIO.  Call
+ * ONCE per RX entry (radio_enableRx); it's a ~12-write I2C burst + a
+ * setBandwidth filter-bank load, far too heavy to run on every squelch
+ * crossing.
+ */
+extern "C" void hd2_at1846s_rx_audio_config(void)
+{
+    at1846s.i2c_writeReg16(0x40,
+                           0x0030); /* RX AF-DSP LISTEN (NOT 0x11 scan-mute) */
+
+    at1846s.i2c_writeReg16(0x41, 0x471e);
+    at1846s.i2c_writeReg16(0x44, 0x0900u | (uint16_t)(g_fm_volume & 0xff));
+    at1846s.i2c_writeReg16(0x33, 0x44a5);
+    at1846s.i2c_writeReg16(0x54, 0x2a3c);
+    at1846s.i2c_writeReg16(0x63, 0x16ad);
+    at1846s.i2c_writeReg16(0x58, 0x8405);
+    at1846s.i2c_writeReg16(0x4e, 0x6002);
+
+    at1846s.i2c_writeReg16(0x7a, 0xa00a);
+    AT1846S::instance().setBandwidth(
+        AT1846S_BW::_25); /* FM bank 0 (vendor-confirmed) */
+
+    /* 0x3a (voice-channel/audio-path select) MUST come AFTER setBandwidth: the
+     * FM bank table includes 0x3a=0x00c3 and silently clobbers the vendor FM-RX
+     * value. */
+    at1846s.i2c_writeReg16(0x3a, 0x80e1);
+
+    /* Vendor FM-RX reg-0x30 enable (rf_apply_channel_to_pll FM branch does
+     * 0x4806 then 0x4826).  0x4826 = band(0x4000)+RX-side(0x800)+RX_ON(0x20)+0x06. */
+    at1846s.i2c_writeReg16(0x30, 0x4806);
+    at1846s.i2c_writeReg16(0x30, 0x4826);
+}
+
+/*
+ * Complete analog-FM RX audio bring-up on the HR_C7000 side: the modem
+ * analog-FM audio gate (socsys).  This is what lets the AT1846S-IF FM demod
+ * reach the codec DAC -> lineout -> speaker.  Called ONCE from radio_init.  The
+ * codec itself is brought up earlier by audio_init() at platform_init time.
+ *
+ * Every value here was verified live against a vendor radio playing FM out the
+ * speaker.
+ */
+extern "C" void hd2_modem_fm_boot_init(void)
+{
+    /* ONE-TIME modem RX + baseband-IF-ADC gate.  Call ONCE from radio_init (rtx
+     * thread startup), BEFORE any RX.
+     *
+     * The masked SYS_SOFT_RSTN write below (active-low, auto-releasing) resets
+     * protocol[0]+phy[1]+fm[2]+adc[5] and releases adc_ctrl[6]+sys[7]+cpu[8],
+     * while PRESERVING the codec[4]/audio-if[3] bits via RMW -- audio_init()
+     * already owns the codec.  Bit6 (adc_ctrl) is released, NOT reset: we must
+     * not reset the CPU/volume ADC at 0x140d0000 -- the UI/main threads are
+     * already polling it.  bit5 (the baseband IF ADC) IS reset -- that's the one
+     * the modem demod needs. */
+    /* FM-RX CLOCK GATE (2026-06-10).  CLK_MGR @0x2c boot value 0xfff0ff3c leaves
+     * [7]modem_clk_fmrx_en + [6]modem_clk_fmtx_en OFF -- so the analog-FM-RX
+     * baseband datapath has NO CLOCK.  Blind write of boot-value|0xC0 (enable
+     * both FM clocks): no read (modem-MMIO reads wedge our loader) and no clock
+     * gets disabled, so safe from the rtx thread.  Must precede the reset +
+     * datapath config below. */
+    SOCSYS->CLK_MGR_REG2C = 0xfff0fffcu;
+
+    /* Reset the modem blocks (baseband ADC[5], FM[2], PHY[1], protocol[0]) and
+     * release CPU/sys/adc_ctrl (8/7/6), but PRESERVE the codec[4]/audio-if[3]
+     * reset bits -- audio_init() owns the codec bring-up and has already run at
+     * platform_init time. RMW keeps its state. */
+    SOCSYS->SYS_SOFT_RSTN = (SOCSYS->SYS_SOFT_RSTN & 0x18u) | 0x1c0u;
+
+    /* AF-RECEIVE BIAS: in AF mode (RF_MODE[24]=1) the
+     * AT1846S audio enters the baseband ADC's VINP, and the ADC's VINM/VCM must
+     * be biased by the CPU-bus DAC (manual §8.2.3.1).  Vendor dac_controller_init
+     * @0x0305960C: route the DAC analog-out pins (DIPLEX2 PTC-mux bits 28/29
+     * clear), power up DAC channels B+C, and drive channel C to the AF bias 0x6E2. */
+    SOCSYS->IO_DIPLEX2 &=
+        0xCFFFFFFFu; /* route DAC out pins (clear PTC mux bits 28-29) */
+    DAC_HW->PD_MODE_EN = 0x00000001u;
+    DAC_HW->DATA_A = 0x00000000u;
+    DAC_HW->DATA_B = 0x00000000u;
+    DAC_HW->DATA_C = 0x00000000u;
+    DAC_HW->PD_CTRL = 0x00000001u; /* power-down A (bit0=1), power-up B+C */
+    DAC_HW->DATA_C =
+        0x000006E2u; /* AF-receive single-point bias (vendor value) */
+
+    /* Modem analog-FM datapath gate + RF/IF/AGC -- written ONCE here, after the
+     * reset.  Values verified live against a vendor radio playing FM. */
+    SOCSYS->BB_DAC_CTRL = 0x8000001fu;
+    SOCSYS->BB_ADC_CTRL =
+        0x000041c3u; /* enadc0[8]+enadc1[7]+adc_enref[6] (baseband IF ADC) */
+    SOCSYS->AUDIO_CONTROL =
+        0x00000002u; /* bit0=0 -> audio via codec DAC (FM) */
+    SOCSYS->AUDIO_BUFFER_CLR = 0x00000000u;
+    SOCSYS->LINEOUT_CTRL = 0x00000001u; /* line2out only -- vendor live value */
+    SOCSYS->WORK_MODE = 0x0000006eu;    /* FM-analog (vendor live) */
+    SOCSYS->RF_MODE = 0x034c9060u;      /* RF_MODE: AF-receive (vendor live) */
+    SOCSYS->RF_CONTROL = 0x00041f1au;   /* RF_CONTROL (vendor live) */
+    SOCSYS->RF_MOD_BIAS = 0x01e80000u;  /* RF/IF reg (vendor live) */
+    SOCSYS->THRESHOLD_VALUE =
+        0x0978786fu; /* arrival/timing-sync detect (vendor live) */
+    SOCSYS->SLOT_GUARD = 0x00000014u; /* slot_guard (vendor live) */
+    SOCSYS->RX_IF_FREQ = 0x000bb800u; /* RX_IF_FREQ = 768 kHz */
+    SOCSYS->RX_AGC = 0x000036b0u;     /* RX_AGC (vendor live) */
+    SOCSYS->SYS_INTERP_MASK =
+        SYS_INTERP_MASK_FM_VENDOR; /* modem/L2 interrupt mask (vendor live) */
+    /* No LAYER2_CONTROL/LAYER2_TXRX_CTRL: those are DMR TDMA slot-sync (datasheet
+     * §9/§10) with no analog-FM role -- verbatim vendor-snapshot cruft, and the
+     * Layer-2 engine is held in reset by SYS_SOFT_RSTN in an FM-only build. */
+}
+
+/* Live AT1846S register access, used by the TX key/dekey sequence above
+ * (hd2_fm_tx_key writes reg 0x0a/0x30/0x40/0x59 with exact verified words). */
+extern "C" uint16_t hd2_at1846s_read(uint8_t reg)
+{
+    return at1846s.i2c_readReg16(reg);
+}
+extern "C" void hd2_at1846s_write(uint8_t reg, uint16_t val)
+{
+    at1846s.i2c_writeReg16(reg, val);
+}
+
+/*
+ * RF carrier/squelch detect via the AT1846S's OWN comparator: reg 0x1C bit0 =
+ * sq_cmp, the chip's RSSI+noise decision with built-in hi/lo hysteresis (using
+ * the chip's init-default thresholds).  Much steadier than thresholding our raw
+ * reg-0x1B RSSI.  Mirrors the vendor's rx_squelch_monitor_tick (@0x03040a6c).
+ * Exposed to OpMode_FM via the radio_checkRxRfSquelch() strong override below.
+ */
+extern "C" bool hd2_rx_carrier_detected(void)
+{
+    return ((at1846s.i2c_readReg16(0x1C) & 0x0001u) != 0u); // sq_cmp
+}
+
+/*
+ * Strong override of the OpMode_FM hardware RF-squelch hook (radio.h): the HD2
+ * has a real on-chip squelch comparator, so report sq_cmp instead of letting
+ * OpMode_FM threshold the jittery raw RSSI.
+ */
+extern "C" bool radio_checkRxRfSquelch(bool *open)
+{
+    *open = hd2_rx_carrier_detected();
+    return true;
+}

--- a/platform/mcu/HR_C7000/registers.h
+++ b/platform/mcu/HR_C7000/registers.h
@@ -11,8 +11,10 @@
  * (gaps for registers this port does not use are RESERVED padding), and cast onto
  * the peripheral base address via the accessor macros at the bottom -- the CMSIS
  * convention. The named registers and their offsets are taken from the HR_C7000
- * vendor user guide (system-control chapter 4, peripherals chapter 5); the wider
- * modem / codec / RF register set is intentionally omitted from this port. Base
+ * vendor user guide (system-control chapter 4, peripherals chapter 5). The
+ * analog-FM subset SOCSYS needs (audio routing, codec gate, CPU DAC, FM
+ * modulator / PTT) is included for the radio driver; the DMR / M17 modem
+ * register set is not. Base
  * addresses, pin-mux masks and "magic" configuration words are hardware facts
  * recovered by on-device reverse engineering of the vendor V2.1.3 firmware; they
  * are not guessed.
@@ -21,6 +23,8 @@
 #ifndef HRC7000_REGISTERS_H
 #define HRC7000_REGISTERS_H
 
+#include <assert.h>
+#include <stddef.h>
 #include <stdint.h>
 
 /* -------------------------------------------------------------------------
@@ -47,7 +51,87 @@ typedef struct {
     volatile uint32_t IO_DIPLEX0;    /* 0x34 PTA pad mux (i2c1/uart2/audio) */
     volatile uint32_t IO_DIPLEX1;    /* 0x38 PTA pad mux (spi0 pins) */
     volatile uint32_t IO_DIPLEX2;    /* 0x3c PTC pad mux */
+    /* --- analog-FM audio / codec / modulator subset (manual 4.6, ch.9/11) --- */
+    uint32_t RESERVED1[12]; /* 0x40 - 0x6c */
+    volatile uint32_t
+        BB_DAC_CTRL; /* 0x70 baseband RF-mod / RX-bias DAC (datasheet §8.1) -- NOT the codec DAC */
+    volatile uint32_t
+        BB_ADC_CTRL; /* 0x74 baseband demod (I/Q) ADC front-end (datasheet §8.2) -- NOT the codec ADC */
+    uint32_t RESERVED2[2]; /* 0x78 - 0x7c */
+    volatile uint32_t
+        AUDIO_CONTROL; /* 0x80 baseband audio source mux (§4.6.5.3: tx_voice_source[0], fm_play_ctrl[6], ring_play_ctrl[7]) */
+    volatile uint32_t
+        AUDIO_BUFFER_CLR; /* 0x84 vocoder decode/encode buffer clear (§4.6.5.4, write-1-self-clear) */
+    volatile uint32_t
+        LINEOUT_CTRL; /* 0x88 [0]line2out_en [1]line1out_en [31]standby(RO) */
+    uint32_t RESERVED3[29]; /* 0x8c - 0xfc */
+    volatile uint32_t
+        WORK_MODE; /* 0x100 work_mode (FM-analog 0x6e; bit7 = FM modulator) */
+    volatile uint32_t
+        RF_MODE;   /* 0x104 baseband RF-interface mode (FM 0x034c9060) */
+    uint32_t RESERVED4[2];        /* 0x108 - 0x10c */
+    volatile uint32_t RF_CONTROL; /* 0x110 tx_pre_on / rf_pre_on_tx */
+    volatile uint32_t
+        RF_MOD_BIAS;       /* 0x114 two-point MOD1/MOD2 amplitude (deviation) */
+    uint32_t RESERVED5[2]; /* 0x118 - 0x11c */
+    volatile uint32_t
+        THRESHOLD_VALUE;   /* 0x120 RX sync-detection thresholds (§9.2.2.9) */
+    uint32_t RESERVED6[17];       /* 0x124 - 0x164 */
+    volatile uint32_t SLOT_GUARD; /* 0x168 TDMA slot guard */
+    uint32_t RESERVED7[17];       /* 0x16c - 0x1ac */
+    volatile uint32_t RX_IF_FREQ; /* 0x1b0 RX IF frequency word */
+    volatile uint32_t RX_AGC;     /* 0x1b4 RX AGC configuration */
+    uint32_t RESERVED8[120];      /* 0x1b8 - 0x394 */
+    volatile uint32_t MODEM_IRQ;  /* 0x398 modem RX IRQ latch (idle 0x4000);
+                                     unused in this FM-only build (RX-capture/future) */
+    volatile uint32_t
+        SYS_INTERP_MASK; /* 0x39c modem/Layer-2 interrupt mask (§4.6.5.10, FM vendor 0x1007f) */
+    volatile uint32_t MODEM_IRQ_ACK; /* 0x3a0 write the latch value back to ACK;
+                                        unused in this FM-only build (RX-capture/future) */
+    uint32_t RESERVED9[23];          /* 0x3a4 - 0x3fc */
+    volatile uint32_t
+        LAYER2_CONTROL;  /* 0x400 DMR L2 [7]txen [6]rxen TDMA slot-sync;
+                            unused in this FM-only build (map completeness) */
+    uint32_t RESERVED10; /* 0x404 */
+    volatile uint32_t
+        LAYER2_TXRX_CTRL; /* 0x408 DMR L2 tx/rx next-slot enable (TDMA slot-sync);
+                             unused in this FM-only build (map completeness) */
+    uint32_t RESERVED11[85]; /* 0x40c - 0x55c */
+    volatile uint32_t
+        FM_PTT; /* 0x560 bit0=1 keys the modem FM-TX engine (ch.11) */
 } SOCSYS_TypeDef;
+
+/* Offset guards: a wrong offset here is a silent hardware bug, so pin the
+ * FM-subset registers to their documented addresses at compile time. */
+static_assert(offsetof(SOCSYS_TypeDef, IO_DIPLEX2) == 0x3c,
+              "SOCSYS IO_DIPLEX2");
+static_assert(offsetof(SOCSYS_TypeDef, BB_DAC_CTRL) == 0x70,
+              "SOCSYS BB_DAC_CTRL");
+static_assert(offsetof(SOCSYS_TypeDef, AUDIO_CONTROL) == 0x80,
+              "SOCSYS AUDIO_CONTROL");
+static_assert(offsetof(SOCSYS_TypeDef, LINEOUT_CTRL) == 0x88,
+              "SOCSYS LINEOUT_CTRL");
+static_assert(offsetof(SOCSYS_TypeDef, WORK_MODE) == 0x100, "SOCSYS WORK_MODE");
+static_assert(offsetof(SOCSYS_TypeDef, RF_MODE) == 0x104, "SOCSYS RF_MODE");
+static_assert(offsetof(SOCSYS_TypeDef, THRESHOLD_VALUE) == 0x120,
+              "SOCSYS THRESHOLD_VALUE");
+static_assert(offsetof(SOCSYS_TypeDef, SLOT_GUARD) == 0x168,
+              "SOCSYS SLOT_GUARD");
+static_assert(offsetof(SOCSYS_TypeDef, RX_IF_FREQ) == 0x1b0,
+              "SOCSYS RX_IF_FREQ");
+static_assert(offsetof(SOCSYS_TypeDef, MODEM_IRQ) == 0x398, "SOCSYS MODEM_IRQ");
+static_assert(offsetof(SOCSYS_TypeDef, MODEM_IRQ_ACK) == 0x3a0,
+              "SOCSYS MODEM_IRQ_ACK");
+static_assert(offsetof(SOCSYS_TypeDef, LAYER2_CONTROL) == 0x400,
+              "SOCSYS LAYER2_CONTROL");
+static_assert(offsetof(SOCSYS_TypeDef, LAYER2_TXRX_CTRL) == 0x408,
+              "SOCSYS LAYER2_TXRX_CTRL");
+static_assert(offsetof(SOCSYS_TypeDef, FM_PTT) == 0x560, "SOCSYS FM_PTT");
+
+/* work_mode / interrupt-mask value macros (analog FM). */
+#define WORK_MODE_FM_MOD 0x80u /* work_mode bit7: FM analog modulator mode */
+#define SYS_INTERP_MASK_FM_VENDOR \
+    0x0001007fu /* vendor FM modem/Layer-2 interrupt-mask value */
 
 /* HD2 board PTC pad-mux values (HD2_DIPLEX2_*) live in targets/HD2/pinmap.h. */
 
@@ -74,7 +158,8 @@ typedef struct {
                                    * the SOCSYS pad-mux (see gpio_setAltFuncB) */
 } GPIO_TypeDef;
 
-/* HD2 board GPIOB pin bits (LED/PTT/PWR/GPS) live in targets/HD2/pinmap.h. */
+/* HD2 board GPIOB pin bits (LED/PTT/PWR/GPS + analog-FM audio-path pins) live
+ * in targets/HD2/pinmap.h. */
 
 /* -------------------------------------------------------------------------
  *  LCD -- HR_C7000 hardware i8080 controller (base 0x12000000, manual 5.3)
@@ -218,6 +303,28 @@ typedef struct {
 #define UART_LSR_DR 0x01u     /* LSR bit 0: RX data ready */
 
 /* -------------------------------------------------------------------------
+ *  CPU DAC (base 0x140f0000, manual 5.10). Three 12-bit channels; PD bits are
+ *  active-HIGH power-DOWN (reset = all channels down). The analog-FM path uses
+ *  DATA_C as the AF-receive bias and DATA_B as the TX APC power-ramp target.
+ * ------------------------------------------------------------------------- */
+typedef struct {
+    volatile uint32_t PD_CTRL;    /* 0x00 [2:0] C/B/A power (1 = down) */
+    volatile uint32_t PD_MODE_EN; /* 0x04 power-mode enable */
+    volatile uint32_t DATA_A;     /* 0x08 channel A data */
+    volatile uint32_t DATA_B;     /* 0x0c channel B data (TX APC ramp) */
+    volatile uint32_t DATA_C;     /* 0x10 channel C data (AF-receive bias) */
+} DAC_TypeDef;
+
+/* -------------------------------------------------------------------------
+ *  Codec AFE control block (base 0x16000900, BYTE-addressed). The codec config
+ *  interface is a byte-wide register file poked at sparse offsets (0xc0-0xef),
+ *  not word registers, so it is accessed via a byte accessor rather than a
+ *  struct. Offsets/roles verified live against a vendor unit playing FM.
+ * ------------------------------------------------------------------------- */
+#define CODEC_BASE 0x16000900u
+#define CODEC_BYTE(off) (*(volatile uint8_t *)(CODEC_BASE + (off)))
+
+/* -------------------------------------------------------------------------
  *  Peripheral instances -- cast the base address onto the register struct.
  * ------------------------------------------------------------------------- */
 #define SOCSYS ((SOCSYS_TypeDef *)0x11000000u)
@@ -226,8 +333,10 @@ typedef struct {
 #define GPIOC ((GPIO_TypeDef *)0x14110000u)
 #define LCD_HW ((LCD_TypeDef *)0x12000000u)
 #define PWM_CH0 ((PWM_Channel_TypeDef *)0x140c0000u)
-#define I2C2 ((I2C_TypeDef *)0x14080000u)
+#define I2C1 ((I2C_TypeDef *)0x14070000u) /* radio bus: AT1846S transceiver */
+#define I2C2 ((I2C_TypeDef *)0x14080000u) /* internal bus: RTC */
 #define ADC_HW ((ADC_TypeDef *)0x140d0000u)
+#define DAC_HW ((DAC_TypeDef *)0x140f0000u)
 #define UART2 ((UART_TypeDef *)0x14050000u) /* GPS module port */
 
 #endif                                      /* HRC7000_REGISTERS_H */

--- a/platform/targets/HD2/CMakeLists.txt
+++ b/platform/targets/HD2/CMakeLists.txt
@@ -54,9 +54,10 @@ set(ORTX_CORE
     ${ORTX}/openrtx/src/core/audio_path.cpp
     ${ORTX}/openrtx/src/core/audio_stream.c
     ${ORTX}/openrtx/src/core/voicePromptUtils.c)
-# Deliberately omitted (stubbed in hd2_stubs.c): voicePrompts.c + audio_codec.c
-# + dsp.cpp (codec2's large static state trips the boot-hang the HD2 build
-# avoids), and rtx.cpp + OpMode_* (radio stack).
+# Deliberately omitted (stubbed in hd2_core_stubs.c): voicePrompts.c +
+# audio_codec.c + dsp.cpp (codec2's large static state trips the boot-hang the
+# HD2 build avoids).  The analog-FM radio stack (rtx.cpp + OpMode_FM.cpp + the
+# HD2 baseband/audio drivers) is now built -- see ORTX_RADIO below.
 
 # --- Default UI -------------------------------------------------------------
 set(ORTX_UI
@@ -88,6 +89,22 @@ set(ORTX_STUBS
     ${ORTX}/platform/drivers/stubs/cps_io_stub.c
     ${ORTX}/platform/drivers/stubs/nvmem_stub.c)
 
+# --- Analog-FM radio stack --------------------------------------------------
+# The hardware-agnostic radio task (rtx.cpp) + the FM operating mode
+# (OpMode_FM.cpp) driving the HD2 baseband/audio drivers: AT1846S transceiver,
+# HR_C7000 codec/modem FM gate (radio_HD2.cpp) and the board audio-routing
+# matrix (audio_HD2.c).  The AT1846S rides the shared HR_C7000 I2C driver
+# (i2c_hrc7000.c, already built with the MCU drivers; instance i2c1 in
+# hwconfig.c).  FM only -- no DMR / M17 / broadcast-FM.  rtx.cpp #includes
+# OpMode_M17.hpp unconditionally, but the M17 object is CONFIG_M17-gated, so
+# OpMode_M17.cpp is not needed here.
+set(ORTX_RADIO
+    ${ORTX}/openrtx/src/rtx/rtx.cpp
+    ${ORTX}/openrtx/src/rtx/OpMode_FM.cpp
+    ${ORTX}/platform/drivers/baseband/radio_HD2.cpp
+    ${ORTX}/platform/drivers/baseband/AT1846S_HD2.cpp
+    ${ORTX}/platform/drivers/audio/audio_HD2.c)
+
 # --- Vendored helper libs the core pulls in ---------------------------------
 set(ORTX_LIBS
     ${ORTX}/lib/minmea/minmea.c
@@ -97,7 +114,7 @@ add_executable(openrtx_hd2
     ${ORTX}/openrtx/src/main.c
     ${CMAKE_SOURCE_DIR}/hd2_glue.cpp
     ${CMAKE_SOURCE_DIR}/hd2_core_stubs.c
-    ${ORTX_CORE} ${ORTX_UI} ${ORTX_HD2} ${ORTX_STUBS} ${ORTX_LIBS})
+    ${ORTX_CORE} ${ORTX_UI} ${ORTX_HD2} ${ORTX_RADIO} ${ORTX_STUBS} ${ORTX_LIBS})
 
 target_include_directories(openrtx_hd2 PRIVATE
     ${CMAKE_SOURCE_DIR}

--- a/platform/targets/HD2/hd2_core_stubs.c
+++ b/platform/targets/HD2/hd2_core_stubs.c
@@ -5,21 +5,19 @@
  * Core entry points the minimal HD2 bring-up cannot yet provide and for which
  * OpenRTX has no generic driver stub.  The driver-layer gaps (codeplug NVM,
  * settings NVM) are filled by platform/drivers/stubs/{cps_io,nvmem}_stub.c;
- * only these two groups have no shared stub and so live here:
+ * only this group has no shared stub and so lives here:
  *
  *   - vp_*  : voice prompts (real impl = core/voicePrompts.c) are left out
  *             until the audio path is brought up.
- *   - rtx_* : the radio task (real impl = rtx/rtx.cpp) is left out until the
- *             baseband/RF stack is brought up.
  *
- * Each group is replaced by its real implementation as that subsystem lands.
+ * The rtx_* radio-task stubs that used to live here are gone: the real radio
+ * task (rtx/rtx.cpp) and FM operating mode now build into this target -- see
+ * the ORTX_RADIO group in CMakeLists.txt.
  */
 
 #include <stdint.h>
 #include <stdbool.h>
-#include <pthread.h>
 #include "core/voicePrompts.h"
-#include "rtx/rtx.h"
 
 /* ---- Voice prompts (no audio path in the minimal bring-up) ---------------- */
 void vp_init()
@@ -66,33 +64,4 @@ void vp_queueString(const char *string, enum vpFlags flags)
 void vp_queueStringTableEntry(const char *const *e)
 {
     (void)e;
-}
-
-/* ---- rtx (no radio task in the minimal bring-up) -------------------------- */
-extern void sleepFor(unsigned int seconds, unsigned int mseconds);
-
-void rtx_init(pthread_mutex_t *m)
-{
-    (void)m;
-}
-void rtx_terminate()
-{
-}
-/* rtx_threadFunc spins `while(RUNNING) rtx_task();` -- sleep so the empty
- * task yields the CPU to the UI/main threads instead of busy-looping. */
-void rtx_task()
-{
-    sleepFor(0, 100);
-}
-void rtx_configure(const rtxStatus_t *cfg)
-{
-    (void)cfg;
-}
-bool rtx_rxSquelchOpen()
-{
-    return false;
-}
-rssi_t rtx_getRssi()
-{
-    return (rssi_t)-127;
 }

--- a/platform/targets/HD2/hwconfig.c
+++ b/platform/targets/HD2/hwconfig.c
@@ -19,6 +19,12 @@
 static pthread_mutex_t adc1Mutex;
 ADC_HRC7000_DEVICE_DEFINE(adc1, &adc1Mutex, ADC_COUNTS_TO_UV(3300000, 10))
 
+/* Radio-bus I2C1 DesignWare master (base 0x14070000) -- the AT1846S transceiver.
+ * Pads PTA7/PTA8 are muxed to I2C1 by platform_init's IO_DIPLEX0 baseline; the
+ * mutex is taken via i2c_acquire()/i2c_release() by the AT1846S driver. */
+static pthread_mutex_t i2c1Mutex = PTHREAD_MUTEX_INITIALIZER;
+I2C_HRC7000_DEVICE_DEFINE(i2c1, I2C1, &i2c1Mutex)
+
 /* Internal I2C2 DesignWare master (base 0x14080000) -- the RTC's dedicated bus.
  * The mutex is taken via i2c_acquire()/i2c_release() by the RTC driver. */
 static pthread_mutex_t i2c2Mutex = PTHREAD_MUTEX_INITIALIZER;

--- a/platform/targets/HD2/hwconfig.h
+++ b/platform/targets/HD2/hwconfig.h
@@ -43,6 +43,7 @@ enum AdcChannels {
  * too; platform.c externs it locally to avoid a hwconfig.h <-> platform.h
  * include cycle (interfaces/platform.h already includes this file). */
 extern const struct Adc adc1;
+extern const struct i2cDevice i2c1; /* radio bus (AT1846S) */
 extern const struct i2cDevice i2c2; /* internal RTC bus */
 
 #ifdef __cplusplus

--- a/platform/targets/HD2/pinmap.h
+++ b/platform/targets/HD2/pinmap.h
@@ -52,4 +52,19 @@
 #define KBD_ROW(n) GPIOC, (KBD_ROW_SHIFT + (n))
 #define KBD_COL(n) GPIOC, (KBD_COL_SHIFT + (n))
 
-#endif /* HD2_PINMAP_H */
+/* GPIOB analog-FM audio-path pins (driven via the atomic gpio_hrc7000 API, by
+ * pin number). Live-verified 2026-06-11. */
+#define SPKR_AMP_PIN 4     /* PTB4  speaker-amp mute, active-LOW (LOW = on) */
+#define AUDIO_ROUTE_PIN 10 /* PTB10 RX-audio route, LOW = routed */
+#define SPKR_GAIN_PIN \
+    17 /* PTB17 speaker-amp analog PATH SELECT (NOT a plain gain):
+                            * HIGH = AT1846S analog demod (drive HIGH for analog-FM RX
+                            * -- the root-cause of the faint-FM-RX saga, LOW = ~inaudible);
+                            * LOW  = codec-DAC lineout (MCU beep / voice-prompt playback,
+                            * where HIGH would leave the codec DAC silent). */
+
+/* GPIOB analog-FM TX board pins (driven by pin number via gpio_hrc7000). */
+#define BAND_SEL_PIN 19 /* PTB19 VHF/UHF band select: HIGH >= 300 MHz */
+#define MIC_PATH_PIN 3  /* PTB3  TX mic-path gate: HIGH while keyed */
+
+#endif                  /* HD2_PINMAP_H */

--- a/platform/targets/HD2/platform.c
+++ b/platform/targets/HD2/platform.c
@@ -9,6 +9,7 @@
  */
 
 #include "interfaces/platform.h"
+#include "interfaces/audio.h"
 #include "peripherals/gpio.h"
 #include "peripherals/rtc.h"
 #include "drivers/ADC/adcHrc7000.h"
@@ -45,6 +46,11 @@ void platform_init()
     GPIOB->DR |= 0x00506414u; /* preserves the PTB13 power latch */
 
     adcHrc7000_init(&adc1);   /* on-chip ADC (battery on ADC_VBAT_CH) */
+
+    /* Bring up the HR_C7000 codec + board audio GPIO at platform_init, before
+     * the rtx thread / radio_init, like every other OpenRTX target. */
+    audio_init();
+
     rtc_init();
 }
 


### PR DESCRIPTION
Builds on the merged minimal bring-up (`Ailunce-HD2`) to add the **analog-FM radio** for the Ailunce HD2 (HR_C7000 / CK803S): the AT1846S transceiver, FM RX/TX, and the `rtx`/`OpMode_FM` wiring, plus a clean audio/modem HAL split.

**On-air verified** — FM RX (squelch + audio) and FM voice TX confirmed on hardware.

### Commits (layered, each a complete step)
1. **mcu: HR_C7000 FM radio/audio/modem registers + atomic GPIO** — SOCSYS register additions (offsets guarded with `static_assert(offsetof)`), and nesting-safe atomic `gpio_setPin/clearPin` (GPIOB is now shared between the UI and radio threads).
2. **HD2: AT1846S transceiver driver** — rides the shared `i2c_hrc7000` driver via an `i2c1` device instance in `hwconfig.c` (no bespoke bus driver; conforms to `peripherals/i2c.h`, mutex in the wrapper).
3. **HD2: analog-FM radio HAL + audio routing** — `radio_HD2` owns the modem datapath; `audio_HD2` owns the codec, brought up idiomatically from `audio_init()` at `platform_init` (as in GDx/MDx/CS7000) and driving the RX AF mute through `radio_enableAfOutput/disableAfOutput`.
4. **HD2: wire rtx task + OpMode_FM, drop rtx stubs** — links `rtx.cpp` + `OpMode_FM.cpp`; removes the `rtx_*` stubs.
5. **rtx: OpMode_FM hardware RF-squelch hook** — see discussion below.

### Notes / design
- **Codec vs modem separation:** the HR_C7000 codec (`0x1600_09xx` block + `LINEOUT`/`AUDIO_CONTROL` gate) is owned by `audio_HD2`; the baseband RF datapath (`BB_DAC_CTRL`/`BB_ADC_CTRL` — these are the *baseband modulation/demod* converters per datasheet §8, **not** the codec — plus `WORK_MODE`, AT1846S) stays in `radio_HD2`. The shared `SYS_SOFT_RSTN` is handed off via an RMW in the modem boot that preserves the codec/audio-if reset bits `audio_init` owns. Register names were corrected to match the datasheet.
- **FM-only:** DMR/Layer-2 register writes were dropped (the Layer-2 struct members are kept in `registers.h` for map completeness, marked unused).

### For discussion
- **`radio_checkRxRfSquelch` hook (commit 5):** OpMode_FM normally thresholds RSSI for RF squelch; this adds an optional hook so a target with a hardware carrier comparator (the AT1846S's, steadier than RSSI) can report squelch directly. I implemented it as a **weak default** in `OpMode_FM.cpp` to avoid touching every target, but I know there's no weak-symbol precedent in the radio HAL — happy to convert it to the full contract (`return false` in each `radio_*.cpp` + `radio_stub.c`) if you'd prefer. Your call on the interface convention.
- The codec-DAC voice-prompt path (PTB17 audio-path select) lands with the voice-prompt follow-up, not this FM-only PR.
