### PR TITLE
xmodem: fix send buffer overflow during padding

### DIFF
--- a/openrtx/src/core/xmodem.c
+++ b/openrtx/src/core/xmodem.c
@@ -143,7 +143,7 @@ ssize_t xmodem_sendData(size_t size, int (*callback)(uint8_t *, size_t))
             padSize = 1024 - blockSize;
         }
 
-        uint8_t *ptr = dataBuf + padSize + 1;
+        uint8_t *ptr = dataBuf + blockSize;
         memset(ptr, 0x1A, padSize);
 
         // Send packet and wait for ACK, resend on NACK.


### PR DESCRIPTION
Fixes #470 

out-of-bounds write in xmodem_sendData() when padding partial blocks.
The padding pointer was calculated from padSize + 1 instead of the end of the valid payload.

Use dataBuf + blockSize to keep padding within the 1024-byte buffer.