### PR TITLE
Fix buffer overflow in eeep_read

### DIFF
--- a/platform/drivers/NVM/eeep.c
+++ b/platform/drivers/NVM/eeep.c
@@ -242,7 +242,7 @@ static int eeep_read(const struct nvmDevice *dev, uint32_t offset, void *data,
         len = rec.size;
 
     memAddr += sizeof(struct eeepRecord);
-    ret = nvm_devRead(priv->nvm, memAddr, data, rec.size);
+    ret = nvm_devRead(priv->nvm, memAddr, data, len);
 
     return ret;
 }


### PR DESCRIPTION
Fixes #474.

eeep_read() clamps len to rec.size, but the subsequent nvm_devRead() call uses rec.size instead of the clamped len.

Use len for the read size to prevent reading beyond the caller's buffer when a smaller length is requested.