### PR TITLE
DTMF Support

### DIFF
--- a/openrtx/include/core/state.h
+++ b/openrtx/include/core/state.h
@@ -41,6 +41,7 @@ typedef struct {
     uint16_t bank;
     uint8_t rtxStatus;
     bool tone_enabled;
+    uint8_t dtmf_code; /* FM DTMF digit being pressed, or DTMF_CODE_NONE */
 
     bool emergency;
     settings_t settings;

--- a/openrtx/include/rtx/OpMode_FM.hpp
+++ b/openrtx/include/rtx/OpMode_FM.hpp
@@ -8,6 +8,7 @@
 #define OPMODE_FM_H
 
 #include "core/audio_path.h"
+#include "hwconfig.h"
 #include "OpMode.hpp"
 
 /**
@@ -82,6 +83,20 @@ private:
     bool   enterRx;     ///< Flag for RX management.
     pathId rxAudioPath; ///< Audio path ID for RX
     pathId txAudioPath; ///< Audio path ID for TX
+
+    #ifdef CONFIG_FM_INBAND_TONES
+    /**
+     * Play the DTMF digit being transmitted on the speaker, so that the
+     * operator hears what is going on air, and stop the sidetone once the
+     * digit is released or transmission ends.
+     *
+     * @param code: DTMF digit being transmitted, or DTMF_CODE_NONE.
+     */
+    void updateDtmfSidetone(const uint8_t code);
+
+    uint8_t dtmfSidetone;     ///< DTMF digit currently played as sidetone.
+    pathId  dtmfAudioPath;    ///< Audio path ID for the DTMF sidetone.
+    #endif
 };
 
 #endif /* OPMODE_FM_H */

--- a/openrtx/include/rtx/OpMode_FM.hpp
+++ b/openrtx/include/rtx/OpMode_FM.hpp
@@ -8,6 +8,7 @@
 #define OPMODE_FM_H
 
 #include "core/audio_path.h"
+#include "core/audio_stream.h"
 #include "hwconfig.h"
 #include "OpMode.hpp"
 
@@ -86,19 +87,26 @@ private:
 
     #ifdef CONFIG_FM_INBAND_TONES
     /**
-     * Play whatever tone is being transmitted on the speaker, so that the
-     * operator hears what is going on air, and stop it once the key is
-     * released or transmission ends. Neither the DTMF digits nor the tone
-     * burst are otherwise audible locally: both are generated inside the
-     * HR_C6000 and reach the modulator only.
+     * Key or release the in-band tones: DTMF digits and the repeater tone
+     * burst. How the tone is produced depends on the platform: with
+     * CONFIG_FM_TONES_STREAM it is synthesized and streamed to the SINK_RTX
+     * device, whence it modulates the transmitter through the radio's line
+     * input and the hardware echoes it on the speaker as a sidetone.
+     * Otherwise the radio driver keys the tone with the baseband tone
+     * generator and this function only plays the matching sidetone on the
+     * speaker.
      *
      * @param dtmfCode: DTMF digit being transmitted, or DTMF_CODE_NONE.
      * @param toneBurst: true while the repeater tone burst is transmitted.
      */
-    void updateTxSidetone(const uint8_t dtmfCode, const bool toneBurst);
+    void updateTxTones(const uint8_t dtmfCode, const bool toneBurst);
 
-    uint8_t txSidetone;        ///< Tone currently played as sidetone.
-    pathId  sidetoneAudioPath; ///< Audio path ID for the sidetone.
+    uint8_t  txTone;            ///< Tone currently keyed.
+    pathId   sidetoneAudioPath; ///< Audio path ID powering the speaker.
+    #ifdef CONFIG_FM_TONES_STREAM
+    pathId   toneRtxPath;       ///< Audio path ID for the tone stream.
+    streamId toneStream;        ///< Stream ID of the ongoing tone.
+    #endif
     #endif
 };
 

--- a/openrtx/include/rtx/OpMode_FM.hpp
+++ b/openrtx/include/rtx/OpMode_FM.hpp
@@ -86,16 +86,19 @@ private:
 
     #ifdef CONFIG_FM_INBAND_TONES
     /**
-     * Play the DTMF digit being transmitted on the speaker, so that the
-     * operator hears what is going on air, and stop the sidetone once the
-     * digit is released or transmission ends.
+     * Play whatever tone is being transmitted on the speaker, so that the
+     * operator hears what is going on air, and stop it once the key is
+     * released or transmission ends. Neither the DTMF digits nor the tone
+     * burst are otherwise audible locally: both are generated inside the
+     * HR_C6000 and reach the modulator only.
      *
-     * @param code: DTMF digit being transmitted, or DTMF_CODE_NONE.
+     * @param dtmfCode: DTMF digit being transmitted, or DTMF_CODE_NONE.
+     * @param toneBurst: true while the repeater tone burst is transmitted.
      */
-    void updateDtmfSidetone(const uint8_t code);
+    void updateTxSidetone(const uint8_t dtmfCode, const bool toneBurst);
 
-    uint8_t dtmfSidetone;     ///< DTMF digit currently played as sidetone.
-    pathId  dtmfAudioPath;    ///< Audio path ID for the DTMF sidetone.
+    uint8_t txSidetone;        ///< Tone currently played as sidetone.
+    pathId  sidetoneAudioPath; ///< Audio path ID for the sidetone.
     #endif
 };
 

--- a/openrtx/include/rtx/rtx.h
+++ b/openrtx/include/rtx/rtx.h
@@ -16,6 +16,12 @@
 extern "C" {
 #endif
 
+/**
+ * Sentinel for rtxStatus_t::dtmf_code / state_t::dtmf_code meaning "no DTMF
+ * digit is currently pressed".
+ */
+#define DTMF_CODE_NONE 0xFF
+
 typedef struct
 {
     uint8_t opMode;         /**< Operating mode (FM, DMR, ...) */
@@ -39,6 +45,8 @@ typedef struct
              txTone   : 15; /**< TX CTC/DCS tone               */
 
     bool     toneEn;
+
+    uint8_t  dtmf_code;     /**< FM DTMF digit to transmit, or DTMF_CODE_NONE */
 
     uint8_t  can      : 4,  /**< M17 Channel Access Number     */
              canRxEn  : 1,  /**< M17 Check CAN on RX           */

--- a/openrtx/src/core/state.c
+++ b/openrtx/src/core/state.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include "core/event.h"
 #include "core/state.h"
+#include "rtx/rtx.h"
 #include "core/battery.h"
 #include "hwconfig.h"
 #include "interfaces/platform.h"
@@ -61,6 +62,7 @@ void state_init()
     state.rtxStatus = RTX_OFF;
     state.emergency = false;
     state.txDisable = false;
+    state.dtmf_code = DTMF_CODE_NONE;
     state.step_index = 4; // Default frequency step 12.5kHz
 
     // Force brightness field to be in range 0 - 100

--- a/openrtx/src/core/threads.c
+++ b/openrtx/src/core/threads.c
@@ -80,6 +80,7 @@ void *ui_threadFunc(void *arg)
             rtx_cfg.txToneEn    = state.channel.fm.txToneEn;
             rtx_cfg.txTone      = ctcss_tone[state.channel.fm.txTone];
             rtx_cfg.toneEn      = state.tone_enabled;
+            rtx_cfg.dtmf_code   = state.dtmf_code;
 
             // Enable Tx if channel allows it and we are in UI main screen
             rtx_cfg.txDisable = state.channel.rx_only || state.txDisable;

--- a/openrtx/src/rtx/OpMode_FM.cpp
+++ b/openrtx/src/rtx/OpMode_FM.cpp
@@ -14,6 +14,32 @@
 #include "drivers/baseband/AT1846S.h"
 #endif
 
+#ifdef CONFIG_FM_INBAND_TONES
+#include "drivers/audio/Cx000_dac.h"
+
+/**
+ * \internal
+ * DTMF tone pairs, indexed by keypad code (0-9 digits, 10 = '*', 11 = '#').
+ * These mirror the tone table the HR_C6000 uses to generate the transmitted
+ * digit and are only used to reproduce it locally on the speaker.
+ */
+static const uint16_t dtmfTonePairs[12][2] =
+{
+    {941, 1336},    // 0
+    {697, 1209},    // 1
+    {697, 1336},    // 2
+    {697, 1477},    // 3
+    {770, 1209},    // 4
+    {770, 1336},    // 5
+    {770, 1477},    // 6
+    {852, 1209},    // 7
+    {852, 1336},    // 8
+    {852, 1477},    // 9
+    {941, 1209},    // *
+    {941, 1477}     // #
+};
+#endif
+
 /**
  * \internal
  * On MD-UV3x0 radios the volume knob does not regulate the amplitude of the
@@ -38,8 +64,50 @@ void _setVolume()
 #endif
 
 OpMode_FM::OpMode_FM() : rfSqlOpen(false), sqlOpen(false), enterRx(true)
+#ifdef CONFIG_FM_INBAND_TONES
+                       , dtmfSidetone(DTMF_CODE_NONE), dtmfAudioPath(0)
+#endif
 {
 }
+
+#ifdef CONFIG_FM_INBAND_TONES
+void OpMode_FM::updateDtmfSidetone(const uint8_t code)
+{
+    if(code == dtmfSidetone)
+        return;
+
+    // Any change tears down the current sidetone first: this both stops a
+    // released digit and lets a new digit start from a clean state when the
+    // operator slides from one key to another without releasing.
+    if(dtmfSidetone != DTMF_CODE_NONE)
+    {
+        Cx000dac_stopBeep();
+        audioPath_release(dtmfAudioPath);
+        dtmfAudioPath = 0;
+    }
+
+    dtmfSidetone = DTMF_CODE_NONE;
+
+    if(code >= 12)
+        return;
+
+    // The speaker is not connected to anything while transmitting, so the
+    // path has to be opened explicitly. PRIO_BEEP keeps the sidetone from
+    // stealing the speaker from voice prompts.
+    dtmfAudioPath = audioPath_request(SOURCE_MCU, SINK_SPK, PRIO_BEEP);
+    if(dtmfAudioPath <= 0)
+        return;
+
+    if(Cx000dac_startDualTone(dtmfTonePairs[code][0], dtmfTonePairs[code][1]) < 0)
+    {
+        audioPath_release(dtmfAudioPath);
+        dtmfAudioPath = 0;
+        return;
+    }
+
+    dtmfSidetone = code;
+}
+#endif
 
 OpMode_FM::~OpMode_FM()
 {
@@ -58,6 +126,9 @@ void OpMode_FM::disable()
     // Clean shutdown.
     platform_ledOff(GREEN);
     platform_ledOff(RED);
+    #ifdef CONFIG_FM_INBAND_TONES
+    updateDtmfSidetone(DTMF_CODE_NONE);
+    #endif
     audioPath_release(rxAudioPath);
     audioPath_release(txAudioPath);
     radio_disableRtx();
@@ -127,8 +198,18 @@ void OpMode_FM::update(rtxStatus_t *const status, const bool newCfg)
         status->opStatus = TX;
     }
 
+    #ifdef CONFIG_FM_INBAND_TONES
+    // Echo the digit being transmitted on the speaker. Only while actually
+    // transmitting: outside of TX no digit reaches the air.
+    updateDtmfSidetone((status->opStatus == TX) ? status->dtmf_code
+                                                : DTMF_CODE_NONE);
+    #endif
+
     if(!platform_getPttStatus() && (status->opStatus == TX))
     {
+        #ifdef CONFIG_FM_INBAND_TONES
+        updateDtmfSidetone(DTMF_CODE_NONE);
+        #endif
         audioPath_release(txAudioPath);
         radio_disableRtx();
 

--- a/openrtx/src/rtx/OpMode_FM.cpp
+++ b/openrtx/src/rtx/OpMode_FM.cpp
@@ -15,13 +15,18 @@
 #endif
 
 #ifdef CONFIG_FM_INBAND_TONES
+
+#ifdef CONFIG_FM_TONES_STREAM
+#include <math.h>
+#include <memory>
+#else
+#include "drivers/baseband/HR_C6000.h"
 #include "drivers/audio/Cx000_dac.h"
+#endif
 
 /**
  * \internal
  * DTMF tone pairs, indexed by keypad code (0-9 digits, 10 = '*', 11 = '#').
- * These mirror the tone table the HR_C6000 uses to generate the transmitted
- * digit and are only used to reproduce it locally on the speaker.
  */
 static const uint16_t dtmfTonePairs[12][2] =
 {
@@ -41,17 +46,77 @@ static const uint16_t dtmfTonePairs[12][2] =
 
 /**
  * \internal
- * Sidetone identifier for the repeater tone burst, taking the first value past
- * the DTMF keypad codes so that both share one "currently playing" state.
+ * Tone identifier for the repeater tone burst, taking the first value past
+ * the DTMF keypad codes so that both share one "currently keyed" state.
  */
-static const uint8_t SIDETONE_TONE_BURST = 12;
+static const uint8_t TONE_ID_BURST = 12;
 
 /**
  * \internal
  * Frequency of the repeater tone burst, in Hz.
  */
 static const uint16_t TONE_BURST_FREQ = 1750;
-#endif
+
+#ifdef CONFIG_FM_TONES_STREAM
+/*
+ * \internal
+ * The tones are played by looping a precomputed buffer through the SINK_RTX
+ * device. The buffer holds 100ms of audio, giving a 10Hz frequency grid:
+ * each tone is rounded to a whole number of cycles per loop so the looped
+ * playback is seamless. The worst rounding error among the DTMF tones is
+ * 0.43%, well within the 1.5% the DTMF specification allows.
+ *
+ * The peak amplitude sets the FM deviation reached through the line input,
+ * whose gain is bandwidth-compensated inside the baseband chip.
+ */
+static const size_t   TONE_BUF_LEN     = 1600;
+static const uint32_t TONE_SAMPLE_RATE = 16000;
+static const int32_t  TONE_PEAK_LEVEL  = 16384;
+
+static std::unique_ptr< int16_t[] > toneBuf;
+
+/**
+ * \internal
+ * Fill the tone buffer with one loop of a single tone or of an equal-level
+ * mix of two tones, with an overall peak amplitude of TONE_PEAK_LEVEL.
+ *
+ * @param freq1: tone frequency in Hz.
+ * @param freq2: frequency of a second tone to mix in, zero for none.
+ */
+static void synthToneLoop(const uint16_t freq1, const uint16_t freq2)
+{
+    // The buffer needs to be reachable by the DMA, the heap always is.
+    if(!toneBuf)
+        toneBuf = std::make_unique< int16_t[] >(TONE_BUF_LEN);
+
+    // Round each tone to a whole number of cycles per loop
+    uint32_t cyc1 = ((freq1 * TONE_BUF_LEN) + (TONE_SAMPLE_RATE / 2))
+                  / TONE_SAMPLE_RATE;
+    uint32_t cyc2 = ((freq2 * TONE_BUF_LEN) + (TONE_SAMPLE_RATE / 2))
+                  / TONE_SAMPLE_RATE;
+
+    for(size_t i = 0; i < TONE_BUF_LEN; i++)
+    {
+        // Indexing modulo the buffer length keeps the phase exact over the
+        // whole loop instead of accumulating floating point error.
+        size_t idx  = (i * cyc1) % TONE_BUF_LEN;
+        float angle = (2.0f * ((float) M_PI) * ((float) idx))
+                    / ((float) TONE_BUF_LEN);
+        float value = sinf(angle);
+
+        if(freq2 != 0)
+        {
+            idx   = (i * cyc2) % TONE_BUF_LEN;
+            angle = (2.0f * ((float) M_PI) * ((float) idx))
+                  / ((float) TONE_BUF_LEN);
+            value = (value + sinf(angle)) / 2.0f;
+        }
+
+        toneBuf[i] = (int16_t)(value * ((float) TONE_PEAK_LEVEL));
+    }
+}
+#endif // CONFIG_FM_TONES_STREAM
+#endif // CONFIG_FM_INBAND_TONES
 
 /**
  * \internal
@@ -78,13 +143,17 @@ void _setVolume()
 
 OpMode_FM::OpMode_FM() : rfSqlOpen(false), sqlOpen(false), enterRx(true)
 #ifdef CONFIG_FM_INBAND_TONES
-                       , txSidetone(DTMF_CODE_NONE), sidetoneAudioPath(0)
+                       , txTone(DTMF_CODE_NONE), sidetoneAudioPath(0)
+#ifdef CONFIG_FM_TONES_STREAM
+                       , toneRtxPath(0), toneStream(-1)
+#endif
 #endif
 {
 }
 
 #ifdef CONFIG_FM_INBAND_TONES
-void OpMode_FM::updateTxSidetone(const uint8_t dtmfCode, const bool toneBurst)
+#ifdef CONFIG_FM_TONES_STREAM
+void OpMode_FM::updateTxTones(const uint8_t dtmfCode, const bool toneBurst)
 {
     // A digit and the tone burst are on separate keys and can be held at once.
     // The digit wins, matching the order the radio driver keys them in.
@@ -92,22 +161,99 @@ void OpMode_FM::updateTxSidetone(const uint8_t dtmfCode, const bool toneBurst)
     if(dtmfCode < 12)
         wanted = dtmfCode;
     else if(toneBurst)
-        wanted = SIDETONE_TONE_BURST;
+        wanted = TONE_ID_BURST;
 
-    if(wanted == txSidetone)
+    if(wanted == txTone)
         return;
 
+    // Any change tears down the current tone first: this both stops a
+    // released key and lets a new digit start from a clean state when the
+    // operator slides from one key to another without releasing.
+    if(txTone != DTMF_CODE_NONE)
+    {
+        audioStream_terminate(toneStream);
+        audioPath_release(sidetoneAudioPath);
+        audioPath_release(toneRtxPath);
+        toneStream        = -1;
+        sidetoneAudioPath = 0;
+        toneRtxPath       = 0;
+
+        // Hand the RTX sink back to the microphone
+        txAudioPath = audioPath_request(SOURCE_MIC, SINK_RTX, PRIO_TX);
+    }
+
+    txTone = DTMF_CODE_NONE;
+
+    if(wanted == DTMF_CODE_NONE)
+        return;
+
+    // The tone goes on air by streaming it to the SINK_RTX device, which
+    // feeds the radio's line input: trade the microphone path for an MCU
+    // one. The radio driver has already switched its modulation source to
+    // the line input, so the microphone is out of the TX chain anyway.
+    audioPath_release(txAudioPath);
+    txAudioPath = 0;
+    toneRtxPath = audioPath_request(SOURCE_MCU, SINK_RTX, PRIO_TX);
+    if(toneRtxPath <= 0)
+    {
+        txAudioPath = audioPath_request(SOURCE_MIC, SINK_RTX, PRIO_TX);
+        return;
+    }
+
+    // The speaker is not connected to anything while transmitting, so a
+    // path has to be opened explicitly for the sidetone the hardware echoes
+    // back. PRIO_BEEP keeps it from stealing the speaker from voice
+    // prompts; failing to get it is fine, the tone still goes on air.
+    sidetoneAudioPath = audioPath_request(SOURCE_MCU, SINK_SPK, PRIO_BEEP);
+
+    if(wanted == TONE_ID_BURST)
+        synthToneLoop(TONE_BURST_FREQ, 0);
+    else
+        synthToneLoop(dtmfTonePairs[wanted][0], dtmfTonePairs[wanted][1]);
+
+    toneStream = audioStream_start(toneRtxPath, toneBuf.get(), TONE_BUF_LEN,
+                                   TONE_SAMPLE_RATE,
+                                   STREAM_OUTPUT | BUF_CIRC_DOUBLE);
+    if(toneStream < 0)
+    {
+        audioPath_release(sidetoneAudioPath);
+        audioPath_release(toneRtxPath);
+        sidetoneAudioPath = 0;
+        toneRtxPath       = 0;
+        txAudioPath = audioPath_request(SOURCE_MIC, SINK_RTX, PRIO_TX);
+        return;
+    }
+
+    txTone = wanted;
+}
+#else
+void OpMode_FM::updateTxTones(const uint8_t dtmfCode, const bool toneBurst)
+{
+    // A digit and the tone burst are on separate keys and can be held at once.
+    // The digit wins, matching the order the radio driver keys them in.
+    uint8_t wanted = DTMF_CODE_NONE;
+    if(dtmfCode < 12)
+        wanted = dtmfCode;
+    else if(toneBurst)
+        wanted = TONE_ID_BURST;
+
+    if(wanted == txTone)
+        return;
+
+    // The tone itself is keyed on air by the radio driver, through the
+    // baseband tone generator: here only the matching sidetone is played on
+    // the speaker, through the Cx000 DAC so that it follows the volume knob.
     // Any change tears down the current sidetone first: this both stops a
     // released key and lets a new digit start from a clean state when the
     // operator slides from one key to another without releasing.
-    if(txSidetone != DTMF_CODE_NONE)
+    if(txTone != DTMF_CODE_NONE)
     {
         Cx000dac_stopBeep();
         audioPath_release(sidetoneAudioPath);
         sidetoneAudioPath = 0;
     }
 
-    txSidetone = DTMF_CODE_NONE;
+    txTone = DTMF_CODE_NONE;
 
     if(wanted == DTMF_CODE_NONE)
         return;
@@ -120,7 +266,7 @@ void OpMode_FM::updateTxSidetone(const uint8_t dtmfCode, const bool toneBurst)
         return;
 
     int ret;
-    if(wanted == SIDETONE_TONE_BURST)
+    if(wanted == TONE_ID_BURST)
         ret = Cx000dac_startBeep(TONE_BURST_FREQ);
     else
         ret = Cx000dac_startDualTone(dtmfTonePairs[wanted][0],
@@ -133,9 +279,10 @@ void OpMode_FM::updateTxSidetone(const uint8_t dtmfCode, const bool toneBurst)
         return;
     }
 
-    txSidetone = wanted;
+    txTone = wanted;
 }
-#endif
+#endif // CONFIG_FM_TONES_STREAM
+#endif // CONFIG_FM_INBAND_TONES
 
 OpMode_FM::~OpMode_FM()
 {
@@ -155,7 +302,7 @@ void OpMode_FM::disable()
     platform_ledOff(GREEN);
     platform_ledOff(RED);
     #ifdef CONFIG_FM_INBAND_TONES
-    updateTxSidetone(DTMF_CODE_NONE, false);
+    updateTxTones(DTMF_CODE_NONE, false);
     #endif
     audioPath_release(rxAudioPath);
     audioPath_release(txAudioPath);
@@ -230,14 +377,14 @@ void OpMode_FM::update(rtxStatus_t *const status, const bool newCfg)
     // Echo what is being transmitted on the speaker. Only while actually
     // transmitting: outside of TX neither tone reaches the air.
     bool txing = (status->opStatus == TX);
-    updateTxSidetone(txing ? status->dtmf_code : DTMF_CODE_NONE,
+    updateTxTones(txing ? status->dtmf_code : DTMF_CODE_NONE,
                      txing && (status->toneEn != 0));
     #endif
 
     if(!platform_getPttStatus() && (status->opStatus == TX))
     {
         #ifdef CONFIG_FM_INBAND_TONES
-        updateTxSidetone(DTMF_CODE_NONE, false);
+        updateTxTones(DTMF_CODE_NONE, false);
         #endif
         audioPath_release(txAudioPath);
         radio_disableRtx();

--- a/openrtx/src/rtx/OpMode_FM.cpp
+++ b/openrtx/src/rtx/OpMode_FM.cpp
@@ -38,6 +38,19 @@ static const uint16_t dtmfTonePairs[12][2] =
     {941, 1209},    // *
     {941, 1477}     // #
 };
+
+/**
+ * \internal
+ * Sidetone identifier for the repeater tone burst, taking the first value past
+ * the DTMF keypad codes so that both share one "currently playing" state.
+ */
+static const uint8_t SIDETONE_TONE_BURST = 12;
+
+/**
+ * \internal
+ * Frequency of the repeater tone burst, in Hz.
+ */
+static const uint16_t TONE_BURST_FREQ = 1750;
 #endif
 
 /**
@@ -65,47 +78,62 @@ void _setVolume()
 
 OpMode_FM::OpMode_FM() : rfSqlOpen(false), sqlOpen(false), enterRx(true)
 #ifdef CONFIG_FM_INBAND_TONES
-                       , dtmfSidetone(DTMF_CODE_NONE), dtmfAudioPath(0)
+                       , txSidetone(DTMF_CODE_NONE), sidetoneAudioPath(0)
 #endif
 {
 }
 
 #ifdef CONFIG_FM_INBAND_TONES
-void OpMode_FM::updateDtmfSidetone(const uint8_t code)
+void OpMode_FM::updateTxSidetone(const uint8_t dtmfCode, const bool toneBurst)
 {
-    if(code == dtmfSidetone)
+    // A digit and the tone burst are on separate keys and can be held at once.
+    // The digit wins, matching the order the radio driver keys them in.
+    uint8_t wanted = DTMF_CODE_NONE;
+    if(dtmfCode < 12)
+        wanted = dtmfCode;
+    else if(toneBurst)
+        wanted = SIDETONE_TONE_BURST;
+
+    if(wanted == txSidetone)
         return;
 
     // Any change tears down the current sidetone first: this both stops a
-    // released digit and lets a new digit start from a clean state when the
+    // released key and lets a new digit start from a clean state when the
     // operator slides from one key to another without releasing.
-    if(dtmfSidetone != DTMF_CODE_NONE)
+    if(txSidetone != DTMF_CODE_NONE)
     {
         Cx000dac_stopBeep();
-        audioPath_release(dtmfAudioPath);
-        dtmfAudioPath = 0;
+        audioPath_release(sidetoneAudioPath);
+        sidetoneAudioPath = 0;
     }
 
-    dtmfSidetone = DTMF_CODE_NONE;
+    txSidetone = DTMF_CODE_NONE;
 
-    if(code >= 12)
+    if(wanted == DTMF_CODE_NONE)
         return;
 
     // The speaker is not connected to anything while transmitting, so the
     // path has to be opened explicitly. PRIO_BEEP keeps the sidetone from
     // stealing the speaker from voice prompts.
-    dtmfAudioPath = audioPath_request(SOURCE_MCU, SINK_SPK, PRIO_BEEP);
-    if(dtmfAudioPath <= 0)
+    sidetoneAudioPath = audioPath_request(SOURCE_MCU, SINK_SPK, PRIO_BEEP);
+    if(sidetoneAudioPath <= 0)
         return;
 
-    if(Cx000dac_startDualTone(dtmfTonePairs[code][0], dtmfTonePairs[code][1]) < 0)
+    int ret;
+    if(wanted == SIDETONE_TONE_BURST)
+        ret = Cx000dac_startBeep(TONE_BURST_FREQ);
+    else
+        ret = Cx000dac_startDualTone(dtmfTonePairs[wanted][0],
+                                     dtmfTonePairs[wanted][1]);
+
+    if(ret < 0)
     {
-        audioPath_release(dtmfAudioPath);
-        dtmfAudioPath = 0;
+        audioPath_release(sidetoneAudioPath);
+        sidetoneAudioPath = 0;
         return;
     }
 
-    dtmfSidetone = code;
+    txSidetone = wanted;
 }
 #endif
 
@@ -127,7 +155,7 @@ void OpMode_FM::disable()
     platform_ledOff(GREEN);
     platform_ledOff(RED);
     #ifdef CONFIG_FM_INBAND_TONES
-    updateDtmfSidetone(DTMF_CODE_NONE);
+    updateTxSidetone(DTMF_CODE_NONE, false);
     #endif
     audioPath_release(rxAudioPath);
     audioPath_release(txAudioPath);
@@ -199,16 +227,17 @@ void OpMode_FM::update(rtxStatus_t *const status, const bool newCfg)
     }
 
     #ifdef CONFIG_FM_INBAND_TONES
-    // Echo the digit being transmitted on the speaker. Only while actually
-    // transmitting: outside of TX no digit reaches the air.
-    updateDtmfSidetone((status->opStatus == TX) ? status->dtmf_code
-                                                : DTMF_CODE_NONE);
+    // Echo what is being transmitted on the speaker. Only while actually
+    // transmitting: outside of TX neither tone reaches the air.
+    bool txing = (status->opStatus == TX);
+    updateTxSidetone(txing ? status->dtmf_code : DTMF_CODE_NONE,
+                     txing && (status->toneEn != 0));
     #endif
 
     if(!platform_getPttStatus() && (status->opStatus == TX))
     {
         #ifdef CONFIG_FM_INBAND_TONES
-        updateDtmfSidetone(DTMF_CODE_NONE);
+        updateTxSidetone(DTMF_CODE_NONE, false);
         #endif
         audioPath_release(txAudioPath);
         radio_disableRtx();

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -1476,6 +1476,34 @@ void ui_updateFSM(bool *sync_rtx)
             *sync_rtx = true;
         }
 
+#ifdef CONFIG_FM_INBAND_TONES
+        // Hot-keypad FM DTMF: while transmitting in FM, holding a digit / * / #
+        // key generates the matching DTMF tone (muting the mic); releasing it
+        // restores the mic. The tone itself is driven by the FM opMode. While a
+        // digit is keyed the keypad is dedicated to DTMF, so the event is
+        // consumed here and does not also drive VFO/memory input.
+        if(txOngoing && (state.channel.mode == OPMODE_FM))
+        {
+            uint16_t dtmfKeys = msg.keys & KBD_CHAR_MASK;
+            uint8_t  prev     = state.dtmf_code;
+            uint8_t  dtmf     = dtmfKeys ? __builtin_ctz(dtmfKeys)
+                                         : DTMF_CODE_NONE;
+            if(dtmf != prev)
+            {
+                state.dtmf_code = dtmf;
+                *sync_rtx = true;
+            }
+            if((dtmf != DTMF_CODE_NONE) || (prev != DTMF_CODE_NONE))
+                return;
+        }
+        else if(state.dtmf_code != DTMF_CODE_NONE)
+        {
+            // Left FM or stopped transmitting with a digit still marked pressed.
+            state.dtmf_code = DTMF_CODE_NONE;
+            *sync_rtx = true;
+        }
+#endif // CONFIG_FM_INBAND_TONES
+
         int priorUIScreen = state.ui_screen;
         switch(state.ui_screen)
         {

--- a/openrtx/src/ui/default/ui.c
+++ b/openrtx/src/ui/default/ui.c
@@ -1470,8 +1470,24 @@ void ui_updateFSM(bool *sync_rtx)
         }
 #endif // PLA%FORM_TTWRPLUS
 
-        if(state.tone_enabled && !(msg.keys & KEY_HASH))
+        // Hot-keypad repeater tone burst: while transmitting in FM, holding F1
+        // keys the 1750Hz tone (muting the mic); releasing it restores the mic.
+        // The event is consumed so that F1 does not also trigger its usual
+        // voice announcement, which has no place mid-transmission anyway.
+        if(txOngoing && (state.channel.mode == OPMODE_FM))
         {
+            bool toneKey = (msg.keys & KEY_F1) != 0;
+            if(toneKey != state.tone_enabled)
+            {
+                state.tone_enabled = toneKey;
+                *sync_rtx = true;
+            }
+            if(toneKey)
+                return;
+        }
+        else if(state.tone_enabled)
+        {
+            // Left FM or stopped transmitting with the tone still keyed.
             state.tone_enabled = false;
             *sync_rtx = true;
         }
@@ -1518,9 +1534,9 @@ void ui_updateFSM(bool *sync_rtx)
                 }
 
                 // Break out of the FSM if the keypad is locked but allow the
-                // use of the hash key in FM mode for the 1750Hz tone.
+                // use of the F1 key in FM mode for the 1750Hz tone.
                 bool skipLock =  (state.channel.mode == OPMODE_FM)
-                              && (msg.keys == KEY_HASH);
+                              && (msg.keys == KEY_F1);
 
                 if ((ui_state.input_locked == true) && (skipLock == false))
                     break;
@@ -1601,15 +1617,7 @@ void ui_updateFSM(bool *sync_rtx)
                             vp_announceM17Info(NULL,  ui_state.edit_mode,
                                                queueFlags);
                         }
-                        else
                         #endif
-                        {
-                            if(!state.tone_enabled)
-                            {
-                                state.tone_enabled = true;
-                                *sync_rtx = true;
-                            }
-                        }
                     }
                     else if(msg.keys & KEY_UP || msg.keys & KNOB_RIGHT)
                     {
@@ -1795,14 +1803,6 @@ void ui_updateFSM(bool *sync_rtx)
                             // Reset text input variables
                             _ui_textInputReset(ui_state.new_callsign,
                                     sizeof(ui_state.new_callsign));
-                        }
-                        else
-                        {
-                            if(!state.tone_enabled)
-                            {
-                                state.tone_enabled = true;
-                                *sync_rtx = true;
-                            }
                         }
                     }
                     else if(msg.keys & KEY_F1)

--- a/platform/drivers/audio/Cx000_dac.cpp
+++ b/platform/drivers/audio/Cx000_dac.cpp
@@ -14,9 +14,10 @@
 
 enum FuncMode
 {
-    DAC_OFF    = 0,
-    DAC_BEEP   = 1,
-    DAC_STREAM = 2
+    DAC_OFF      = 0,
+    DAC_BEEP     = 1,
+    DAC_STREAM   = 2,
+    DAC_DUALTONE = 3
 };
 
 /*
@@ -42,6 +43,8 @@ static bool syncPoint = false;
 static bool stopReq   = false;
 static size_t readPos;
 static size_t beepIncr;
+static size_t readPos2;     // Second oscillator, dual tone mode only
+static size_t beepIncr2;    // Second oscillator, dual tone mode only
 static struct streamCtx *stream;
 static pthread_mutex_t  mutex;
 static pthread_cond_t   wakeup_cond;
@@ -93,6 +96,29 @@ void Cx000dac_task()
         {
             readPos += beepIncr;
             data[i] = sineTable[(readPos >> 16) & 0x3F];
+        }
+
+        c6000->sendAudio((uint8_t *) data);
+        return;
+    }
+
+    // Dual tone mode: same as beep, but summing two oscillators. Each one is
+    // halved before summing, so the result has the same peak amplitude as a
+    // single beep and cannot clip. The sine table is stored big endian, as the
+    // DAC wants it, so samples are swapped to native endianness to be summed
+    // and swapped back afterwards.
+    if(funcMode == DAC_DUALTONE)
+    {
+        uint16_t data[DAC_FIFO_SIZE];
+        for(size_t i = 0; i < DAC_FIFO_SIZE; i += 1)
+        {
+            readPos  += beepIncr;
+            readPos2 += beepIncr2;
+
+            int16_t s1 = (int16_t) __builtin_bswap16(sineTable[(readPos  >> 16) & 0x3F]);
+            int16_t s2 = (int16_t) __builtin_bswap16(sineTable[(readPos2 >> 16) & 0x3F]);
+
+            data[i] = __builtin_bswap16((uint16_t)((s1 / 2) + (s2 / 2)));
         }
 
         c6000->sendAudio((uint8_t *) data);
@@ -158,10 +184,30 @@ int Cx000dac_startBeep(const uint16_t freq)
     return 0;
 }
 
+int Cx000dac_startDualTone(const uint16_t freq1, const uint16_t freq2)
+{
+    if((freq1 < TONE_BASE_FREQ) || (freq2 < TONE_BASE_FREQ))
+        return -EINVAL;
+
+    if(funcMode != DAC_OFF)
+        return -EBUSY;
+
+    beepIncr  = (freq1 << 16) / TONE_BASE_FREQ;
+    beepIncr2 = (freq2 << 16) / TONE_BASE_FREQ;
+    readPos   = 0;
+    readPos2  = 0;
+    funcMode  = DAC_DUALTONE;
+
+    // Set the "OpenMusic" bit
+    c6000->writeCfgRegister(0x06, 0x22);
+
+    return 0;
+}
+
 void Cx000dac_stopBeep()
 {
-    // Stop only beeps, streams have an higher priority
-    if(funcMode != DAC_BEEP)
+    // Stop only beeps and tones, streams have an higher priority
+    if((funcMode != DAC_BEEP) && (funcMode != DAC_DUALTONE))
         return;
 
     // Clear the "OpenMusic" bit

--- a/platform/drivers/audio/Cx000_dac.h
+++ b/platform/drivers/audio/Cx000_dac.h
@@ -32,7 +32,18 @@ extern const struct audioDriver Cx000_dac_audio_driver;
 int Cx000dac_startBeep(const uint16_t freq);
 
 /**
- * Stop an ongoing "beep" tone.
+ * Start generation of a two-tone sound from DAC output, for example a DTMF
+ * digit. The two tones are mixed at equal amplitude and the result has the
+ * same peak level as a single "beep" tone.
+ *
+ * @param freq1: first tone frequency in Hz.
+ * @param freq2: second tone frequency in Hz.
+ * @return zero on success, a negative error code otherwise.
+ */
+int Cx000dac_startDualTone(const uint16_t freq1, const uint16_t freq2);
+
+/**
+ * Stop an ongoing "beep" or dual tone sound.
  */
 void Cx000dac_stopBeep();
 

--- a/platform/drivers/audio/audio_CS7000.cpp
+++ b/platform/drivers/audio/audio_CS7000.cpp
@@ -202,11 +202,15 @@ bool audio_checkPathCompatibility(const enum AudioSource p1Source,
                                   const enum AudioSink   p2Sink)
 
 {
-    if(p1Source == p2Source)
-        return false;
-
     if(p1Sink == p2Sink)
         return false;
+
+    // SOURCE_MCU is not one physical source: each sink is fed by its own
+    // device (the HR_C6000 DAC for the speaker, the STM32 DAC for the RTX
+    // stage), so two MCU paths towards different sinks can coexist. This is
+    // used to echo the transmitted in-band tones on the speaker.
+    if(p1Source == p2Source)
+        return (p1Source == SOURCE_MCU);
 
     return true;
 }

--- a/platform/drivers/baseband/HR_C6000.cpp
+++ b/platform/drivers/baseband/HR_C6000.cpp
@@ -6,6 +6,7 @@
 
 #include "core/utils.h"
 #include "drivers/baseband/HR_C6000.h"
+#include "radioUtils.h"
 
 /*
  * Table of HR_C6000 CTCSS tones, used for reverse lookup of tone index to be
@@ -76,4 +77,67 @@ void HR_C6000::sendTone(const uint32_t freq, const uint8_t deviation)
     writeCfgRegister(0xAD, 0x11);
     writeCfgRegister(0x60, 0x00);         // Disable FM transmission
     writeCfgRegister(0x60, 0x80);         // Enable FM transmission, start sending the tone
+}
+
+void HR_C6000::initDtmf()
+{
+    // The HR_C6000 has a built-in DTMF generator: eight oscillator slots
+    // (0x11A..0x129) hold the eight standard DTMF frequencies, and the digit
+    // code selects which low+high pair the chip mixes. The slots live in the
+    // auxiliary register bank, not in the main configuration one.
+    static const uint16_t dtmfFreq[8] =
+        { 697, 770, 852, 941, 1209, 1336, 1477, 1633 };
+    for(uint8_t i = 0; i < 8; i++)
+    {
+        uint32_t tone = ((uint32_t)dtmfFreq[i] * 65536) / 32000;
+        uint16_t addr = 0x11A + (i * 2);
+        writeReg16(C6000_SpiOpModes::AUX, addr + 1, (tone >> 8) & 0xFF);
+        writeReg16(C6000_SpiOpModes::AUX, addr,     (tone & 0xFF));
+    }
+
+    dtmfTableValid = true;
+}
+
+void HR_C6000::sendDtmf(const uint8_t code, const uint8_t deviation)
+{
+    // Assumes initDtmf() has already programmed the tone table. Selects the
+    // digit's low+high pair from that table and keys it on air.
+    writeCfgRegister(0xA1, 0x82);          // Enable DTMF mode
+    writeCfgRegister(0xA0, deviation);     // Set DTMF tone deviation
+    writeCfgRegister(0xA4, 0xFA);          // Tone time (large -> continuous)
+    writeCfgRegister(0xA3, 0x19);          // Tone gap (unused for a single code)
+
+    // The high nibble of 0xD1 holds undocumented FM-DTMF bits set elsewhere;
+    // preserve them and only set the code count (low nibble) to one.
+    uint8_t codeCount = (readCfgRegister(0xD1) & 0xF0) | 0x01;
+    writeCfgRegister(0xD1, codeCount);
+    writeCfgRegister(0xAF, code << 4);     // First code goes in the high nibble
+    writeCfgRegister(0x60, 0x00);          // Disable FM transmission
+    writeCfgRegister(0x60, 0x80);          // Enable FM transmission, start sending
+}
+
+void HR_C6000::sendDtmfKey(const uint8_t key, const freq_t txFrequency,
+                           const bool narrowBand)
+{
+    // Keypad code to HR_C6000 digit code: the digits map to themselves, while
+    // '*' and '#' are the last two entries of the chip's code space.
+    static const uint8_t codeMap[12] =
+        { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xE /* * */, 0xF /* # */ };
+
+    if(key >= 12)
+        return;
+
+    // Program the tone table when it is not already good: this is the case on
+    // the first digit, and after sendTone() has borrowed one of the slots.
+    if(dtmfTableValid == false)
+        initDtmf();
+
+    // Deviation coefficients for the DTMF generator, per band and bandwidth.
+    uint8_t deviation;
+    if(getBandFromFrequency(txFrequency) == BND_VHF)
+        deviation = narrowBand ? 0x3A : 0x75;
+    else
+        deviation = narrowBand ? 0x12 : 0x24;
+
+    sendDtmf(codeMap[key], deviation);
 }

--- a/platform/drivers/baseband/HR_C6000.cpp
+++ b/platform/drivers/baseband/HR_C6000.cpp
@@ -59,24 +59,22 @@ void HR_C6000::sendTone(const uint32_t freq, const uint8_t deviation)
 {
     uint32_t tone = (freq * 65536) / 32000;
 
-    // Set  DTMF tone osc 1 to frequency of the required tone
-    writeReg16(C6000_SpiOpModes::CONFIG, 0x11A, (tone & 0xFF));
-    writeReg16(C6000_SpiOpModes::CONFIG, 0x11B, (tone >> 8) & 0xFF);
+    // A single tone is produced by retuning both of the oscillators that DTMF
+    // digit '1' mixes (697 Hz and 1209 Hz) to the requested frequency and then
+    // keying that digit: the two oscillators beat at the same frequency, so
+    // only one tone reaches the modulator. The oscillator slots live in the
+    // auxiliary register bank, see initDtmf().
+    writeReg16(C6000_SpiOpModes::AUX, 0x11B, (tone >> 8) & 0xFF);
+    writeReg16(C6000_SpiOpModes::AUX, 0x11A, (tone & 0xFF));
+    writeReg16(C6000_SpiOpModes::AUX, 0x123, (tone >> 8) & 0xFF);
+    writeReg16(C6000_SpiOpModes::AUX, 0x122, (tone & 0xFF));
 
-    // Set  DTMF tone osc 2 to frequency of the required tone
-    writeReg16(C6000_SpiOpModes::CONFIG, 0x122, (tone & 0xFF));
-    writeReg16(C6000_SpiOpModes::CONFIG, 0x123, (tone >> 8) & 0xFF);
+    // The 697 Hz and 1209 Hz slots are left detuned, so the tone table has to
+    // be programmed again before the next DTMF digit. sendDtmfKey() picks this
+    // up on its own.
+    dtmfTableValid = false;
 
-    writeCfgRegister(0xA1, 0x02);         // Enable DTMF
-    writeCfgRegister(0xA0, deviation);    // Set DTMF tone deviation
-    writeCfgRegister(0xA4, 0xFF);         // Set the tone time to maximum
-    writeCfgRegister(0xA3, 0x00);         // Set the tone gap to zero
-    writeCfgRegister(0xD1, 0x06);         // Set the number of codes to six
-    writeCfgRegister(0xAF, 0x11);         // Set the same code to be sent six times (2 codes per register)
-    writeCfgRegister(0xAE, 0x11);
-    writeCfgRegister(0xAD, 0x11);
-    writeCfgRegister(0x60, 0x00);         // Disable FM transmission
-    writeCfgRegister(0x60, 0x80);         // Enable FM transmission, start sending the tone
+    sendDtmf(0x01, deviation);
 }
 
 void HR_C6000::initDtmf()

--- a/platform/drivers/baseband/HR_C6000.h
+++ b/platform/drivers/baseband/HR_C6000.h
@@ -76,7 +76,47 @@ public:
      */
     void sendTone(const uint32_t freq, const uint8_t deviation);
 
+    /**
+     * Program the HR_C6000 built-in DTMF generator's eight tone slots with the
+     * standard DTMF frequencies, which sendDtmf() then selects digits from.
+     * sendDtmfKey() keeps the table programmed on its own, so drivers using it
+     * have no need to call this.
+     */
+    void initDtmf();
+
+    /**
+     * Transmit a DTMF digit using the HR_C6000 built-in DTMF generator. While
+     * active the tone replaces the microphone audio in the FM modulation, so
+     * this both keys the DTMF digit on air and mutes the mic; the mic is
+     * restored the next time the analog transmitter is (re)started.
+     *
+     * @param code: DTMF digit code (0-9 = digits, 0xE = '*', 0xF = '#',
+     *              0xA-0xD = 'A'-'D').
+     * @param deviation: tone deviation.
+     */
+    void sendDtmf(const uint8_t code, const uint8_t deviation);
+
+    /**
+     * Transmit the DTMF digit corresponding to a keypad key. Takes care of the
+     * keypad-to-chip digit mapping, of the tone deviation, which depends on
+     * transmit band and channel bandwidth, and of programming the tone table.
+     *
+     * @param key: keypad code, 0-9 for the digits, 10 for '*' and 11 for '#'.
+     *             Any other value is ignored.
+     * @param txFrequency: transmit frequency, in Hz.
+     * @param narrowBand: true when the channel bandwidth is 12.5kHz.
+     */
+    void sendDtmfKey(const uint8_t key, const freq_t txFrequency,
+                     const bool narrowBand);
+
 private:
+
+    /**
+     * True when the DTMF tone table holds the standard frequencies. Cleared by
+     * anything that borrows one of the tone slots for another purpose, so that
+     * the next DTMF digit knows it has to program the table again.
+     */
+    bool dtmfTableValid = false;
 
     /**
      * Write a register with 16-bit address.

--- a/platform/drivers/baseband/HR_C6000_CS7000.cpp
+++ b/platform/drivers/baseband/HR_C6000_CS7000.cpp
@@ -196,7 +196,10 @@ void HR_Cx000< M >::fmMode()
 template< class M >
 void HR_Cx000< M >::startAnalogTx(const TxAudioSource source, const FmConfig cfg)
 {
-    uint8_t audioCfg = 0x81;
+    // LineOut2 is kept enabled, as fmMode() and stopAnalogTx() do: dropping it
+    // for the duration of the transmission silences everything the codec plays,
+    // including the DAC that drives the speaker on this radio.
+    uint8_t audioCfg = 0x89;
     if(source == TxAudioSource::MIC)     audioCfg |= 0x02;
     if(source == TxAudioSource::LINE_IN) audioCfg |= 0x40;
 

--- a/platform/drivers/baseband/HR_C6000_UV3x0.cpp
+++ b/platform/drivers/baseband/HR_C6000_UV3x0.cpp
@@ -179,7 +179,11 @@ void HR_Cx000< M >::startAnalogTx(const TxAudioSource source, const FmConfig cfg
      * "Linein1" input, while signal coming from the tone generator is connected
      *  to "Mic_p".
      */
-    uint8_t audioCfg = 0x81;
+    // LineOut2 is kept enabled, as fmMode() and stopAnalogTx() do: dropping it
+    // for the duration of the transmission silences everything the codec plays,
+    // including the DAC. Nothing is audible during TX anyway unless an audio
+    // path to the speaker is open, so leaving it on changes nothing by itself.
+    uint8_t audioCfg = 0x89;
     if(source == TxAudioSource::MIC)     audioCfg |= 0x40;
     if(source == TxAudioSource::LINE_IN) audioCfg |= 0x02;
 

--- a/platform/drivers/baseband/radio_CS7000.cpp
+++ b/platform/drivers/baseband/radio_CS7000.cpp
@@ -329,14 +329,26 @@ void radio_enableTx()
             // a new transmission.
             if(config->txToneEn)
                 C6000.setTxCtcss(config->txTone, 0x20);
-            else if(config->toneEn)
-                C6000.sendTone(1750, 0x1E);
             else
                 C6000.disableTones();
 
             FmConfig cfg = (config->bandwidth == BW_12_5) ? FmConfig::BW_12p5kHz
                                                           : FmConfig::BW_25kHz;
-            C6000.startAnalogTx(TxAudioSource::MIC, cfg | FmConfig::PREEMPH_EN);
+            TxAudioSource source = TxAudioSource::MIC;
+
+            #ifdef CONFIG_FM_INBAND_TONES
+            // While a DTMF digit or the tone burst is keyed, the modulation
+            // source is a tone streamed to the SINK_RTX device, entering the
+            // baseband through the line input. Pre-emphasis stays on, like
+            // for voice: the tones then leave with the same spectrum the
+            // HR_C6000 tone generator produces on the other radios, and come
+            // out flat after the receiver's de-emphasis.
+            if((config->toneEn == true) ||
+               (config->dtmf_code != DTMF_CODE_NONE))
+                source = TxAudioSource::LINE_IN;
+            #endif
+
+            C6000.startAnalogTx(source, cfg | FmConfig::PREEMPH_EN);
         }
             break;
 

--- a/platform/drivers/baseband/radio_UV3x0.cpp
+++ b/platform/drivers/baseband/radio_UV3x0.cpp
@@ -243,6 +243,18 @@ void radio_enableTx()
         at1846s.enableTone(17500);
     }
 
+#ifdef CONFIG_FM_INBAND_TONES
+    // Transmit the currently-pressed DTMF digit through the HR_C6000, which is
+    // the FM modulator on this radio. This replaces the mic audio with the
+    // tone; releasing the key (dtmf_code == DTMF_CODE_NONE) re-runs this path
+    // without the tone, so startAnalogTx() above restores the mic.
+    if(config->opMode == OPMODE_FM)
+    {
+        C6000.sendDtmfKey(config->dtmf_code, config->txFrequency,
+                          config->bandwidth == BW_12_5);
+    }
+#endif // CONFIG_FM_INBAND_TONES
+
     radioStatus = TX;
 }
 

--- a/platform/drivers/baseband/radio_UV3x0.cpp
+++ b/platform/drivers/baseband/radio_UV3x0.cpp
@@ -216,7 +216,14 @@ void radio_enableTx()
     // beginning of each transmission. This problem is particularly evident in
     // M17 mode because it causes the truncation of the preamble sequence.
     //
-    sleepFor(0, 50);
+    // Skipped when this is a mid-transmission re-key (DTMF digit or tone
+    // burst changes): the gap only exists at TX start, and the delay holds
+    // up the rtx thread with the microphone already restored while the
+    // sidetone is still sounding, long enough for the mic to pick it up and
+    // send a short ghost digit on air.
+    //
+    if(radioStatus != TX)
+        sleepFor(0, 50);
 
     at1846s.setFuncMode(AT1846S_FuncMode::TX);
 

--- a/platform/drivers/baseband/radio_UV3x0.cpp
+++ b/platform/drivers/baseband/radio_UV3x0.cpp
@@ -247,7 +247,10 @@ void radio_enableTx()
 
     if (config->toneEn)
     {
-        at1846s.enableTone(17500);
+        // The HR_C6000 is the FM modulator on this radio, so the tone burst has
+        // to be generated there: switching the AT1846S modulation source to its
+        // own tone generator mutes the microphone but produces no deviation.
+        C6000.sendTone(1750, 0x1E);
     }
 
 #ifdef CONFIG_FM_INBAND_TONES

--- a/platform/targets/CS7000-PLUS/hwconfig.h
+++ b/platform/targets/CS7000-PLUS/hwconfig.h
@@ -58,6 +58,13 @@ extern const struct gpsDevice gps;
 /* Device supports M17 mode */
 #define CONFIG_M17
 
+/* Device supports in-band FM tones (DTMF and tone burst). On this radio they
+ * are synthesized by the MCU and streamed to the SINK_RTX device, feeding the
+ * baseband line input: the HR_C6000 internal generator cannot be used, its
+ * DAC playback never reaches the line output while transmitting. */
+#define CONFIG_FM_INBAND_TONES
+#define CONFIG_FM_TONES_STREAM
+
 /* Device has a GPS chip */
 #define CONFIG_GPS
 #define CONFIG_GPS_STM32_USART6

--- a/platform/targets/CS7000/hwconfig.h
+++ b/platform/targets/CS7000/hwconfig.h
@@ -57,6 +57,13 @@ extern const struct gpsDevice gps;
 /* Device supports M17 mode */
 #define CONFIG_M17
 
+/* Device supports in-band FM tones (DTMF and tone burst). On this radio they
+ * are synthesized by the MCU and streamed to the SINK_RTX device, feeding the
+ * baseband line input: the HR_C6000 internal generator cannot be used, its
+ * DAC playback never reaches the line output while transmitting. */
+#define CONFIG_FM_INBAND_TONES
+#define CONFIG_FM_TONES_STREAM
+
 /* Device has a GPS chip */
 #define CONFIG_GPS
 #define CONFIG_GPS_STM32_USART6

--- a/platform/targets/DM-1701/hwconfig.h
+++ b/platform/targets/DM-1701/hwconfig.h
@@ -47,6 +47,9 @@ extern const struct Adc adc1;
 /* Device supports M17 mode */
 #define CONFIG_M17
 
+/* Device supports in-band FM tones (DTMF and tone burst) via the HR_C6000 */
+#define CONFIG_FM_INBAND_TONES
+
 /* Microphone audio input */
 #define CONFIG_MIC_GAIN 32
 #define CONFIG_MIC_OVERSAMPLE 8

--- a/platform/targets/MD-UV3x0/hwconfig.h
+++ b/platform/targets/MD-UV3x0/hwconfig.h
@@ -53,6 +53,9 @@ extern const struct Adc adc1;
 /* Device supports M17 mode */
 #define CONFIG_M17
 
+/* Device supports in-band FM tones (DTMF and tone burst) via the HR_C6000 */
+#define CONFIG_FM_INBAND_TONES
+
 /* Microphone audio input */
 #define CONFIG_MIC_GAIN 32
 #define CONFIG_MIC_OVERSAMPLE 8


### PR DESCRIPTION
This PR:

- Moves the 1750hz feature to being activated  via PTT+F1, in order to make way for...
- Most hardware platforms support "hot keyboard" style DTMF

The behavior is that if the user is holding PTT, and they are on a UV3x0 or CS7000 and they press the keypad 0-9*#, the corresponding DTMF tone is played over the speaker (observing the volume setting) and sent over RF. the 1750hz access tone also gets similar speaker feedback now.

There are two implementations for how this works, which was required due to one of my UX requirements of giving the user feedback of what is being transmitted by playing the sound also over the speaker. On the UV3x0/DM1701 platform, tones for RF are generated via the HR_C6000's built-in dtmf generator and for AF the come via the DAC so that the can use the volum knob's volume. For the CS7000 and plus, since the DAC playback can't be routed this way during transmission (I tried for a bit and failed!), the tone is generated via MCU and put to the rtx sink and then echoed to the speaker.

I tested both mechanisms with an rtl_sdr and found that error was small, though as you'd imagine the dedicated dtmf function performed slightly better. Both also checked out as working properly with my local allstar node for DTMF based repeater commands. I also verified the 1750hz tone feature as working now on both platforms.

As part of making these changes, I also had to update HR_C6000::sendTone() so that the table went to the proper register, which then allowed me to shift the uv3x0 to use this pattern rather than the AT1846S (because it failed to work in my testing).
Also, startAnalogTx() on both platforms now keeps the lineout2 enabled during TX so that the tone could be played ovr the speaker to inform the user of what was going on.

I investigated originally keeping the 1750hz tone on the # key, but on discord got feedback that the requisite setting was not optimal to maintain that + introduce dtmf. So, mapping the key was the suggestion and it seems to work nicely in my testing tonight.

Other platforms like the  MD-380/390, GD-77 and DM-1801 are not setup to us this feature now, as I don't have those on hand and the feature seems quite platform specific (though hopefully by introducing a couple of approaches here in this PR, those future additions would require far less work).